### PR TITLE
Implement fix for glitching WASAPI playback

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -5764,6 +5764,7 @@ PA_THREAD_FUNC ProcThreadPoll(void *param)
 	// Calculate timeout for next polling attempt.
 	sleep_ms_in  = GetFramesSleepTime(stream->in.framesPerHostCallback / WASAPI_PACKETS_PER_INPUT_BUFFER, stream->in.wavex.Format.nSamplesPerSec);
 	sleep_ms_out = GetFramesSleepTime(stream->out.framesPerBuffer, stream->out.wavex.Format.nSamplesPerSec);
+	sleep_ms_out /= 2; // wait only for half of the buffer
 
 	// WASAPI Input packets tend to expire very easily, let's limit sleep time to 2 milliseconds
 	// for all cases. Please propose better solution if any.
@@ -5776,6 +5777,7 @@ PA_THREAD_FUNC ProcThreadPoll(void *param)
 	{
 		//sleep_ms_in = GetFramesSleepTime((stream->bufferProcessor.framesPerUserBuffer ? stream->bufferProcessor.framesPerUserBuffer : stream->in.params.frames_per_buffer), stream->in.wavex.Format.nSamplesPerSec);
 		sleep_ms_out = GetFramesSleepTime((stream->bufferProcessor.framesPerUserBuffer ? stream->bufferProcessor.framesPerUserBuffer : stream->out.params.frames_per_buffer), stream->out.wavex.Format.nSamplesPerSec);
+		sleep_ms_out /= 2; // wait only for half of the buffer
 	}
 
 	// Choose smallest
@@ -5789,6 +5791,7 @@ PA_THREAD_FUNC ProcThreadPoll(void *param)
 	{
 		sleep_ms_in  = GetFramesSleepTimeMicroseconds(stream->in.framesPerHostCallback / WASAPI_PACKETS_PER_INPUT_BUFFER, stream->in.wavex.Format.nSamplesPerSec);
 		sleep_ms_out = GetFramesSleepTimeMicroseconds((stream->bufferProcessor.framesPerUserBuffer ? stream->bufferProcessor.framesPerUserBuffer : stream->out.params.frames_per_buffer), stream->out.wavex.Format.nSamplesPerSec);
+		sleep_ms_out /= 2; // wait only for half of the buffer
 
 		// Choose smallest
 		if ((sleep_ms_in != 0) && (sleep_ms_out != 0))


### PR DESCRIPTION
Fixing #303 by reducing the sleep delays on playback in polled thread mainloop. This reverts the sleep delays back to the same values as used in the stable versions of PA.