### PR TITLE
wdmks: ensure that pins that failed creation by PinNew() are zeroed.

### DIFF
--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -2844,6 +2844,10 @@ PaError FilterInitializePins( PaWinWdmFilter* filter )
             filter->pins[pinId] = newPin;
             ++filter->validPinCount;
         }
+        else
+        {
+            filter->pins[pinId] = 0;
+        }
     }
 
     if (filter->validPinCount == 0)


### PR DESCRIPTION
Note that PaUtil_AllocateMemory currently calls GlobalAlloc without the GMEM_ZEROINIT flag, so there was no guarantee that filter->pins[pinId] was zero.