### PR TITLE
alsa: Option to ignore all ALSA plugin devices.

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -1066,6 +1066,10 @@ static int IgnorePlugin( const char *pluginId )
     static const char *ignoredPlugins[] = {"hw", "plughw", "plug", "dsnoop", "tee",
         "file", "null", "shm", "cards", "rate_convert", NULL};
     int i = 0;
+
+    if( getenv( "PA_ALSA_IGNORE_ALL_PLUGINS" ) && atoi( getenv( "PA_ALSA_IGNORE_ALL_PLUGINS") ) )
+        return 1;
+
     while( ignoredPlugins[i] )
     {
         if( !strcmp( pluginId, ignoredPlugins[i] ) )
@@ -1327,6 +1331,8 @@ static PaError BuildDeviceList( PaAlsaHostApiRepresentation *alsaApi )
                     paInsufficientMemory );
             snprintf( deviceName, len, "%s: %s (%s)", cardName, infoName, buf );
 
+            PA_DEBUG(( "%s: Found device [%d]: %s\n", __FUNCTION__, numDeviceNames, deviceName ));
+
             ++numDeviceNames;
             if( !hwDevInfos || numDeviceNames > maxDeviceNames )
             {
@@ -1450,7 +1456,7 @@ static PaError BuildDeviceList( PaAlsaHostApiRepresentation *alsaApi )
 
         PA_ENSURE( FillInDevInfo( alsaApi, hwInfo, blocking, devInfo, &devIdx ) );
     }
-    assert( devIdx < numDeviceNames );
+    assert( devIdx <= numDeviceNames );
     /* Now inspect 'dmix' and 'default' plugins */
     for( i = 0; i < numDeviceNames; ++i )
     {


### PR DESCRIPTION
Option to ignore all ALSA plugin devices by using PA_ALSA_IGNORE_ALL_PLUGINS environment variable. 

Fixed logic of guarding assertion in BuildDeviceList() when only one PCM device is available (may occur if PA_ALSA_IGNORE_ALL_PLUGINS is defined).

Ignoring ALSA plugin devices is useful when using using PortAudio with ALSA interface in embedded systems like [Yocto Linux](http://www.yoctoproject.org). Some plugins are causing segfaults and practically may not be needed at all for the developer. By defining PA_ALSA_IGNORE_ALL_PLUGINS developer is able to switch off Alsa Plugin devices, only PCM devices will exist in this case (internal sound card, USB DAC, ...).
