### PR TITLE
wasapi: Fix paInvalidSampleRate (and any other) error code is replaced with paInvalidDevice.

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -3705,11 +3705,11 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 		stream->in.params.wow64_workaround  = paWasapi->useWOW64Workaround;
 
 		// Create and activate audio client
-        if (FAILED(hr = ActivateAudioClientInput(stream)))
+		if ((result = ActivateAudioClientInput(stream)) != paNoError)
 		{
-			LogPaError(result = paInvalidDevice);
+			LogPaError(result);
 			goto error;
-        }
+		}
 
 		// Get closest format
         hostInputSampleFormat = PaUtil_SelectClosestAvailableFormat(WaveToPaFormat(&stream->in.wavex), inputSampleFormat);
@@ -3839,11 +3839,11 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 		stream->out.params.wow64_workaround  = paWasapi->useWOW64Workaround;
 
 		// Create and activate audio client
-        if (FAILED(hr = ActivateAudioClientOutput(stream)))
+		if ((result = ActivateAudioClientOutput(stream)) != paNoError)
 		{
-			LogPaError(result = paInvalidDevice);
+			LogPaError(result);
 			goto error;
-        }
+		}
 
 		// Get closest format
         hostOutputSampleFormat = PaUtil_SelectClosestAvailableFormat(WaveToPaFormat(&stream->out.wavex), outputSampleFormat);


### PR DESCRIPTION
Fix paInvalidSampleRate (and any other) error code is replaced with paInvalidDevice if audio client failed to be created due to some reason. 

Not critical but does not allow to report reason of failure to the user correctly.

Closes #314