### PR TITLE
Fix GUID defines in pa_win_wdmks.c when compiling with clang-cl

### DIFF
--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -163,9 +163,15 @@ Default is to use the pin category.
 #define DYNAMIC_GUID(data) {data}
 #define _NTRTL_ /* Turn off default definition of DEFINE_GUIDEX */
 #undef DEFINE_GUID
-#define DEFINE_GUID(n, ...) EXTERN_C const GUID n = {__VA_ARGS__}
-#define DEFINE_GUID_THUNK(n, ...) DEFINE_GUID(n, __VA_ARGS__)
-#define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
+#ifdef __clang__ /* clang-cl: avoid too many arguments error */
+  #define DEFINE_GUID(n, ...) EXTERN_C const GUID n = {__VA_ARGS__}
+  #define DEFINE_GUID_THUNK(n, ...) DEFINE_GUID(n, __VA_ARGS__)
+  #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
+#else
+  #define DEFINE_GUID(n, data) EXTERN_C const GUID n = {data}
+  #define DEFINE_GUID_THUNK(n, data) DEFINE_GUID(n, data)
+  #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
+#endif /* __clang__ */
 #endif
 
 #include <setupapi.h>

--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -163,8 +163,8 @@ Default is to use the pin category.
 #define DYNAMIC_GUID(data) {data}
 #define _NTRTL_ /* Turn off default definition of DEFINE_GUIDEX */
 #undef DEFINE_GUID
-#define DEFINE_GUID(n,data) EXTERN_C const GUID n = {data}
-#define DEFINE_GUID_THUNK(n,data) DEFINE_GUID(n,data)
+#define DEFINE_GUID(n, ...) EXTERN_C const GUID n = {__VA_ARGS__}
+#define DEFINE_GUID_THUNK(n, ...) DEFINE_GUID(n, __VA_ARGS__)
 #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
 #endif
 


### PR DESCRIPTION
Fix GUID define when compiling with clang-cl
```
In file included from /vcpkg/buildtrees/portaudio/src/ebd3ebfacc-58e92047a8.clean/src/hostapi/wdmks/pa_win_wdmks.c:187:
/clang_windows_sdk/winsdk/Include/10.0.18362.0/shared/mmreg.h(2474,1): error: too many arguments provided to function-like macro invocation
DEFINE_GUIDSTRUCT("00000001-0000-0010-8000-00aa00389b71", KSDATAFORMAT_SUBTYPE_PCM);
^
/clang_windows_sdk/winsdk/Include/10.0.18362.0/shared/mmreg.h(2462,33): note: expanded from macro 'DEFINE_GUIDSTRUCT'
#define DEFINE_GUIDSTRUCT(g, n) DEFINE_GUIDEX(n)
                                ^
/vcpkg/buildtrees/portaudio/src/ebd3ebfacc-58e92047a8.clean/src/hostapi/wdmks/pa_win_wdmks.c(168,47): note: expanded from macro 'DEFINE_GUIDEX'
#define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
                                              ^
<scratch space>(205,1): note: expanded from here
STATIC_KSDATAFORMAT_SUBTYPE_PCM
^
/clang_windows_sdk/winsdk/Include/10.0.18362.0/shared/mmreg.h(2473,5): note: expanded from macro 'STATIC_KSDATAFORMAT_SUBTYPE_PCM'
    DEFINE_WAVEFORMATEX_GUID(WAVE_FORMAT_PCM)
    ^
/clang_windows_sdk/winsdk/Include/10.0.18362.0/shared/mmreg.h(2468,50): note: expanded from macro 'DEFINE_WAVEFORMATEX_GUID'
#define DEFINE_WAVEFORMATEX_GUID(x) (USHORT)(x), 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
                                                 ^
/vcpkg/buildtrees/portaudio/src/ebd3ebfacc-58e92047a8.clean/src/hostapi/wdmks/pa_win_wdmks.c(166,9): note: macro 'DEFINE_GUID' defined here
#define DEFINE_GUID(n,data) EXTERN_C const GUID n = {data}
        ^

```