### PR TITLE
Fix breaking strict-aliasing rules (if compiled with GCC with -fstrict-aliasing in PaWin_InitializeWaveFormatExtensible()

### DIFF
--- a/src/os/win/pa_win_waveformat.c
+++ b/src/os/win/pa_win_waveformat.c
@@ -98,14 +98,15 @@ void PaWin_InitializeWaveFormatExtensible( PaWinWaveFormat *waveFormat,
 	waveFormatEx->wBitsPerSample = bytesPerSample * 8;
 	waveFormatEx->cbSize = 22;
 
-	*((WORD*)&waveFormat->fields[PAWIN_INDEXOF_WVALIDBITSPERSAMPLE]) =
-			waveFormatEx->wBitsPerSample;
+    memcpy(&waveFormat->fields[PAWIN_INDEXOF_WVALIDBITSPERSAMPLE],
+        &waveFormatEx->wBitsPerSample, sizeof(WORD));
 
-	*((DWORD*)&waveFormat->fields[PAWIN_INDEXOF_DWCHANNELMASK]) = channelMask;
-		
+    memcpy(&waveFormat->fields[PAWIN_INDEXOF_DWCHANNELMASK],
+        &channelMask, sizeof(DWORD));
+
     guid = pawin_ksDataFormatSubtypeGuidBase;
     guid.Data1 = (USHORT)waveFormatTag;
-    *((GUID*)&waveFormat->fields[PAWIN_INDEXOF_SUBFORMAT]) = guid;
+    memcpy(&waveFormat->fields[PAWIN_INDEXOF_SUBFORMAT], &guid, sizeof(GUID));
 }
 
 PaWinWaveFormatChannelMask PaWin_DefaultChannelMask( int numChannels )


### PR DESCRIPTION
Fixed breaking strict-aliasing rules (if compiled with GCC with -fstrict-aliasing) in PaWin_InitializeWaveFormatExtensible().

Cosmetic changes: replaced tabs with 4 spaces and trimmed trailing spaces.

GCC's warning without a fix looks like this:

```c
pa_win_waveformat.c: In function 'PaWin_InitializeWaveFormatExtensible':
pa_win_waveformat.c:101:2: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  *((WORD*)&waveFormat->fields[PAWIN_INDEXOF_WVALIDBITSPERSAMPLE]) =
  ^
pa_win_waveformat.c:104:2: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  *((DWORD*)&waveFormat->fields[PAWIN_INDEXOF_DWCHANNELMASK]) = channelMask;
  ^
pa_win_waveformat.c:108:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     *((GUID*)&waveFormat->fields[PAWIN_INDEXOF_SUBFORMAT]) = guid;
     ^
```