### PR TITLE
Update pa_mac_core_utilities.h

### DIFF
--- a/src/hostapi/coreaudio/pa_mac_core_utilities.h
+++ b/src/hostapi/coreaudio/pa_mac_core_utilities.h
@@ -206,9 +206,9 @@ OSStatus xrunCallback(
     void* inClientData ) ;
 
 /** returns zero on success or a unix style error code. */
-int initializeXRunListenerList();
+int initializeXRunListenerList( void );
 /** returns zero on success or a unix style error code. */
-int destroyXRunListenerList();
+int destroyXRunListenerList( void );
 
 /**Returns the list, so that it can be passed to CorAudio.*/
 void *addToXRunListenerList( void *stream );


### PR DESCRIPTION
Insert "void" twice to turn these two declarations into prototypes.