### PR TITLE
pa_mac_core_utilities: add void to empty function argument list

### DIFF
--- a/src/hostapi/coreaudio/pa_mac_core_utilities.c
+++ b/src/hostapi/coreaudio/pa_mac_core_utilities.c
@@ -641,13 +641,13 @@ OSStatus xrunCallback(
    return 0;
 }
 
-int initializeXRunListenerList()
+int initializeXRunListenerList( void )
 {
    xRunListSize = 0;
    bzero( (void *) &firstXRunListNode, sizeof(firstXRunListNode) );
    return pthread_mutex_init( &xrunMutex, NULL );
 }
-int destroyXRunListenerList()
+int destroyXRunListenerList( void )
 {
    PaMacXRunListNode *node;
    node = firstXRunListNode.next;

--- a/src/hostapi/coreaudio/pa_mac_core_utilities.h
+++ b/src/hostapi/coreaudio/pa_mac_core_utilities.h
@@ -206,9 +206,9 @@ OSStatus xrunCallback(
     void* inClientData ) ;
 
 /** returns zero on success or a unix style error code. */
-int initializeXRunListenerList();
+int initializeXRunListenerList( void );
 /** returns zero on success or a unix style error code. */
-int destroyXRunListenerList();
+int destroyXRunListenerList( void );
 
 /**Returns the list, so that it can be passed to CorAudio.*/
 void *addToXRunListenerList( void *stream );


### PR DESCRIPTION
Insert "void" in the argument list to turn initializeXRunListenerList and destroyXRunListenerList declarations into valid prototypes. Also update the function definitions to match. Thanks to Paul Boersma.