### PR TITLE
Fix issue #321 broken MSVC build. 

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -2503,7 +2503,7 @@ PaError PaWasapi_UpdateDeviceList()
 #if defined(PA_WASAPI_MAX_CONST_DEVICE_COUNT) && (PA_WASAPI_MAX_CONST_DEVICE_COUNT > 0)
     return UpdateDeviceList();
 #else
-    return paNoError;
+    return paInternalError;
 #endif
 }
 

--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -2498,12 +2498,14 @@ static PaError UpdateDeviceList()
 }
 
 // ------------------------------------------------------------------------------------------
-#if defined(PA_WASAPI_MAX_CONST_DEVICE_COUNT) && (PA_WASAPI_MAX_CONST_DEVICE_COUNT > 0)
 PaError PaWasapi_UpdateDeviceList()
 {
+#if defined(PA_WASAPI_MAX_CONST_DEVICE_COUNT) && (PA_WASAPI_MAX_CONST_DEVICE_COUNT > 0)
     return UpdateDeviceList();
-}
+#else
+    return paNoError;
 #endif
+}
 
 // ------------------------------------------------------------------------------------------
 int PaWasapi_GetDeviceCurrentFormat( PaStream *pStream, void *pFormat, unsigned int formatSize, int bOutput )


### PR DESCRIPTION
Always define PaWasapi_UpdateDeviceList(), even when it is a no-op, because it is mentioned in the .def file.