### PR TITLE
fix non latin1 character in pa_debugprint.c

### DIFF
--- a/src/common/pa_debugprint.c
+++ b/src/common/pa_debugprint.c
@@ -71,7 +71,7 @@ void PaUtil_SetDebugPrintFunction(PaUtilLogCallback cb)
 }
 
 /*
- If your platform doesn’t have vsnprintf, you are stuck with a
+ If your platform doesn't have vsnprintf, you are stuck with a
  VERY dangerous alternative, vsprintf (with no n)
 */
 #if _MSC_VER


### PR DESCRIPTION
This is a simple PR that fixes the following warning on Windows:
pa_debugprint.c(1,1): warning C4828: The file contains a character starting at offset 0xa95 that is illegal in the current source character set (codepage 65001)