### PR TITLE
Change PaWinUtilComInitializationResult::initializingThreadId to DWORD to match the native type of WIN32 thread id

### DIFF
--- a/src/os/win/pa_win_coinitialize.c
+++ b/src/os/win/pa_win_coinitialize.c
@@ -135,7 +135,7 @@ void PaWinUtil_CoUninitialize( PaHostApiTypeId hostApiType, PaWinUtilComInitiali
         DWORD currentThreadId = GetCurrentThreadId();
 		if( comInitializationResult->initializingThreadId != currentThreadId )
 		{
-			PA_DEBUG(("ERROR: failed PaWinUtil_CoUninitialize calling thread[%d] does not match initializing thread[%d]\n",
+			PA_DEBUG(("ERROR: failed PaWinUtil_CoUninitialize calling thread[%lu] does not match initializing thread[%lu]\n",
 				currentThreadId, comInitializationResult->initializingThreadId));
 		}
 		else

--- a/src/os/win/pa_win_coinitialize.h
+++ b/src/os/win/pa_win_coinitialize.h
@@ -55,7 +55,7 @@ extern "C"
 */
 typedef struct PaWinUtilComInitializationResult{
     int state;
-    int initializingThreadId;
+    DWORD initializingThreadId;
 } PaWinUtilComInitializationResult;
 
 


### PR DESCRIPTION
This change eliminates compiler warning on MSVC
`pa_win_coinitialize.c(136,53): warning C4389: '!=': signed/unsigned mismatch`
