### PR TITLE
use variadic arguments in DEFINE_GUID also for MSVC

### DIFF
--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -163,7 +163,7 @@ Default is to use the pin category.
 #define DYNAMIC_GUID(data) {data}
 #define _NTRTL_ /* Turn off default definition of DEFINE_GUIDEX */
 #undef DEFINE_GUID
-#ifdef __clang__ /* clang-cl: avoid too many arguments error */
+#if defined(__clang__) || (defined(_MSVC_TRADITIONAL) && !_MSVC_TRADITIONAL) /* clang-cl and new msvc preprocessor: avoid too many arguments error */
   #define DEFINE_GUID(n, ...) EXTERN_C const GUID n = {__VA_ARGS__}
   #define DEFINE_GUID_THUNK(n, ...) DEFINE_GUID(n, __VA_ARGS__)
   #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
@@ -171,7 +171,7 @@ Default is to use the pin category.
   #define DEFINE_GUID(n, data) EXTERN_C const GUID n = {data}
   #define DEFINE_GUID_THUNK(n, data) DEFINE_GUID(n, data)
   #define DEFINE_GUIDEX(n) DEFINE_GUID_THUNK(n, STATIC_##n)
-#endif /* __clang__ */
+#endif /* __clang__, !_MSVC_TRADITIONAL */
 #endif
 
 #include <setupapi.h>


### PR DESCRIPTION
The fix for DEFINE_GUID that was recently added in pa_win_wdmks.c is also needed for the MSVC compiler.
Latest versions of the compiler support the `/Zc:preprocessor` option which is conforming to C99 and later standards
https://docs.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-160
so it generates the exact same error as Clang (too many arguments error).