### PR TITLE
wdmks: suppress uninitialized variable warnings

### DIFF
--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -4340,9 +4340,10 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     PaWinWdmStream *stream = 0;
     /* unsigned long framesPerHostBuffer; these may not be equivalent for all implementations */
     PaSampleFormat inputSampleFormat, outputSampleFormat;
-    PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
+    PaSampleFormat hostInputSampleFormat = paInt16;
+    PaSampleFormat hostOutputSampleFormat = paInt16;
     int userInputChannels,userOutputChannels;
-    WAVEFORMATEXTENSIBLE wfx;
+    WAVEFORMATEXTENSIBLE wfx = { 0 };
 
     PA_LOGE_;
     PA_DEBUG(("OpenStream:sampleRate = %f\n",sampleRate));
@@ -4380,7 +4381,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     else
     {
         userInputChannels = 0;
-        inputSampleFormat = hostInputSampleFormat = paInt16; /* Suppress 'uninitialised var' warnings. */
+        inputSampleFormat = paInt16; /* Suppress 'uninitialised var' warnings. */
     }
 
     if( outputParameters )
@@ -4415,7 +4416,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     else
     {
         userOutputChannels = 0;
-        outputSampleFormat = hostOutputSampleFormat = paInt16; /* Suppress 'uninitialized var' warnings. */
+        outputSampleFormat = paInt16; /* Suppress 'uninitialized var' warnings. */
     }
 
     /* validate platform specific flags */

--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -4340,8 +4340,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     PaWinWdmStream *stream = 0;
     /* unsigned long framesPerHostBuffer; these may not be equivalent for all implementations */
     PaSampleFormat inputSampleFormat, outputSampleFormat;
-    PaSampleFormat hostInputSampleFormat = paInt16;
-    PaSampleFormat hostOutputSampleFormat = paInt16;
+    PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
     int userInputChannels,userOutputChannels;
     WAVEFORMATEXTENSIBLE wfx = { 0 };
 
@@ -4601,6 +4600,8 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     }
     else
     {
+        hostInputSampleFormat = (PaSampleFormat) 0; /* Avoid uninitialized variable warning */
+        
         stream->capture.pPin = NULL;
         stream->capture.bytesPerFrame = 0;
     }
@@ -4725,6 +4726,8 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     }
     else
     {
+        hostOutputSampleFormat = (PaSampleFormat) 0; /* Avoid uninitialized variable warning */
+
         stream->render.pPin = NULL;
         stream->render.bytesPerFrame = 0;
     }


### PR DESCRIPTION
It seems an attempt to suppress "uninitialized variable used" warnings was made previously but was not complete.
This PR fixes this.

NB: I always compile with /WX (treat warnings as errors) that's why I am a bit pedantic with warnings.
Another idea if you think it's meaningful to leave some variables uninitialized is to document why and
suppress warnings using `#pragma warning push/#pragma warning( disable: ...)/# pragma warning pop`