### PR TITLE
Fix a GCC warning due to unsigned substraction

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -3204,7 +3204,7 @@ static int SetApproximateSampleRate( snd_pcm_t *pcm, snd_pcm_hw_params_t *hwPara
     ENSURE_( alsa_snd_pcm_hw_params_set_rate_near( pcm, hwParams, &setRate, NULL ), paUnanticipatedHostError );
     /* The value actually set will be put in 'setRate' (may be way off); check the deviation as a proportion
      * of the requested-rate with reference to the max-deviate-ratio (larger values allow less deviation) */
-    deviation = abs( setRate - reqRate );
+    deviation = abs( (int)setRate - (int)reqRate );
     if( deviation > 0 && deviation * RATE_MAX_DEVIATE_RATIO > reqRate )
         result = paInvalidSampleRate;
 


### PR DESCRIPTION
Given

    unsigned int reqRate, setRate, deviation;

then 

    setRate - reqRate

is also an unsigned int - the code works "by chance" as `abs` casts that to an int which overflows and is technically undefined behaviour, for instance for setRate = 44100 and reqRate = 48000.

Thus cast them to int when computing the absolute value to ensure no UB.