### PR TITLE
pa_converters include math if PA_USE_C99_LRINTF

### DIFF
--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -66,6 +66,9 @@
 #include "pa_endianness.h"
 #include "pa_types.h"
 
+#ifdef PA_USE_C99_LRINTF
+#include <math.h>
+#endif
 
 PaSampleFormat PaUtil_SelectClosestAvailableFormat(
         PaSampleFormat availableFormats, PaSampleFormat format )


### PR DESCRIPTION
pa_converters.c did not include math.h in case PA_USE_C99_LRINTF is defined
so the compiler could not find the definition for lrintf