### PR TITLE
Fix to use UTF-8 text instead of ANSI in MME and DSound

### DIFF
--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -408,16 +408,6 @@ static char *DuplicateDeviceNameString( PaUtilAllocationGroup *allocations, cons
     
     if( src != NULL )
     {
-#if !defined(_UNICODE) && !defined(UNICODE)
-        size_t len = WideCharToMultiByte(CP_ACP, 0, src, -1, NULL, 0, NULL, NULL);
-
-        result = (char*)PaUtil_GroupAllocateMemory( allocations, (long)(len + 1) );
-        if( result ) {
-            if (WideCharToMultiByte(CP_ACP, 0, src, -1, result, (int)len, NULL, NULL) == 0) {
-                result = 0;
-            }
-        }
-#else
         size_t len = WideCharToMultiByte(CP_UTF8, 0, src, -1, NULL, 0, NULL, NULL);
 
         result = (char*)PaUtil_GroupAllocateMemory( allocations, (long)(len + 1) );
@@ -426,7 +416,6 @@ static char *DuplicateDeviceNameString( PaUtilAllocationGroup *allocations, cons
                 result = 0;
             }
         }
-#endif
     }
     else
     {

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -295,7 +295,7 @@ static signed long GetStreamWriteAvailable( PaStream* stream );
         wchar_t mmeErrorTextWide[ MAXERRORLENGTH ];                     \
         char mmeErrorText[ MAXERRORLENGTH ];                            \
         waveInGetErrorTextW( mmresult, mmeErrorTextWide, MAXERRORLENGTH );   \
-        WideCharToMultiByte( CP_UTF8, WC_COMPOSITECHECK | WC_DEFAULTCHAR,\
+        WideCharToMultiByte( CP_UTF8, 0,                                \
             mmeErrorTextWide, -1, mmeErrorText, MAXERRORLENGTH, NULL, NULL );  \
         PaUtil_SetLastHostErrorInfo( paMME, mmresult, mmeErrorText );   \
     }
@@ -305,7 +305,7 @@ static signed long GetStreamWriteAvailable( PaStream* stream );
         wchar_t mmeErrorTextWide[ MAXERRORLENGTH ];                     \
         char mmeErrorText[ MAXERRORLENGTH ];                            \
         waveOutGetErrorTextW( mmresult, mmeErrorTextWide, MAXERRORLENGTH );  \
-        WideCharToMultiByte( CP_UTF8, WC_COMPOSITECHECK | WC_DEFAULTCHAR,\
+        WideCharToMultiByte( CP_UTF8, 0,                                \
             mmeErrorTextWide, -1, mmeErrorText, MAXERRORLENGTH, NULL, NULL );  \
         PaUtil_SetLastHostErrorInfo( paMME, mmresult, mmeErrorText );   \
     }

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -290,24 +290,24 @@ static signed long GetStreamWriteAvailable( PaStream* stream );
 
 /* macros for setting last host error information */
 
-#define PA_MME_SET_LAST_WAVEIN_ERROR( mmresult ) \
-    {                                                                   \
-        wchar_t mmeErrorTextWide[ MAXERRORLENGTH ];                     \
-        char mmeErrorText[ MAXERRORLENGTH ];                            \
-        waveInGetErrorTextW( mmresult, mmeErrorTextWide, MAXERRORLENGTH );   \
-        WideCharToMultiByte( CP_UTF8, 0,                                \
-            mmeErrorTextWide, -1, mmeErrorText, MAXERRORLENGTH, NULL, NULL );  \
-        PaUtil_SetLastHostErrorInfo( paMME, mmresult, mmeErrorText );   \
+#define PA_MME_SET_LAST_WAVEIN_ERROR( mmresult )                              \
+    {                                                                         \
+        wchar_t mmeErrorTextWide[ MAXERRORLENGTH ];                           \
+        char mmeErrorText[ MAXERRORLENGTH ];                                  \
+        waveInGetErrorTextW( mmresult, mmeErrorTextWide, MAXERRORLENGTH );    \
+        WideCharToMultiByte( CP_UTF8, 0, mmeErrorTextWide, -1,                \
+            mmeErrorText, MAXERRORLENGTH, NULL, NULL );                       \
+        PaUtil_SetLastHostErrorInfo( paMME, mmresult, mmeErrorText );         \
     }
 
-#define PA_MME_SET_LAST_WAVEOUT_ERROR( mmresult ) \
-    {                                                                   \
-        wchar_t mmeErrorTextWide[ MAXERRORLENGTH ];                     \
-        char mmeErrorText[ MAXERRORLENGTH ];                            \
-        waveOutGetErrorTextW( mmresult, mmeErrorTextWide, MAXERRORLENGTH );  \
-        WideCharToMultiByte( CP_UTF8, 0,                                \
-            mmeErrorTextWide, -1, mmeErrorText, MAXERRORLENGTH, NULL, NULL );  \
-        PaUtil_SetLastHostErrorInfo( paMME, mmresult, mmeErrorText );   \
+#define PA_MME_SET_LAST_WAVEOUT_ERROR( mmresult )                             \
+    {                                                                         \
+        wchar_t mmeErrorTextWide[ MAXERRORLENGTH ];                           \
+        char mmeErrorText[ MAXERRORLENGTH ];                                  \
+        waveOutGetErrorTextW( mmresult, mmeErrorTextWide, MAXERRORLENGTH );   \
+        WideCharToMultiByte( CP_UTF8, 0, mmeErrorTextWide, -1,                \
+            mmeErrorText, MAXERRORLENGTH, NULL, NULL );                       \
+        PaUtil_SetLastHostErrorInfo( paMME, mmresult, mmeErrorText );         \
     }
 
 


### PR DESCRIPTION
Fixes MME and DSound ANSI characters under MBCS builds. Despite what MS docs say, MME actually does provide non-TCHAR methods (noticed it when Visual Studio IntelliSense suggested them).
While fixing the device names, I've noticed that MME error macros also used ANSI, so i fixed them aswell.

Fixes #224.

Tested on my machine (in my test app which i'm using for integrating PortAudio in our Unity game, thus we use a custom ordering and include the API and Exclusive in the name):
```
VoiceMeeter Output (VB-Audio VoiceMeeter VAIO) (Windows WASAPI)
VoiceMeeter Output (VB-Audio VoiceMeeter VAIO) (Windows WASAPI) - Exclusive
Trust Starzz (Realtek High Definition Audio) (Windows WASAPI)
Trust Starzz (Realtek High Definition Audio) (Windows WASAPI) - Exclusive
Podstawowy sterownik przechwytywania dźwięku (Windows DirectSound)
Trust Starzz (Realtek High Definition Audio) (Windows DirectSound)
VoiceMeeter Output (VB-Audio VoiceMeeter VAIO) (Windows DirectSound)
Mapowanie dźwięku Microsoft - Input (MME)
Trust Starzz (Realtek High Defi (MME)
VoiceMeeter Output (VB-Audio Vo (MME)
Mikrofon (Realtek HD Audio Mic input) (Windows WDM-KS)
FrontMic (Realtek HD Audio Front Mic input) (Windows WDM-KS)
Wejście liniowe (Realtek HD Audio Line input) (Windows WDM-KS)
Miks stereo (Realtek HD Audio Stereo input) (Windows WDM-KS)
VoiceMeeter Output (VoiceMeeter vaio) (Windows WDM-KS)
ASIO4ALL v2 (ASIO)
Voicemeeter Virtual ASIO (ASIO)
```
As you can see, polish characters like ź, ę are all correctly converted.