### PR TITLE
WASAPI: Report thread running so Pa_StartStream can return

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -5890,6 +5890,12 @@ PA_THREAD_FUNC ProcThreadEvent(void *param)
         goto thread_error;
     }
 
+    // Signal: stream running
+    stream->running = TRUE;
+
+    // Notify: thread started
+    SetEvent(stream->hThreadStart);
+
     // Initialize event & start INPUT stream
     if (stream->in.clientProc)
     {
@@ -5939,12 +5945,6 @@ PA_THREAD_FUNC ProcThreadEvent(void *param)
         }
 
     }
-
-    // Signal: stream running
-    stream->running = TRUE;
-
-    // Notify: thread started
-    SetEvent(stream->hThreadStart);
 
     // Notify: state
     NotifyStateChanged(stream, paWasapiStreamStateThreadStart, ERROR_SUCCESS);
@@ -6171,6 +6171,12 @@ PA_THREAD_FUNC ProcThreadPoll(void *param)
     // Boost thread priority
     PaWasapi_ThreadPriorityBoost((void **)&stream->hAvTask, stream->nThreadPriority);
 
+    // Signal: stream running
+    stream->running = TRUE;
+
+    // Notify: thread started
+    SetEvent(stream->hThreadStart);
+
     // Initialize event & start INPUT stream
     if (stream->in.clientProc)
     {
@@ -6237,12 +6243,6 @@ PA_THREAD_FUNC ProcThreadPoll(void *param)
             goto thread_error;
         }
     }
-
-    // Signal: stream running
-    stream->running = TRUE;
-
-    // Notify: thread started
-    SetEvent(stream->hThreadStart);
 
     // Notify: state
     NotifyStateChanged(stream, paWasapiStreamStateThreadStart, ERROR_SUCCESS);


### PR DESCRIPTION
Report thread running so Pa_StartStream can return prior to PaStreamCallback.

StartStream() calls WaitForSingleObject(stream->hThreadStart, 60*1000)
but it will not be able to return until X number of PaStreamCallback
have been performed by ProcessOutputBuffer().

The above behaviour will cause a deadlock if the user supplied
PaStreamCallback tries to access a shared lock currently held by the
function calling Pa_StartStream().

Also it's a bit weird that you start receiving PaStreamCallbacks
before Pa_StartStream() is able to complete.