### PR TITLE
Clean up whitespace in src/common in preparation for .editorconfig.

### DIFF
--- a/src/common/pa_allocation.c
+++ b/src/common/pa_allocation.c
@@ -27,13 +27,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -78,7 +78,7 @@ static struct PaUtilAllocationGroupLink *AllocateLinks( long count,
 {
     struct PaUtilAllocationGroupLink *result;
     int i;
-    
+
     result = (struct PaUtilAllocationGroupLink *)PaUtil_AllocateMemory(
             sizeof(struct PaUtilAllocationGroupLink) * count );
     if( result )
@@ -95,7 +95,7 @@ static struct PaUtilAllocationGroupLink *AllocateLinks( long count,
         }
         result[count-1].next = nextSpare;
     }
-    
+
     return result;
 }
 
@@ -147,7 +147,7 @@ void* PaUtil_GroupAllocateMemory( PaUtilAllocationGroup* group, long size )
 {
     struct PaUtilAllocationGroupLink *links, *link;
     void *result = 0;
-    
+
     /* allocate more links if necessary */
     if( !group->spareLinks )
     {
@@ -176,7 +176,7 @@ void* PaUtil_GroupAllocateMemory( PaUtilAllocationGroup* group, long size )
         }
     }
 
-    return result;    
+    return result;
 }
 
 
@@ -208,7 +208,7 @@ void PaUtil_GroupFreeMemory( PaUtilAllocationGroup* group, void *buffer )
 
             break;
         }
-        
+
         previous = current;
         current = current->next;
     }

--- a/src/common/pa_allocation.h
+++ b/src/common/pa_allocation.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -44,7 +44,7 @@
 
  @brief Allocation Group prototypes. An Allocation Group makes it easy to
  allocate multiple blocks of memory and free them all at once.
- 
+
  An allocation group is useful for keeping track of multiple blocks
  of memory which are allocated at the same time (such as during initialization)
  and need to be deallocated at the same time. The allocation group maintains

--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -40,17 +40,17 @@
  @ingroup common_src
 
  @brief Conversion function implementations.
- 
+
  If the C9x function lrintf() is available, define PA_USE_C99_LRINTF to use it
 
  @todo Consider whether functions which dither but don't clip should exist,
  V18 automatically enabled clipping whenever dithering was selected. Perhaps
- we should do the same. 
+ we should do the same.
     see: "require clipping for dithering sample conversion functions?"
     http://www.portaudio.com/trac/ticket/112
 
  @todo implement the converters marked IMPLEMENT ME: Int32_To_Int24_Dither,
- Int32_To_UInt8_Dither, Int24_To_Int16_Dither, Int24_To_Int8_Dither, 
+ Int32_To_UInt8_Dither, Int24_To_Int16_Dither, Int24_To_Int8_Dither,
  Int24_To_UInt8_Dither, Int16_To_Int8_Dither, Int16_To_UInt8_Dither
     see: "some conversion functions are not implemented in pa_converters.c"
     http://www.portaudio.com/trac/ticket/35
@@ -74,7 +74,7 @@ PaSampleFormat PaUtil_SelectClosestAvailableFormat(
 
     format &= ~paNonInterleaved;
     availableFormats &= ~paNonInterleaved;
-    
+
     if( (format & availableFormats) == 0 )
     {
         /* NOTE: this code depends on the sample format constants being in
@@ -97,7 +97,7 @@ PaSampleFormat PaUtil_SelectClosestAvailableFormat(
         {
             result = 0;
         }
-        
+
         if( result == 0 ){
             /* scan for worse formats */
             result = format;
@@ -110,7 +110,7 @@ PaSampleFormat PaUtil_SelectClosestAvailableFormat(
             if( (result & availableFormats) == 0 )
                 result = paSampleFormatNotSupported;
         }
-        
+
     }else{
         result = format;
     }
@@ -286,7 +286,7 @@ PaUtilConverterTable paConverters = {
     0, /* PaUtilConverter *Int24_To_Int8_Dither; */
     0, /* PaUtilConverter *Int24_To_UInt8; */
     0, /* PaUtilConverter *Int24_To_UInt8_Dither; */
-    
+
     0, /* PaUtilConverter *Int16_To_Float32; */
     0, /* PaUtilConverter *Int16_To_Int32; */
     0, /* PaUtilConverter *Int16_To_Int24; */
@@ -348,9 +348,9 @@ static void Float32_To_Int32(
         *dest = lrintf(scaled-0.5f);
 #else
         double scaled = *src * 0x7FFFFFFF;
-        *dest = (PaInt32) scaled;        
+        *dest = (PaInt32) scaled;
 #endif
-        
+
         src += sourceStride;
         dest += destinationStride;
     }
@@ -395,7 +395,7 @@ static void Float32_To_Int32_Clip(
     float *src = (float*)sourceBuffer;
     PaInt32 *dest =  (PaInt32*)destinationBuffer;
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
         /* REVIEW */
@@ -458,13 +458,13 @@ static void Float32_To_Int24(
     PaInt32 temp;
 
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
         /* convert to 32 bit and drop the low 8 bits */
         double scaled = (double)(*src) * 2147483647.0;
         temp = (PaInt32) scaled;
-        
+
 #if defined(PA_LITTLE_ENDIAN)
         dest[0] = (unsigned char)(temp >> 8);
         dest[1] = (unsigned char)(temp >> 16);
@@ -498,7 +498,7 @@ static void Float32_To_Int24_Dither(
         double dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         double dithered = ((double)*src * (2147483646.0)) + dither;
-        
+
         temp = (PaInt32) dithered;
 
 #if defined(PA_LITTLE_ENDIAN)
@@ -528,7 +528,7 @@ static void Float32_To_Int24_Clip(
     PaInt32 temp;
 
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
         /* convert to 32 bit and drop the low 8 bits */
@@ -561,16 +561,16 @@ static void Float32_To_Int24_DitherClip(
     float *src = (float*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
     PaInt32 temp;
-    
+
     while( count-- )
     {
         /* convert to 32 bit and drop the low 8 bits */
-        
+
         double dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         double dithered = ((double)*src * (2147483646.0)) + dither;
         PA_CLIP_( dithered, -2147483648., 2147483647.  );
-        
+
         temp = (PaInt32) dithered;
 
 #if defined(PA_LITTLE_ENDIAN)
@@ -728,7 +728,7 @@ static void Float32_To_Int8_Dither(
 {
     float *src = (float*)sourceBuffer;
     signed char *dest =  (signed char*)destinationBuffer;
-    
+
     while( count-- )
     {
         float dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
@@ -819,7 +819,7 @@ static void Float32_To_UInt8_Dither(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest =  (unsigned char*)destinationBuffer;
-    
+
     while( count-- )
     {
         float dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
@@ -827,7 +827,7 @@ static void Float32_To_UInt8_Dither(
         float dithered = (*src * (126.0f)) + dither;
         PaInt32 samp = (PaInt32) dithered;
         *dest = (unsigned char) (128 + samp);
-        
+
         src += sourceStride;
         dest += destinationStride;
     }
@@ -910,10 +910,10 @@ static void Int32_To_Int24(
     PaInt32 *src    = (PaInt32*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
     (void) ditherGenerator; /* unused parameter */
-    
-	while( count-- )
+
+    while( count-- )
     {
-		/* REVIEW */
+        /* REVIEW */
 #if defined(PA_LITTLE_ENDIAN)
         dest[0] = (unsigned char)(*src >> 8);
         dest[1] = (unsigned char)(*src >> 16);
@@ -1041,7 +1041,7 @@ static void Int32_To_UInt8(
 
     while( count-- )
     {
-		(*dest) = (unsigned char)(((*src) >> 24) + 128); 
+        (*dest) = (unsigned char)(((*src) >> 24) + 128);
 
         src += sourceStride;
         dest += destinationStride;
@@ -1080,12 +1080,12 @@ static void Int24_To_Float32(
     PaInt32 temp;
 
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
 
 #if defined(PA_LITTLE_ENDIAN)
-        temp = (((PaInt32)src[0]) << 8);  
+        temp = (((PaInt32)src[0]) << 8);
         temp = temp | (((PaInt32)src[1]) << 16);
         temp = temp | (((PaInt32)src[2]) << 24);
 #elif defined(PA_BIG_ENDIAN)
@@ -1113,12 +1113,12 @@ static void Int24_To_Int32(
     PaInt32 temp;
 
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
 
 #if defined(PA_LITTLE_ENDIAN)
-        temp = (((PaInt32)src[0]) << 8);  
+        temp = (((PaInt32)src[0]) << 8);
         temp = temp | (((PaInt32)src[1]) << 16);
         temp = temp | (((PaInt32)src[2]) << 24);
 #elif defined(PA_BIG_ENDIAN)
@@ -1143,20 +1143,20 @@ static void Int24_To_Int16(
 {
     unsigned char *src = (unsigned char*)sourceBuffer;
     PaInt16 *dest = (PaInt16*)destinationBuffer;
-    
+
     PaInt16 temp;
 
     (void) ditherGenerator; /* unused parameter */
-        
+
     while( count-- )
     {
-		
+
 #if defined(PA_LITTLE_ENDIAN)
-		/* src[0] is discarded */
+        /* src[0] is discarded */
         temp = (((PaInt16)src[1]));
         temp = temp | (PaInt16)(((PaInt16)src[2]) << 8);
 #elif defined(PA_BIG_ENDIAN)
-		/* src[2] is discarded */
+        /* src[2] is discarded */
         temp = (PaInt16)(((PaInt16)src[0]) << 8);
         temp = temp | (((PaInt16)src[1]));
 #endif
@@ -1184,7 +1184,7 @@ static void Int24_To_Int16_Dither(
     {
 
 #if defined(PA_LITTLE_ENDIAN)
-        temp = (((PaInt32)src[0]) << 8);  
+        temp = (((PaInt32)src[0]) << 8);
         temp = temp | (((PaInt32)src[1]) << 16);
         temp = temp | (((PaInt32)src[2]) << 24);
 #elif defined(PA_BIG_ENDIAN)
@@ -1211,20 +1211,20 @@ static void Int24_To_Int8(
 {
     unsigned char *src = (unsigned char*)sourceBuffer;
     signed char  *dest = (signed char*)destinationBuffer;
-    
+
     (void) ditherGenerator; /* unused parameter */
-        
+
     while( count-- )
-    {	
-	
+    {
+
 #if defined(PA_LITTLE_ENDIAN)
-		/* src[0] is discarded */
-		/* src[1] is discarded */
+        /* src[0] is discarded */
+        /* src[1] is discarded */
         *dest = src[2];
 #elif defined(PA_BIG_ENDIAN)
-		/* src[2] is discarded */
-		/* src[1] is discarded */
-		*dest = src[0];
+        /* src[2] is discarded */
+        /* src[1] is discarded */
+        *dest = src[0];
 #endif
 
         src += sourceStride * 3;
@@ -1241,14 +1241,14 @@ static void Int24_To_Int8_Dither(
 {
     unsigned char *src = (unsigned char*)sourceBuffer;
     signed char  *dest = (signed char*)destinationBuffer;
-    
+
     PaInt32 temp, dither;
 
     while( count-- )
     {
 
 #if defined(PA_LITTLE_ENDIAN)
-        temp = (((PaInt32)src[0]) << 8);  
+        temp = (((PaInt32)src[0]) << 8);
         temp = temp | (((PaInt32)src[1]) << 16);
         temp = temp | (((PaInt32)src[2]) << 24);
 #elif defined(PA_BIG_ENDIAN)
@@ -1275,20 +1275,20 @@ static void Int24_To_UInt8(
 {
     unsigned char *src = (unsigned char*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
-    
+
     (void) ditherGenerator; /* unused parameter */
-        
+
     while( count-- )
     {
-		
+
 #if defined(PA_LITTLE_ENDIAN)
-		/* src[0] is discarded */
-		/* src[1] is discarded */
+        /* src[0] is discarded */
+        /* src[1] is discarded */
         *dest = (unsigned char)(src[2] + 128);
 #elif defined(PA_BIG_ENDIAN)
         *dest = (unsigned char)(src[0] + 128);
-		/* src[1] is discarded */
-		/* src[2] is discarded */		
+        /* src[1] is discarded */
+        /* src[2] is discarded */
 #endif
 
         src += sourceStride * 3;
@@ -1349,7 +1349,7 @@ static void Int16_To_Int32(
         /* REVIEW: we should consider something like
             (*src << 16) | (*src & 0xFFFF)
         */
-        
+
         *dest = *src << 16;
 
         src += sourceStride;
@@ -1369,11 +1369,11 @@ static void Int16_To_Int24(
     PaInt16 temp;
 
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
         temp = *src;
-        
+
 #if defined(PA_LITTLE_ENDIAN)
         dest[0] = 0;
         dest[1] = (unsigned char)(temp);
@@ -1442,7 +1442,7 @@ static void Int16_To_UInt8(
 
     while( count-- )
     {
-		(*dest) = (unsigned char)(((*src) >> 8) + 128); 
+        (*dest) = (unsigned char)(((*src) >> 8) + 128);
 
         src += sourceStride;
         dest += destinationStride;
@@ -1503,7 +1503,7 @@ static void Int8_To_Int32(
 
     while( count-- )
     {
-		(*dest) = (*src) << 24;
+        (*dest) = (*src) << 24;
 
         src += sourceStride;
         dest += destinationStride;
@@ -1613,7 +1613,7 @@ static void UInt8_To_Int32(
 
     while( count-- )
     {
-		(*dest) = (*src - 128) << 24;
+        (*dest) = (*src - 128) << 24;
 
         src += sourceStride;
         dest += destinationStride;
@@ -1627,11 +1627,11 @@ static void UInt8_To_Int24(
     void *sourceBuffer, signed int sourceStride,
     unsigned int count, struct PaUtilTriangularDitherGenerator *ditherGenerator )
 {
-	unsigned char *src  = (unsigned char*)sourceBuffer;
+    unsigned char *src  = (unsigned char*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
     (void) ditherGenerator; /* unused parameters */
-    
-	while( count-- )
+
+    while( count-- )
     {
 
 #if defined(PA_LITTLE_ENDIAN)
@@ -1643,10 +1643,10 @@ static void UInt8_To_Int24(
         dest[1] = 0;
         dest[2] = 0;
 #endif
-		
+
         src += sourceStride;
-        dest += destinationStride * 3;    
-	}
+        dest += destinationStride * 3;
+    }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1698,7 +1698,7 @@ static void Copy_8_To_8(
 {
     unsigned char *src = (unsigned char*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
-                                                      
+
     (void) ditherGenerator; /* unused parameter */
 
     while( count-- )
@@ -1719,9 +1719,9 @@ static void Copy_16_To_16(
 {
     PaUint16 *src = (PaUint16 *)sourceBuffer;
     PaUint16 *dest = (PaUint16 *)destinationBuffer;
-                                                        
+
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
         *dest = *src;
@@ -1742,7 +1742,7 @@ static void Copy_24_To_24(
     unsigned char *dest = (unsigned char*)destinationBuffer;
 
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
         dest[0] = src[0];
@@ -1765,7 +1765,7 @@ static void Copy_32_To_32(
     PaUint32 *src = (PaUint32 *)sourceBuffer;
 
     (void) ditherGenerator; /* unused parameter */
-    
+
     while( count-- )
     {
         *dest = *src;
@@ -1787,7 +1787,7 @@ PaUtilConverterTable paConverters = {
     Float32_To_Int24_Dither,       /* PaUtilConverter *Float32_To_Int24_Dither; */
     Float32_To_Int24_Clip,         /* PaUtilConverter *Float32_To_Int24_Clip; */
     Float32_To_Int24_DitherClip,   /* PaUtilConverter *Float32_To_Int24_DitherClip; */
-    
+
     Float32_To_Int16,              /* PaUtilConverter *Float32_To_Int16; */
     Float32_To_Int16_Dither,       /* PaUtilConverter *Float32_To_Int16_Dither; */
     Float32_To_Int16_Clip,         /* PaUtilConverter *Float32_To_Int16_Clip; */

--- a/src/common/pa_converters.h
+++ b/src/common/pa_converters.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -119,7 +119,7 @@ PaUtilConverter* PaUtil_SelectConverter( PaSampleFormat sourceFormat,
 typedef void PaUtilZeroer(
     void *destinationBuffer, signed int destinationStride, unsigned int count );
 
-    
+
 /** Find a buffer zeroer function for the given destination format.
     @return
     A pointer to a PaUtilZeroer which will perform the requested
@@ -145,7 +145,7 @@ typedef struct{
     PaUtilConverter *Float32_To_Int24_Dither;
     PaUtilConverter *Float32_To_Int24_Clip;
     PaUtilConverter *Float32_To_Int24_DitherClip;
-    
+
     PaUtilConverter *Float32_To_Int16;
     PaUtilConverter *Float32_To_Int16_Dither;
     PaUtilConverter *Float32_To_Int16_Clip;
@@ -193,7 +193,7 @@ typedef struct{
     PaUtilConverter *Int8_To_Int24;
     PaUtilConverter *Int8_To_Int16;
     PaUtilConverter *Int8_To_UInt8;
-    
+
     PaUtilConverter *UInt8_To_Float32;
     PaUtilConverter *UInt8_To_Int32;
     PaUtilConverter *UInt8_To_Int24;

--- a/src/common/pa_cpuload.c
+++ b/src/common/pa_cpuload.c
@@ -27,13 +27,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -94,7 +94,7 @@ void PaUtil_EndCpuLoadMeasurement( PaUtilCpuLoadMeasurer* measurer, unsigned lon
 #define LOWPASS_COEFFICIENT_1   (0.99999 - LOWPASS_COEFFICIENT_0)
 
         measurer->averageLoad = (LOWPASS_COEFFICIENT_0 * measurer->averageLoad) +
-                               (LOWPASS_COEFFICIENT_1 * measuredLoad);
+                                (LOWPASS_COEFFICIENT_1 * measuredLoad);
     }
 }
 

--- a/src/common/pa_cpuload.h
+++ b/src/common/pa_cpuload.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -68,5 +68,5 @@ double PaUtil_GetCpuLoad( PaUtilCpuLoadMeasurer* measurer );
 
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */     
+#endif /* __cplusplus */
 #endif /* PA_CPULOAD_H */

--- a/src/common/pa_debugprint.c
+++ b/src/common/pa_debugprint.c
@@ -43,11 +43,11 @@
  @brief Implements log function.
 
     PaUtil_SetLogPrintFunction can be user called to replace the provided
-	DefaultLogPrint function, which writes to stderr.
-	One can NOT pass var_args across compiler/dll boundaries as it is not
-	"byte code/abi portable". So the technique used here is to allocate a local
-	a static array, write in it, then callback the user with a pointer to its
-	start.
+    DefaultLogPrint function, which writes to stderr.
+    One can NOT pass var_args across compiler/dll boundaries as it is not
+    "byte code/abi portable". So the technique used here is to allocate a local
+    a static array, write in it, then callback the user with a pointer to its
+    start.
 */
 
 #include <stdio.h>
@@ -57,8 +57,8 @@
 
 // for OutputDebugStringA
 #if defined(_MSC_VER) && defined(PA_ENABLE_MSVC_DEBUG_OUTPUT)
-	#define WIN32_LEAN_AND_MEAN // exclude rare headers
-	#include "windows.h"
+    #define WIN32_LEAN_AND_MEAN // exclude rare headers
+    #include "windows.h"
 #endif
 
 // User callback
@@ -75,32 +75,32 @@ void PaUtil_SetDebugPrintFunction(PaUtilLogCallback cb)
  VERY dangerous alternative, vsprintf (with no n)
 */
 #if _MSC_VER
-	/* Some Windows Mobile SDKs don't define vsnprintf but all define _vsnprintf (hopefully).
-	   According to MSDN "vsnprintf is identical to _vsnprintf". So we use _vsnprintf with MSC.
-	*/
-	#define VSNPRINTF  _vsnprintf 
+    /* Some Windows Mobile SDKs don't define vsnprintf but all define _vsnprintf (hopefully).
+       According to MSDN "vsnprintf is identical to _vsnprintf". So we use _vsnprintf with MSC.
+    */
+    #define VSNPRINTF  _vsnprintf
 #else
-	#define VSNPRINTF  vsnprintf
+    #define VSNPRINTF  vsnprintf
 #endif
 
 #define PA_LOG_BUF_SIZE 2048
 
 void PaUtil_DebugPrint( const char *format, ... )
 {
-	// Optional logging into Output console of Visual Studio
+    // Optional logging into Output console of Visual Studio
 #if defined(_MSC_VER) && defined(PA_ENABLE_MSVC_DEBUG_OUTPUT)
-	{
-		char buf[PA_LOG_BUF_SIZE];
-		va_list ap;
-		va_start(ap, format);
-		VSNPRINTF(buf, sizeof(buf), format, ap);
-		buf[sizeof(buf)-1] = 0;
-		OutputDebugStringA(buf);
-		va_end(ap);
-	}
+    {
+        char buf[PA_LOG_BUF_SIZE];
+        va_list ap;
+        va_start(ap, format);
+        VSNPRINTF(buf, sizeof(buf), format, ap);
+        buf[sizeof(buf)-1] = 0;
+        OutputDebugStringA(buf);
+        va_end(ap);
+    }
 #endif
 
-	// Output to User-Callback
+    // Output to User-Callback
     if (userCB != NULL)
     {
         char strdump[PA_LOG_BUF_SIZE];
@@ -112,7 +112,7 @@ void PaUtil_DebugPrint( const char *format, ... )
         va_end(ap);
     }
     else
-	// Standard output to stderr
+    // Standard output to stderr
     {
         va_list ap;
         va_start(ap, format);

--- a/src/common/pa_debugprint.h
+++ b/src/common/pa_debugprint.h
@@ -101,7 +101,7 @@ void PaUtil_DebugPrint( const char *format, ... );
 
 
 #ifdef PA_LOG_API_CALLS
-#define PA_LOGAPI(x) PaUtil_DebugPrint x 
+#define PA_LOGAPI(x) PaUtil_DebugPrint x
 
 #define PA_LOGAPI_ENTER(functionName) PaUtil_DebugPrint( functionName " called.\n" )
 
@@ -110,16 +110,16 @@ void PaUtil_DebugPrint( const char *format, ... );
 #define PA_LOGAPI_EXIT(functionName) PaUtil_DebugPrint( functionName " returned.\n" )
 
 #define PA_LOGAPI_EXIT_PAERROR( functionName, result ) \
-	PaUtil_DebugPrint( functionName " returned:\n" ); \
-	PaUtil_DebugPrint("\tPaError: %d ( %s )\n", result, Pa_GetErrorText( result ) )
+    PaUtil_DebugPrint( functionName " returned:\n" ); \
+    PaUtil_DebugPrint("\tPaError: %d ( %s )\n", result, Pa_GetErrorText( result ) )
 
 #define PA_LOGAPI_EXIT_T( functionName, resultFormatString, result ) \
-	PaUtil_DebugPrint( functionName " returned:\n" ); \
-	PaUtil_DebugPrint("\t" resultFormatString "\n", result )
+    PaUtil_DebugPrint( functionName " returned:\n" ); \
+    PaUtil_DebugPrint("\t" resultFormatString "\n", result )
 
 #define PA_LOGAPI_EXIT_PAERROR_OR_T_RESULT( functionName, positiveResultFormatString, result ) \
-	PaUtil_DebugPrint( functionName " returned:\n" ); \
-	if( result > 0 ) \
+    PaUtil_DebugPrint( functionName " returned:\n" ); \
+    if( result > 0 ) \
         PaUtil_DebugPrint("\t" positiveResultFormatString "\n", result ); \
     else \
         PaUtil_DebugPrint("\tPaError: %d ( %s )\n", result, Pa_GetErrorText( result ) )
@@ -133,7 +133,7 @@ void PaUtil_DebugPrint( const char *format, ... );
 #define PA_LOGAPI_EXIT_PAERROR_OR_T_RESULT( functionName, positiveResultFormatString, result )
 #endif
 
-    
+
 typedef void (*PaUtilLogCallback ) (const char *log);
 
 /**

--- a/src/common/pa_dither.c
+++ b/src/common/pa_dither.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -72,10 +72,10 @@ PaInt32 PaUtil_Generate16BitTriangularDither( PaUtilTriangularDitherGenerator *s
 
     /* Generate triangular distribution about 0.
      * Shift before adding to prevent overflow which would skew the distribution.
-     * Also shift an extra bit for the high pass filter. 
+     * Also shift an extra bit for the high pass filter.
      */
 #define DITHER_SHIFT_  ((sizeof(PaInt32)*8 - PA_DITHER_BITS_) + 1)
-	
+
     current = (((PaInt32)state->randSeed1)>>DITHER_SHIFT_) +
               (((PaInt32)state->randSeed2)>>DITHER_SHIFT_);
 
@@ -100,7 +100,7 @@ float PaUtil_GenerateFloatTriangularDither( PaUtilTriangularDitherGenerator *sta
 
     /* Generate triangular distribution about 0.
      * Shift before adding to prevent overflow which would skew the distribution.
-     * Also shift an extra bit for the high pass filter. 
+     * Also shift an extra bit for the high pass filter.
      */
     current = (((PaInt32)state->randSeed1)>>DITHER_SHIFT_) +
               (((PaInt32)state->randSeed2)>>DITHER_SHIFT_);
@@ -137,7 +137,7 @@ things like this:  r3=(r1 & 0x7F)<<8; instead of calling rand() again.
   float s1, s2;                //error feedback buffers
   float s = 0.5f;              //set to 0.0f for no noise shaping
   float w = pow(2.0,bits-1);   //word length (usually bits=16)
-  float wi= 1.0f/w;            
+  float wi= 1.0f/w;
   float d = wi / RAND_MAX;     //dither amplitude (2 lsb)
   float o = wi * 0.5f;         //remove dc offset
   float in, tmp;
@@ -148,19 +148,19 @@ things like this:  r3=(r1 & 0x7F)<<8; instead of calling rand() again.
 
   r2=r1;                               //can make HP-TRI dither by
   r1=rand();                           //subtracting previous rand()
-    
+
   in += s * (s1 + s1 - s2);            //error feedback
-  tmp = in + o + d * (float)(r1 - r2); //dc offset and dither 
-  
+  tmp = in + o + d * (float)(r1 - r2); //dc offset and dither
+
   out = (int)(w * tmp);                //truncate downwards
   if(tmp<0.0f) out--;                  //this is faster than floor()
 
-  s2 = s1;                            
+  s2 = s1;
   s1 = in - wi * (float)out;           //error
 
 
 
--- 
+--
 paul.kellett@maxim.abel.co.uk
 http://www.maxim.abel.co.uk
 */
@@ -172,7 +172,7 @@ http://www.maxim.abel.co.uk
 Type : First order error feedforward dithering code
 References : Posted by Jon Watte
 
-Notes : 
+Notes :
 This is about as simple a dithering algorithm as you can implement, but it's
 likely to sound better than just truncating to N bits.
 
@@ -183,36 +183,36 @@ and integer SIMD type instructions, or CMOV.
 
 Last, if sound quality is paramount (such as when going from > 16 bits to 16
 bits) you probably want to use a higher-order dither function found elsewhere
-on this site. 
+on this site.
 
 
-Code : 
-// This code will down-convert and dither a 16-bit signed short 
-// mono signal into an 8-bit unsigned char signal, using a first 
-// order forward-feeding error term dither. 
+Code :
+// This code will down-convert and dither a 16-bit signed short
+// mono signal into an 8-bit unsigned char signal, using a first
+// order forward-feeding error term dither.
 
-#define uchar unsigned char 
+#define uchar unsigned char
 
-void dither_one_channel_16_to_8( short * input, uchar * output, int count, int * memory ) 
-{ 
-  int m = *memory; 
-  while( count-- > 0 ) { 
-    int i = *input++; 
-    i += m; 
-    int j = i + 32768 - 128; 
-    uchar o; 
-    if( j < 0 ) { 
-      o = 0; 
-    } 
-    else if( j > 65535 ) { 
-      o = 255; 
-    } 
-    else { 
-      o = (uchar)((j>>8)&0xff); 
-    } 
-    m = ((j-32768+128)-i); 
-    *output++ = o; 
-  } 
-  *memory = m; 
-} 
+void dither_one_channel_16_to_8( short * input, uchar * output, int count, int * memory )
+{
+  int m = *memory;
+  while( count-- > 0 ) {
+    int i = *input++;
+    i += m;
+    int j = i + 32768 - 128;
+    uchar o;
+    if( j < 0 ) {
+      o = 0;
+    }
+    else if( j > 65535 ) {
+      o = 255;
+    }
+    else {
+      o = (uchar)((j>>8)&0xff);
+    }
+    m = ((j-32768+128)-i);
+    *output++ = o;
+  }
+  *memory = m;
+}
 */

--- a/src/common/pa_dither.h
+++ b/src/common/pa_dither.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 

--- a/src/common/pa_endianness.h
+++ b/src/common/pa_endianness.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -67,19 +67,19 @@ extern "C"
 #if defined(__APPLE__)
     /* we need to do some endian detection that is sensitive to hardware arch */
     #if defined(__LITTLE_ENDIAN__)
-       #if !defined( PA_LITTLE_ENDIAN )
-          #define PA_LITTLE_ENDIAN
-       #endif
-       #if defined( PA_BIG_ENDIAN )
-          #undef PA_BIG_ENDIAN
-       #endif
+        #if !defined( PA_LITTLE_ENDIAN )
+            #define PA_LITTLE_ENDIAN
+        #endif
+        #if defined( PA_BIG_ENDIAN )
+            #undef PA_BIG_ENDIAN
+        #endif
     #else
-       #if !defined( PA_BIG_ENDIAN )
-          #define PA_BIG_ENDIAN
-       #endif
-       #if defined( PA_LITTLE_ENDIAN )
-          #undef PA_LITTLE_ENDIAN
-       #endif
+        #if !defined( PA_BIG_ENDIAN )
+            #define PA_BIG_ENDIAN
+        #endif
+        #if defined( PA_LITTLE_ENDIAN )
+            #undef PA_LITTLE_ENDIAN
+        #endif
     #endif
 #else
     /* this is not an apple, so first check the existing defines, and, failing that,

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -457,10 +457,10 @@ const char *Pa_GetErrorText( PaError errorCode )
     case paIncompatibleStreamHostApi: result = "Incompatible stream host API"; break;
     case paBadBufferPtr:             result = "Bad buffer pointer"; break;
     default:
-		if( errorCode > 0 )
-			result = "Invalid error code (value greater than zero)";
+        if( errorCode > 0 )
+            result = "Invalid error code (value greater than zero)";
         else
-			result = "Invalid error code";
+            result = "Invalid error code";
         break;
     }
     return result;
@@ -637,7 +637,7 @@ const PaHostApiInfo* Pa_GetHostApiInfo( PaHostApiIndex hostApi )
 
     }
 
-     return info;
+    return info;
 }
 
 
@@ -884,9 +884,9 @@ static PaError ValidateOpenStreamParameters(
     PaDeviceIndex *hostApiInputDevice,
     PaDeviceIndex *hostApiOutputDevice )
 {
-    int inputHostApiIndex  = -1, /* Suppress uninitialised var warnings: compiler does */
-        outputHostApiIndex = -1; /* not see that if inputParameters and outputParame-  */
-                                 /* ters are both nonzero, these indices are set.      */
+    int inputHostApiIndex  = -1;    /* Suppress uninitialised var warnings: compiler does */
+    int outputHostApiIndex = -1;    /* not see that if inputParameters and outputParameters  */
+                                    /* are both nonzero, these indices are set. */
 
     if( (inputParameters == NULL) && (outputParameters == NULL) )
     {
@@ -1016,7 +1016,7 @@ static PaError ValidateOpenStreamParameters(
     {
         /* must be a callback stream */
         if( !streamCallback )
-             return paInvalidFlag;
+            return paInvalidFlag;
 
         /* must be a full duplex stream */
         if( (inputParameters == NULL) || (outputParameters == NULL) )
@@ -1296,8 +1296,8 @@ PaError Pa_OpenDefaultStream( PaStream** stream,
     if( inputChannelCount > 0 )
     {
         hostApiInputParameters.device = Pa_GetDefaultInputDevice();
-		if( hostApiInputParameters.device == paNoDevice )
-			return paDeviceUnavailable;
+        if( hostApiInputParameters.device == paNoDevice )
+            return paDeviceUnavailable;
 
         hostApiInputParameters.channelCount = inputChannelCount;
         hostApiInputParameters.sampleFormat = sampleFormat;
@@ -1319,8 +1319,8 @@ PaError Pa_OpenDefaultStream( PaStream** stream,
     if( outputChannelCount > 0 )
     {
         hostApiOutputParameters.device = Pa_GetDefaultOutputDevice();
-		if( hostApiOutputParameters.device == paNoDevice )
-			return paDeviceUnavailable;
+        if( hostApiOutputParameters.device == paNoDevice )
+            return paDeviceUnavailable;
 
         hostApiOutputParameters.channelCount = outputChannelCount;
         hostApiOutputParameters.sampleFormat = sampleFormat;

--- a/src/common/pa_hostapi.h
+++ b/src/common/pa_hostapi.h
@@ -29,20 +29,20 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
 /** @file
  @ingroup common_src
 
- @brief Interfaces and representation structures used by pa_front.c 
+ @brief Interfaces and representation structures used by pa_front.c
  to manage and communicate with host API implementations.
 */
 
@@ -51,12 +51,12 @@
 /**
 The PA_NO_* host API macros are now deprecated in favor of PA_USE_* macros.
 PA_USE_* indicates whether a particular host API will be initialized by PortAudio.
-An undefined or 0 value indicates that the host API will not be used. A value of 1 
-indicates that the host API will be used. PA_USE_* macros should be left undefined 
+An undefined or 0 value indicates that the host API will not be used. A value of 1
+indicates that the host API will be used. PA_USE_* macros should be left undefined
 or defined to either 0 or 1.
 
 The code below ensures that PA_USE_* macros are always defined and have value
-0 or 1. Undefined symbols are defaulted to 0. Symbols that are neither 0 nor 1 
+0 or 1. Undefined symbols are defaulted to 0. Symbols that are neither 0 nor 1
 are defaulted to 1.
 */
 
@@ -65,7 +65,7 @@ are defaulted to 1.
 #elif (PA_USE_SKELETON != 0) && (PA_USE_SKELETON != 1)
 #undef PA_USE_SKELETON
 #define PA_USE_SKELETON 1
-#endif 
+#endif
 
 #if defined(PA_NO_ASIO) || defined(PA_NO_DS) || defined(PA_NO_WMME) || defined(PA_NO_WASAPI) || defined(PA_NO_WDMKS)
 #error "Portaudio: PA_NO_<APINAME> is no longer supported, please remove definition and use PA_USE_<APINAME> instead"
@@ -76,35 +76,35 @@ are defaulted to 1.
 #elif (PA_USE_ASIO != 0) && (PA_USE_ASIO != 1)
 #undef PA_USE_ASIO
 #define PA_USE_ASIO 1
-#endif 
+#endif
 
 #ifndef PA_USE_DS
 #define PA_USE_DS 0
 #elif (PA_USE_DS != 0) && (PA_USE_DS != 1)
 #undef PA_USE_DS
 #define PA_USE_DS 1
-#endif 
+#endif
 
 #ifndef PA_USE_WMME
 #define PA_USE_WMME 0
 #elif (PA_USE_WMME != 0) && (PA_USE_WMME != 1)
 #undef PA_USE_WMME
 #define PA_USE_WMME 1
-#endif 
+#endif
 
 #ifndef PA_USE_WASAPI
 #define PA_USE_WASAPI 0
 #elif (PA_USE_WASAPI != 0) && (PA_USE_WASAPI != 1)
 #undef PA_USE_WASAPI
 #define PA_USE_WASAPI 1
-#endif 
+#endif
 
 #ifndef PA_USE_WDMKS
 #define PA_USE_WDMKS 0
 #elif (PA_USE_WDMKS != 0) && (PA_USE_WDMKS != 1)
 #undef PA_USE_WDMKS
 #define PA_USE_WDMKS 1
-#endif 
+#endif
 
 /* Set default values for Unix based APIs. */
 #if defined(PA_NO_OSS) || defined(PA_NO_ALSA) || defined(PA_NO_JACK) || defined(PA_NO_COREAUDIO) || defined(PA_NO_SGI) || defined(PA_NO_ASIHPI)
@@ -116,42 +116,42 @@ are defaulted to 1.
 #elif (PA_USE_OSS != 0) && (PA_USE_OSS != 1)
 #undef PA_USE_OSS
 #define PA_USE_OSS 1
-#endif 
+#endif
 
 #ifndef PA_USE_ALSA
 #define PA_USE_ALSA 0
 #elif (PA_USE_ALSA != 0) && (PA_USE_ALSA != 1)
 #undef PA_USE_ALSA
 #define PA_USE_ALSA 1
-#endif 
+#endif
 
 #ifndef PA_USE_JACK
 #define PA_USE_JACK 0
 #elif (PA_USE_JACK != 0) && (PA_USE_JACK != 1)
 #undef PA_USE_JACK
 #define PA_USE_JACK 1
-#endif 
+#endif
 
 #ifndef PA_USE_SGI
 #define PA_USE_SGI 0
 #elif (PA_USE_SGI != 0) && (PA_USE_SGI != 1)
 #undef PA_USE_SGI
 #define PA_USE_SGI 1
-#endif 
+#endif
 
 #ifndef PA_USE_COREAUDIO
 #define PA_USE_COREAUDIO 0
 #elif (PA_USE_COREAUDIO != 0) && (PA_USE_COREAUDIO != 1)
 #undef PA_USE_COREAUDIO
 #define PA_USE_COREAUDIO 1
-#endif 
+#endif
 
 #ifndef PA_USE_ASIHPI
 #define PA_USE_ASIHPI 0
 #elif (PA_USE_ASIHPI != 0) && (PA_USE_ASIHPI != 1)
 #undef PA_USE_ASIHPI
 #define PA_USE_ASIHPI 1
-#endif 
+#endif
 
 #ifdef __cplusplus
 extern "C"
@@ -216,13 +216,13 @@ typedef struct PaUtilHostApiRepresentation {
         The inputParameters and outputParameters pointers should not be saved
         as they will not remain valid after OpenStream is called.
 
-        
+
         The following guarantees are made about parameters to (*OpenStream)():
 
             [NOTE: the following list up to *END PA FRONT VALIDATIONS* should be
                 kept in sync with the one for ValidateOpenStreamParameters and
                 Pa_OpenStream in pa_front.c]
-                
+
             PaHostApiRepresentation *hostApi
                 - is valid for this implementation
 
@@ -233,7 +233,7 @@ typedef struct PaUtilHostApiRepresentation {
 
             - if inputParameters & outputParmeters are both valid, that
                 inputParameters->device & outputParmeters->device  both use the same host api
- 
+
             PaDeviceIndex inputParameters->device
                 - is within range (0 to Pa_CountDevices-1) Or:
                 - is paUseHostApiSpecificDeviceSpecification and
@@ -243,30 +243,30 @@ typedef struct PaUtilHostApiRepresentation {
             int inputParameters->numChannels
                 - if inputParameters->device is not paUseHostApiSpecificDeviceSpecification, numInputChannels is > 0
                 - upper bound is NOT validated against device capabilities
- 
+
             PaSampleFormat inputParameters->sampleFormat
                 - is one of the sample formats defined in portaudio.h
 
             void *inputParameters->hostApiSpecificStreamInfo
                 - if supplied its hostApi field matches the input device's host Api
- 
+
             PaDeviceIndex outputParmeters->device
                 - is within range (0 to Pa_CountDevices-1)
- 
+
             int outputParmeters->numChannels
                 - if inputDevice is valid, numInputChannels is > 0
                 - upper bound is NOT validated against device capabilities
- 
+
             PaSampleFormat outputParmeters->sampleFormat
                 - is one of the sample formats defined in portaudio.h
-        
+
             void *outputParmeters->hostApiSpecificStreamInfo
                 - if supplied its hostApi field matches the output device's host Api
- 
+
             double sampleRate
                 - is not an 'absurd' rate (less than 1000. or greater than 384000.)
                 - sampleRate is NOT validated against device capabilities
- 
+
             PaStreamFlags streamFlags
                 - unused platform neutral flags are zero
                 - paNeverDropInput is only used for full-duplex callback streams
@@ -278,7 +278,7 @@ typedef struct PaUtilHostApiRepresentation {
         The following validations MUST be performed by (*OpenStream)():
 
             - check that input device can support numInputChannels
-            
+
             - check that input device can support inputSampleFormat, or that
                 we have the capability to convert from outputSampleFormat to
                 a native format
@@ -287,7 +287,7 @@ typedef struct PaUtilHostApiRepresentation {
                 or return an error if no inputStreamInfo is expected
 
             - check that output device can support numOutputChannels
-            
+
             - check that output device can support outputSampleFormat, or that
                 we have the capability to convert from outputSampleFormat to
                 a native format
@@ -327,11 +327,11 @@ typedef struct PaUtilHostApiRepresentation {
 
 /** Prototype for the initialization function which must be implemented by every
  host API.
- 
- This function should only return an error other than paNoError if it encounters 
- an unexpected and fatal error (memory allocation error for example). In general, 
- there may be conditions under which it returns a NULL interface pointer and also 
- returns paNoError. For example, if the ASIO implementation detects that ASIO is 
+
+ This function should only return an error other than paNoError if it encounters
+ an unexpected and fatal error (memory allocation error for example). In general,
+ there may be conditions under which it returns a NULL interface pointer and also
+ returns paNoError. For example, if the ASIO implementation detects that ASIO is
  not installed, it should return a NULL interface, and paNoError.
 
  @see paHostApiInitializers
@@ -341,11 +341,11 @@ typedef PaError PaUtilHostApiInitializer( PaUtilHostApiRepresentation**, PaHostA
 
 /** paHostApiInitializers is a NULL-terminated array of host API initialization
  functions. These functions are called by pa_front.c to initialize the host APIs
- when the client calls Pa_Initialize(). 
- 
+ when the client calls Pa_Initialize().
+
  The initialization functions are invoked in order.
 
- The first successfully initialized host API that has a default input *or* output 
+ The first successfully initialized host API that has a default input *or* output
  device is used as the default PortAudio host API. This is based on the logic that
  there is only one default host API, and it must contain the default input and output
  devices (if defined).

--- a/src/common/pa_memorybarrier.h
+++ b/src/common/pa_memorybarrier.h
@@ -30,13 +30,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 

--- a/src/common/pa_memorybarrier.h
+++ b/src/common/pa_memorybarrier.h
@@ -71,32 +71,32 @@
 #elif defined(__GNUC__)
     /* GCC >= 4.1 has built-in intrinsics. We'll use those */
 #   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
-#      define PaUtil_FullMemoryBarrier()  __sync_synchronize()
-#      define PaUtil_ReadMemoryBarrier()  __sync_synchronize()
-#      define PaUtil_WriteMemoryBarrier() __sync_synchronize()
+#       define PaUtil_FullMemoryBarrier()  __sync_synchronize()
+#       define PaUtil_ReadMemoryBarrier()  __sync_synchronize()
+#       define PaUtil_WriteMemoryBarrier() __sync_synchronize()
     /* as a fallback, GCC understands volatile asm and "memory" to mean it
      * should not reorder memory read/writes */
     /* Note that it is not clear that any compiler actually defines __PPC__,
      * it can probably removed safely. */
 #   elif defined( __ppc__ ) || defined( __powerpc__) || defined( __PPC__ )
-#      define PaUtil_FullMemoryBarrier()  asm volatile("sync":::"memory")
-#      define PaUtil_ReadMemoryBarrier()  asm volatile("sync":::"memory")
-#      define PaUtil_WriteMemoryBarrier() asm volatile("sync":::"memory")
+#       define PaUtil_FullMemoryBarrier()  asm volatile("sync":::"memory")
+#       define PaUtil_ReadMemoryBarrier()  asm volatile("sync":::"memory")
+#       define PaUtil_WriteMemoryBarrier() asm volatile("sync":::"memory")
 #   elif defined( __i386__ ) || defined( __i486__ ) || defined( __i586__ ) || \
-         defined( __i686__ ) || defined( __x86_64__ )
-#      define PaUtil_FullMemoryBarrier()  asm volatile("mfence":::"memory")
-#      define PaUtil_ReadMemoryBarrier()  asm volatile("lfence":::"memory")
-#      define PaUtil_WriteMemoryBarrier() asm volatile("sfence":::"memory")
+            defined( __i686__ ) || defined( __x86_64__ )
+#       define PaUtil_FullMemoryBarrier()  asm volatile("mfence":::"memory")
+#       define PaUtil_ReadMemoryBarrier()  asm volatile("lfence":::"memory")
+#       define PaUtil_WriteMemoryBarrier() asm volatile("sfence":::"memory")
 #   else
-#      ifdef ALLOW_SMP_DANGERS
-#         warning Memory barriers not defined on this system or system unknown
-#         warning For SMP safety, you should fix this.
-#         define PaUtil_FullMemoryBarrier()
-#         define PaUtil_ReadMemoryBarrier()
-#         define PaUtil_WriteMemoryBarrier()
-#      else
-#         error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
-#      endif
+#       ifdef ALLOW_SMP_DANGERS
+#           warning Memory barriers not defined on this system or system unknown
+#           warning For SMP safety, you should fix this.
+#           define PaUtil_FullMemoryBarrier()
+#           define PaUtil_ReadMemoryBarrier()
+#           define PaUtil_WriteMemoryBarrier()
+#       else
+#           error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
+#       endif
 #   endif
 #elif (_MSC_VER >= 1400) && !defined(_WIN32_WCE)
 #   include <intrin.h>
@@ -117,12 +117,12 @@
 #   define PaUtil_WriteMemoryBarrier() _asm { lock add    [esp], 0 }
 #else
 #   ifdef ALLOW_SMP_DANGERS
-#      warning Memory barriers not defined on this system or system unknown
-#      warning For SMP safety, you should fix this.
-#      define PaUtil_FullMemoryBarrier()
-#      define PaUtil_ReadMemoryBarrier()
-#      define PaUtil_WriteMemoryBarrier()
+#       warning Memory barriers not defined on this system or system unknown
+#       warning For SMP safety, you should fix this.
+#       define PaUtil_FullMemoryBarrier()
+#       define PaUtil_ReadMemoryBarrier()
+#       define PaUtil_WriteMemoryBarrier()
 #   else
-#      error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
+#       error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
 #   endif
 #endif

--- a/src/common/pa_process.c
+++ b/src/common/pa_process.c
@@ -27,13 +27,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -142,7 +142,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         }
         else /* unknown host buffer size */
         {
-             bp->framesPerTempBuffer = PA_FRAMES_PER_TEMP_BUFFER_WHEN_HOST_BUFFER_SIZE_IS_UNKNOWN_;
+            bp->framesPerTempBuffer = PA_FRAMES_PER_TEMP_BUFFER_WHEN_HOST_BUFFER_SIZE_IS_UNKNOWN_;
         }
     }
     else
@@ -198,7 +198,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
     bp->framesInTempInputBuffer = bp->initialFramesInTempInputBuffer;
     bp->framesInTempOutputBuffer = bp->initialFramesInTempOutputBuffer;
 
-    
+
     if( inputChannelCount > 0 )
     {
         bytesPerSample = Pa_GetSampleSize( hostInputSampleFormat );
@@ -224,7 +224,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         }
 
         /* Under the assumption that no ADC in existence delivers better than 24bits resolution,
-            we disable dithering when host input format is paInt32 and user format is paInt24, 
+            we disable dithering when host input format is paInt32 and user format is paInt24,
             since the host samples will just be padded with zeros anyway. */
 
         tempInputStreamFlags = streamFlags;
@@ -239,23 +239,23 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
             PaUtil_SelectConverter( hostInputSampleFormat, userInputSampleFormat, tempInputStreamFlags );
 
         bp->inputZeroer = PaUtil_SelectZeroer( userInputSampleFormat );
-            
+
         bp->userInputIsInterleaved = (userInputSampleFormat & paNonInterleaved)?0:1;
-		
+
         bp->hostInputIsInterleaved = (hostInputSampleFormat & paNonInterleaved)?0:1;
 
         bp->userInputSampleFormatIsEqualToHost = ((userInputSampleFormat & ~paNonInterleaved) == (hostInputSampleFormat & ~paNonInterleaved));
 
         tempInputBufferSize =
             bp->framesPerTempBuffer * bp->bytesPerUserInputSample * inputChannelCount;
-         
+
         bp->tempInputBuffer = PaUtil_AllocateMemory( tempInputBufferSize );
         if( bp->tempInputBuffer == 0 )
         {
             result = paInsufficientMemory;
             goto error;
         }
-        
+
         if( bp->framesInTempInputBuffer > 0 )
             memset( bp->tempInputBuffer, 0, tempInputBufferSize );
 
@@ -328,7 +328,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
 
         if( bp->framesInTempOutputBuffer > 0 )
             memset( bp->tempOutputBuffer, 0, tempOutputBufferSize );
-        
+
         if( userOutputSampleFormat & paNonInterleaved )
         {
             bp->tempOutputBufferPtrs =
@@ -343,7 +343,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         bp->hostOutputChannels[0] = (PaUtilChannelDescriptor*)
                 PaUtil_AllocateMemory( sizeof(PaUtilChannelDescriptor)*outputChannelCount * 2 );
         if( bp->hostOutputChannels[0] == 0 )
-        {                                                                     
+        {
             result = paInsufficientMemory;
             goto error;
         }
@@ -393,7 +393,7 @@ void PaUtil_TerminateBufferProcessor( PaUtilBufferProcessor* bp )
 
     if( bp->hostInputChannels[0] )
         PaUtil_FreeMemory( bp->hostInputChannels[0] );
-        
+
     if( bp->tempOutputBuffer )
         PaUtil_FreeMemory( bp->tempOutputBuffer );
 
@@ -420,7 +420,7 @@ void PaUtil_ResetBufferProcessor( PaUtilBufferProcessor* bp )
     }
 
     if( bp->framesInTempOutputBuffer > 0 )
-    {      
+    {
         tempOutputBufferSize =
             bp->framesPerTempBuffer * bp->bytesPerUserOutputSample * bp->outputChannelCount;
         memset( bp->tempOutputBuffer, 0, tempOutputBufferSize );
@@ -448,7 +448,7 @@ void PaUtil_SetInputFrameCount( PaUtilBufferProcessor* bp,
     else
         bp->hostInputFrameCount[0] = frameCount;
 }
-        
+
 
 void PaUtil_SetNoInput( PaUtilBufferProcessor* bp )
 {
@@ -462,7 +462,7 @@ void PaUtil_SetInputChannel( PaUtilBufferProcessor* bp,
         unsigned int channel, void *data, unsigned int stride )
 {
     assert( channel < bp->inputChannelCount );
-    
+
     bp->hostInputChannels[0][channel].data = data;
     bp->hostInputChannels[0][channel].stride = stride;
 }
@@ -496,7 +496,7 @@ void PaUtil_SetNonInterleavedInputChannel( PaUtilBufferProcessor* bp,
 {
     assert( channel < bp->inputChannelCount );
     assert( !bp->hostInputIsInterleaved );
-    
+
     bp->hostInputChannels[0][channel].data = data;
     bp->hostInputChannels[0][channel].stride = 1;
 }
@@ -532,7 +532,7 @@ void PaUtil_Set2ndInterleavedInputChannels( PaUtilBufferProcessor* bp,
     assert( firstChannel < bp->inputChannelCount );
     assert( firstChannel + channelCount <= bp->inputChannelCount );
     assert( bp->hostInputIsInterleaved );
-    
+
     for( i=0; i< channelCount; ++i )
     {
         bp->hostInputChannels[1][channel+i].data = p;
@@ -541,13 +541,13 @@ void PaUtil_Set2ndInterleavedInputChannels( PaUtilBufferProcessor* bp,
     }
 }
 
-        
+
 void PaUtil_Set2ndNonInterleavedInputChannel( PaUtilBufferProcessor* bp,
         unsigned int channel, void *data )
 {
     assert( channel < bp->inputChannelCount );
     assert( !bp->hostInputIsInterleaved );
-    
+
     bp->hostInputChannels[1][channel].data = data;
     bp->hostInputChannels[1][channel].stride = 1;
 }
@@ -597,7 +597,7 @@ void PaUtil_SetInterleavedOutputChannels( PaUtilBufferProcessor* bp,
     assert( firstChannel < bp->outputChannelCount );
     assert( firstChannel + channelCount <= bp->outputChannelCount );
     assert( bp->hostOutputIsInterleaved );
-    
+
     for( i=0; i< channelCount; ++i )
     {
         PaUtil_SetOutputChannel( bp, channel + i, p, channelCount );
@@ -647,7 +647,7 @@ void PaUtil_Set2ndInterleavedOutputChannels( PaUtilBufferProcessor* bp,
     assert( firstChannel < bp->outputChannelCount );
     assert( firstChannel + channelCount <= bp->outputChannelCount );
     assert( bp->hostOutputIsInterleaved );
-    
+
     for( i=0; i< channelCount; ++i )
     {
         PaUtil_Set2ndOutputChannel( bp, channel + i, p, channelCount );
@@ -655,13 +655,13 @@ void PaUtil_Set2ndInterleavedOutputChannels( PaUtilBufferProcessor* bp,
     }
 }
 
-        
+
 void PaUtil_Set2ndNonInterleavedOutputChannel( PaUtilBufferProcessor* bp,
         unsigned int channel, void *data )
 {
     assert( channel < bp->outputChannelCount );
     assert( !bp->hostOutputIsInterleaved );
-    
+
     PaUtil_Set2ndOutputChannel( bp, channel, data, 1 );
 }
 
@@ -673,11 +673,11 @@ void PaUtil_BeginBufferProcessing( PaUtilBufferProcessor* bp,
 
     /* the first streamCallback will be called to process samples which are
         currently in the input buffer before the ones starting at the timeInfo time */
-        
+
     bp->timeInfo->inputBufferAdcTime -= bp->framesInTempInputBuffer * bp->samplePeriod;
-    
+
     /* We just pass through timeInfo->currentTime provided by the caller. This is
-        not strictly conformant to the word of the spec, since the buffer processor 
+        not strictly conformant to the word of the spec, since the buffer processor
         might call the callback multiple times, and we never refresh currentTime. */
 
     /* the first streamCallback will be called to generate samples which will be
@@ -735,7 +735,7 @@ static unsigned long NonAdaptingProcess( PaUtilBufferProcessor *bp,
             }
             else /* there are input channels */
             {
-                
+
                 destBytePtr = (unsigned char *)bp->tempInputBuffer;
 
                 if( bp->userInputIsInterleaved )
@@ -779,7 +779,7 @@ static unsigned long NonAdaptingProcess( PaUtilBufferProcessor *bp,
                                 i * bp->bytesPerUserInputSample * frameCount;
                         }
                     }
-                
+
                     userInput = bp->tempInputBufferPtrs;
                 }
 
@@ -795,7 +795,7 @@ static unsigned long NonAdaptingProcess( PaUtilBufferProcessor *bp,
                     }
                 }
                 else
-	            {
+                {
                     if( skipInputConvert )
                     {
                         for( i=0; i<bp->inputChannelCount; ++i )
@@ -837,7 +837,7 @@ static unsigned long NonAdaptingProcess( PaUtilBufferProcessor *bp,
                     /* process host buffer directly, or use temp buffer if formats differ or host buffer non-interleaved,
                      * or if num channels differs between the host (set in stride) and the user (eg with some Alsa hw:) */
                     if( bp->userOutputSampleFormatIsEqualToHost && bp->hostOutputIsInterleaved
-                          && bp->outputChannelCount == hostOutputChannels[0].stride )
+                            && bp->outputChannelCount == hostOutputChannels[0].stride )
                     {
                         userOutput = hostOutputChannels[0].data;
                         skipOutputConvert = 1;
@@ -869,7 +869,7 @@ static unsigned long NonAdaptingProcess( PaUtilBufferProcessor *bp,
                     userOutput = bp->tempOutputBufferPtrs;
                 }
             }
-        
+
             *streamCallbackResult = bp->streamCallback( userInput, userOutput,
                     frameCount, bp->timeInfo, bp->callbackStatusFlags, bp->userData );
 
@@ -884,50 +884,50 @@ static unsigned long NonAdaptingProcess( PaUtilBufferProcessor *bp,
                 bp->timeInfo->outputBufferDacTime += frameCount * bp->samplePeriod;
 
                 /* convert output data (user -> host) */
-                
+
                 if( bp->outputChannelCount != 0 && bp->hostOutputChannels[0][0].data )
                 {
                     if( skipOutputConvert )
-					{
-						for( i=0; i<bp->outputChannelCount; ++i )
-                    	{
-                        	/* advance dest ptr for next iteration */
-                        	hostOutputChannels[i].data = ((unsigned char*)hostOutputChannels[i].data) +
-                            	    frameCount * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
-                    	}
-					}
-					else
-					{
+                    {
+                        for( i=0; i<bp->outputChannelCount; ++i )
+                        {
+                            /* advance dest ptr for next iteration */
+                            hostOutputChannels[i].data = ((unsigned char*)hostOutputChannels[i].data) +
+                                    frameCount * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
+                        }
+                    }
+                    else
+                    {
 
-                    	srcBytePtr = (unsigned char *)bp->tempOutputBuffer;
+                        srcBytePtr = (unsigned char *)bp->tempOutputBuffer;
 
-                    	if( bp->userOutputIsInterleaved )
-                    	{
-                        	srcSampleStrideSamples = bp->outputChannelCount;
-                        	srcChannelStrideBytes = bp->bytesPerUserOutputSample;
-                    	}
-                    	else /* user output is not interleaved */
-                    	{
-                        	srcSampleStrideSamples = 1;
-                        	srcChannelStrideBytes = frameCount * bp->bytesPerUserOutputSample;
-                    	}
+                        if( bp->userOutputIsInterleaved )
+                        {
+                            srcSampleStrideSamples = bp->outputChannelCount;
+                            srcChannelStrideBytes = bp->bytesPerUserOutputSample;
+                        }
+                        else /* user output is not interleaved */
+                        {
+                            srcSampleStrideSamples = 1;
+                            srcChannelStrideBytes = frameCount * bp->bytesPerUserOutputSample;
+                        }
 
-                    	for( i=0; i<bp->outputChannelCount; ++i )
-                    	{
-                        	bp->outputConverter(    hostOutputChannels[i].data,
-                                                	hostOutputChannels[i].stride,
-                                                	srcBytePtr, srcSampleStrideSamples,
-                                                	frameCount, &bp->ditherGenerator );
+                        for( i=0; i<bp->outputChannelCount; ++i )
+                        {
+                            bp->outputConverter(    hostOutputChannels[i].data,
+                                                    hostOutputChannels[i].stride,
+                                                    srcBytePtr, srcSampleStrideSamples,
+                                                    frameCount, &bp->ditherGenerator );
 
-                        	srcBytePtr += srcChannelStrideBytes;  /* skip to next source channel */
+                            srcBytePtr += srcChannelStrideBytes;  /* skip to next source channel */
 
-                        	/* advance dest ptr for next iteration */
-                        	hostOutputChannels[i].data = ((unsigned char*)hostOutputChannels[i].data) +
-                                		frameCount * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
-                    	}
-					}
+                            /* advance dest ptr for next iteration */
+                            hostOutputChannels[i].data = ((unsigned char*)hostOutputChannels[i].data) +
+                                        frameCount * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
+                        }
+                    }
                 }
-             
+
                 framesProcessed += frameCount;
 
                 framesToGo -= frameCount;
@@ -982,7 +982,7 @@ static unsigned long AdaptingInputOnlyProcess( PaUtilBufferProcessor *bp,
     unsigned long frameCount;
     unsigned long framesToGo = framesToProcess;
     unsigned long framesProcessed = 0;
-    
+
     userOutput = 0;
 
     do
@@ -998,7 +998,7 @@ static unsigned long AdaptingInputOnlyProcess( PaUtilBufferProcessor *bp,
             destBytePtr = ((unsigned char*)bp->tempInputBuffer) +
                     bp->bytesPerUserInputSample * bp->inputChannelCount *
                     bp->framesInTempInputBuffer;
-                      
+
             destSampleStrideSamples = bp->inputChannelCount;
             destChannelStrideBytes = bp->bytesPerUserInputSample;
 
@@ -1018,7 +1018,7 @@ static unsigned long AdaptingInputOnlyProcess( PaUtilBufferProcessor *bp,
                 bp->tempInputBufferPtrs[i] = ((unsigned char*)bp->tempInputBuffer) +
                     i * bp->bytesPerUserInputSample * bp->framesPerUserBuffer;
             }
-                    
+
             userInput = bp->tempInputBufferPtrs;
         }
 
@@ -1058,7 +1058,7 @@ static unsigned long AdaptingInputOnlyProcess( PaUtilBufferProcessor *bp,
 
                 bp->timeInfo->inputBufferAdcTime += bp->framesPerUserBuffer * bp->samplePeriod;
             }
-            
+
             bp->framesInTempInputBuffer = 0;
         }
 
@@ -1113,7 +1113,7 @@ static unsigned long AdaptingOutputOnlyProcess( PaUtilBufferProcessor *bp,
             }
 
             bp->timeInfo->inputBufferAdcTime = 0;
-            
+
             *streamCallbackResult = bp->streamCallback( userInput, userOutput,
                     bp->framesPerUserBuffer, bp->timeInfo,
                     bp->callbackStatusFlags, bp->userData );
@@ -1150,7 +1150,7 @@ static unsigned long AdaptingOutputOnlyProcess( PaUtilBufferProcessor *bp,
                 srcBytePtr = ((unsigned char*)bp->tempOutputBuffer) +
                         bp->bytesPerUserOutputSample *
                         (bp->framesPerUserBuffer - bp->framesInTempOutputBuffer);
-                            
+
                 srcSampleStrideSamples = 1;
                 srcChannelStrideBytes = bp->framesPerUserBuffer * bp->bytesPerUserOutputSample;
             }
@@ -1191,9 +1191,9 @@ static unsigned long AdaptingOutputOnlyProcess( PaUtilBufferProcessor *bp,
                         frameCount * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
             }
         }
-        
+
         framesProcessed += frameCount;
-        
+
         framesToGo -= frameCount;
 
     }while( framesToGo > 0 );
@@ -1202,8 +1202,8 @@ static unsigned long AdaptingOutputOnlyProcess( PaUtilBufferProcessor *bp,
 }
 
 /* CopyTempOutputBuffersToHostOutputBuffers is called from AdaptingProcess to copy frames from
-	tempOutputBuffer to hostOutputChannels. This includes data conversion
-	and interleaving. 
+    tempOutputBuffer to hostOutputChannels. This includes data conversion
+    and interleaving.
 */
 static void CopyTempOutputBuffersToHostOutputBuffers( PaUtilBufferProcessor *bp)
 {
@@ -1215,65 +1215,65 @@ static void CopyTempOutputBuffersToHostOutputBuffers( PaUtilBufferProcessor *bp)
     unsigned int srcChannelStrideBytes; /* stride from one channel to the next, in bytes */
     unsigned int i;
 
-     /* copy frames from user to host output buffers */
-     while( bp->framesInTempOutputBuffer > 0 &&
-             ((bp->hostOutputFrameCount[0] + bp->hostOutputFrameCount[1]) > 0) )
-     {
-         maxFramesToCopy = bp->framesInTempOutputBuffer;
+    /* copy frames from user to host output buffers */
+    while( bp->framesInTempOutputBuffer > 0 &&
+            ((bp->hostOutputFrameCount[0] + bp->hostOutputFrameCount[1]) > 0) )
+    {
+        maxFramesToCopy = bp->framesInTempOutputBuffer;
 
-         /* select the output buffer set (1st or 2nd) */
-         if( bp->hostOutputFrameCount[0] > 0 )
-         {
-             hostOutputChannels = bp->hostOutputChannels[0];
-             frameCount = PA_MIN_( bp->hostOutputFrameCount[0], maxFramesToCopy );
-         }
-         else
-         {
-             hostOutputChannels = bp->hostOutputChannels[1];
-             frameCount = PA_MIN_( bp->hostOutputFrameCount[1], maxFramesToCopy );
-         }
+        /* select the output buffer set (1st or 2nd) */
+        if( bp->hostOutputFrameCount[0] > 0 )
+        {
+            hostOutputChannels = bp->hostOutputChannels[0];
+            frameCount = PA_MIN_( bp->hostOutputFrameCount[0], maxFramesToCopy );
+        }
+        else
+        {
+            hostOutputChannels = bp->hostOutputChannels[1];
+            frameCount = PA_MIN_( bp->hostOutputFrameCount[1], maxFramesToCopy );
+        }
 
-         if( bp->userOutputIsInterleaved )
-         {
-             srcBytePtr = ((unsigned char*)bp->tempOutputBuffer) +
-                     bp->bytesPerUserOutputSample * bp->outputChannelCount *
-                     (bp->framesPerUserBuffer - bp->framesInTempOutputBuffer);
-                         
-             srcSampleStrideSamples = bp->outputChannelCount;
-             srcChannelStrideBytes = bp->bytesPerUserOutputSample;
-         }
-         else /* user output is not interleaved */
-         {
-             srcBytePtr = ((unsigned char*)bp->tempOutputBuffer) +
-                     bp->bytesPerUserOutputSample *
-                     (bp->framesPerUserBuffer - bp->framesInTempOutputBuffer);
+        if( bp->userOutputIsInterleaved )
+        {
+            srcBytePtr = ((unsigned char*)bp->tempOutputBuffer) +
+                    bp->bytesPerUserOutputSample * bp->outputChannelCount *
+                    (bp->framesPerUserBuffer - bp->framesInTempOutputBuffer);
 
-             srcSampleStrideSamples = 1;
-             srcChannelStrideBytes = bp->framesPerUserBuffer * bp->bytesPerUserOutputSample;
-         }
+            srcSampleStrideSamples = bp->outputChannelCount;
+            srcChannelStrideBytes = bp->bytesPerUserOutputSample;
+        }
+        else /* user output is not interleaved */
+        {
+            srcBytePtr = ((unsigned char*)bp->tempOutputBuffer) +
+                    bp->bytesPerUserOutputSample *
+                    (bp->framesPerUserBuffer - bp->framesInTempOutputBuffer);
 
-         for( i=0; i<bp->outputChannelCount; ++i )
-         {
-             assert( hostOutputChannels[i].data != NULL );
-             bp->outputConverter(    hostOutputChannels[i].data,
-                                     hostOutputChannels[i].stride,
-                                     srcBytePtr, srcSampleStrideSamples,
-                                     frameCount, &bp->ditherGenerator );
+            srcSampleStrideSamples = 1;
+            srcChannelStrideBytes = bp->framesPerUserBuffer * bp->bytesPerUserOutputSample;
+        }
 
-             srcBytePtr += srcChannelStrideBytes;  /* skip to next source channel */
+        for( i=0; i<bp->outputChannelCount; ++i )
+        {
+            assert( hostOutputChannels[i].data != NULL );
+            bp->outputConverter(    hostOutputChannels[i].data,
+                                    hostOutputChannels[i].stride,
+                                    srcBytePtr, srcSampleStrideSamples,
+                                    frameCount, &bp->ditherGenerator );
 
-             /* advance dest ptr for next iteration */
-             hostOutputChannels[i].data = ((unsigned char*)hostOutputChannels[i].data) +
-                     frameCount * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
-         }
+            srcBytePtr += srcChannelStrideBytes;  /* skip to next source channel */
 
-         if( bp->hostOutputFrameCount[0] > 0 )
-             bp->hostOutputFrameCount[0] -= frameCount;
-         else
-             bp->hostOutputFrameCount[1] -= frameCount;
+            /* advance dest ptr for next iteration */
+            hostOutputChannels[i].data = ((unsigned char*)hostOutputChannels[i].data) +
+                    frameCount * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
+        }
 
-         bp->framesInTempOutputBuffer -= frameCount;
-     }
+        if( bp->hostOutputFrameCount[0] > 0 )
+            bp->hostOutputFrameCount[0] -= frameCount;
+        else
+            bp->hostOutputFrameCount[1] -= frameCount;
+
+        bp->framesInTempOutputBuffer -= frameCount;
+    }
 }
 
 /*
@@ -1300,7 +1300,7 @@ static unsigned long AdaptingProcess( PaUtilBufferProcessor *bp,
     unsigned int destSampleStrideSamples; /* stride from one sample to the next within a channel, in samples */
     unsigned int destChannelStrideBytes; /* stride from one channel to the next, in bytes */
     unsigned int i, j;
- 
+
 
     framesAvailable = bp->hostInputFrameCount[0] + bp->hostInputFrameCount[1];/* this is assumed to be the same as the output buffer's frame count */
 
@@ -1310,9 +1310,9 @@ static unsigned long AdaptingProcess( PaUtilBufferProcessor *bp,
         endProcessingMinFrameCount = (bp->framesPerUserBuffer - 1);
 
     /* Fill host output with remaining frames in user output (tempOutputBuffer) */
-    CopyTempOutputBuffersToHostOutputBuffers( bp );		  	
+    CopyTempOutputBuffersToHostOutputBuffers( bp );
 
-    while( framesAvailable > endProcessingMinFrameCount ) 
+    while( framesAvailable > endProcessingMinFrameCount )
     {
 
         if( bp->framesInTempOutputBuffer == 0 && *streamCallbackResult != paContinue )
@@ -1326,7 +1326,7 @@ static unsigned long AdaptingProcess( PaUtilBufferProcessor *bp,
                 if( frameCount > 0 )
                 {
                     hostOutputChannels = bp->hostOutputChannels[i];
-                    
+
                     for( j=0; j<bp->outputChannelCount; ++j )
                     {
                         bp->outputZeroer(   hostOutputChannels[j].data,
@@ -1340,7 +1340,7 @@ static unsigned long AdaptingProcess( PaUtilBufferProcessor *bp,
                     bp->hostOutputFrameCount[i] = 0;
                 }
             }
-        }          
+        }
 
 
         /* copy frames from host to user input buffers */
@@ -1398,7 +1398,7 @@ static unsigned long AdaptingProcess( PaUtilBufferProcessor *bp,
                 bp->hostInputFrameCount[0] -= frameCount;
             else
                 bp->hostInputFrameCount[1] -= frameCount;
-                
+
             bp->framesInTempInputBuffer += frameCount;
 
             /* update framesAvailable and framesProcessed based on input consumed
@@ -1470,13 +1470,13 @@ static unsigned long AdaptingProcess( PaUtilBufferProcessor *bp,
             }
         }
 
-        /* copy frames from user (tempOutputBuffer) to host output buffers (hostOutputChannels) 
+        /* copy frames from user (tempOutputBuffer) to host output buffers (hostOutputChannels)
            Means to process the user output provided by the callback. Has to be called after
             each callback. */
-        CopyTempOutputBuffersToHostOutputBuffers( bp );		  	
+        CopyTempOutputBuffersToHostOutputBuffers( bp );
 
     }
-    
+
     return framesProcessed;
 }
 
@@ -1485,7 +1485,7 @@ unsigned long PaUtil_EndBufferProcessing( PaUtilBufferProcessor* bp, int *stream
 {
     unsigned long framesToProcess, framesToGo;
     unsigned long framesProcessed = 0;
-    
+
     if( bp->inputChannelCount != 0 && bp->outputChannelCount != 0
             && bp->hostInputChannels[0][0].data /* input was supplied (see PaUtil_SetNoInput) */
             && bp->hostOutputChannels[0][0].data /* output was supplied (see PaUtil_SetNoOutput) */ )
@@ -1560,17 +1560,17 @@ unsigned long PaUtil_EndBufferProcessing( PaUtilBufferProcessor* bp, int *stream
                                        *hostOutputFrameCount );
 
                 assert( framesToProcess != 0 );
-                
+
                 framesProcessedThisIteration = NonAdaptingProcess( bp, streamCallbackResult,
                         hostInputChannels, hostOutputChannels,
-                        framesToProcess );                                       
+                        framesToProcess );
 
                 *hostInputFrameCount -= framesProcessedThisIteration;
                 *hostOutputFrameCount -= framesProcessedThisIteration;
 
                 framesProcessed += framesProcessedThisIteration;
                 framesToGo -= framesProcessedThisIteration;
-                
+
             }while( framesToGo > 0 );
         }
         else
@@ -1587,7 +1587,7 @@ unsigned long PaUtil_EndBufferProcessing( PaUtilBufferProcessor* bp, int *stream
                         framesToProcess );
 
             /* process second buffer if provided */
-    
+
             framesToProcess = (bp->inputChannelCount != 0)
                             ? bp->hostInputFrameCount[1]
                             : bp->hostOutputFrameCount[1];
@@ -1605,7 +1605,7 @@ unsigned long PaUtil_EndBufferProcessing( PaUtilBufferProcessor* bp, int *stream
         if( bp->inputChannelCount != 0 && bp->outputChannelCount != 0 )
         {
             /* full duplex */
-            
+
             if( bp->hostBufferSizeMode == paUtilVariableHostBufferSizePartialUsageAllowed  )
             {
                 framesProcessed = AdaptingProcess( bp, streamCallbackResult,
@@ -1656,7 +1656,7 @@ unsigned long PaUtil_EndBufferProcessing( PaUtilBufferProcessor* bp, int *stream
 int PaUtil_IsBufferProcessorOutputEmpty( PaUtilBufferProcessor* bp )
 {
     return (bp->framesInTempOutputBuffer) ? 0 : 1;
-} 
+}
 
 
 unsigned long PaUtil_CopyInput( PaUtilBufferProcessor* bp,
@@ -1676,7 +1676,7 @@ unsigned long PaUtil_CopyInput( PaUtilBufferProcessor* bp,
     if( bp->userInputIsInterleaved )
     {
         destBytePtr = (unsigned char*)*buffer;
-        
+
         destSampleStrideSamples = bp->inputChannelCount;
         destChannelStrideBytes = bp->bytesPerUserInputSample;
 
@@ -1701,11 +1701,11 @@ unsigned long PaUtil_CopyInput( PaUtilBufferProcessor* bp,
     else
     {
         /* user input is not interleaved */
-        
+
         nonInterleavedDestPtrs = (void**)*buffer;
 
         destSampleStrideSamples = 1;
-        
+
         for( i=0; i<bp->inputChannelCount; ++i )
         {
             destBytePtr = (unsigned char*)nonInterleavedDestPtrs[i];
@@ -1718,7 +1718,7 @@ unsigned long PaUtil_CopyInput( PaUtilBufferProcessor* bp,
             /* advance callers dest pointer (nonInterleavedDestPtrs[i]) */
             destBytePtr += bp->bytesPerUserInputSample * framesToCopy;
             nonInterleavedDestPtrs[i] = destBytePtr;
-            
+
             /* advance source ptr for next iteration */
             hostInputChannels[i].data = ((unsigned char*)hostInputChannels[i].data) +
                     framesToCopy * hostInputChannels[i].stride * bp->bytesPerHostInputSample;
@@ -1726,7 +1726,7 @@ unsigned long PaUtil_CopyInput( PaUtilBufferProcessor* bp,
     }
 
     bp->hostInputFrameCount[0] -= framesToCopy;
-    
+
     return framesToCopy;
 }
 
@@ -1747,7 +1747,7 @@ unsigned long PaUtil_CopyOutput( PaUtilBufferProcessor* bp,
     if( bp->userOutputIsInterleaved )
     {
         srcBytePtr = (unsigned char*)*buffer;
-        
+
         srcSampleStrideSamples = bp->outputChannelCount;
         srcChannelStrideBytes = bp->bytesPerUserOutputSample;
 
@@ -1773,15 +1773,15 @@ unsigned long PaUtil_CopyOutput( PaUtilBufferProcessor* bp,
     else
     {
         /* user output is not interleaved */
-        
+
         nonInterleavedSrcPtrs = (void**)*buffer;
 
         srcSampleStrideSamples = 1;
-        
+
         for( i=0; i<bp->outputChannelCount; ++i )
         {
             srcBytePtr = (unsigned char*)nonInterleavedSrcPtrs[i];
-            
+
             bp->outputConverter(    hostOutputChannels[i].data,
                                     hostOutputChannels[i].stride,
                                     srcBytePtr, srcSampleStrideSamples,
@@ -1791,7 +1791,7 @@ unsigned long PaUtil_CopyOutput( PaUtilBufferProcessor* bp,
             /* advance callers source pointer (nonInterleavedSrcPtrs[i]) */
             srcBytePtr += bp->bytesPerUserOutputSample * framesToCopy;
             nonInterleavedSrcPtrs[i] = srcBytePtr;
-            
+
             /* advance dest ptr for next iteration */
             hostOutputChannels[i].data = ((unsigned char*)hostOutputChannels[i].data) +
                     framesToCopy * hostOutputChannels[i].stride * bp->bytesPerHostOutputSample;
@@ -1799,7 +1799,7 @@ unsigned long PaUtil_CopyOutput( PaUtilBufferProcessor* bp,
     }
 
     bp->hostOutputFrameCount[0] += framesToCopy;
-    
+
     return framesToCopy;
 }
 
@@ -1826,6 +1826,6 @@ unsigned long PaUtil_ZeroOutput( PaUtilBufferProcessor* bp, unsigned long frameC
     }
 
     bp->hostOutputFrameCount[0] += framesToZero;
-    
+
     return framesToZero;
 }

--- a/src/common/pa_process.h
+++ b/src/common/pa_process.h
@@ -28,16 +28,16 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
- 
+
 /** @file
  @ingroup common_src
 
@@ -72,7 +72,7 @@
  The following sections provide an overview of how to use the buffer processor.
  Interested readers are advised to consult the host API implementations for
  examples of buffer processor usage.
- 
+
 
  <h4>Initialization, resetting and termination</h4>
 
@@ -92,7 +92,7 @@
  When the buffer processor is no longer used call
  PaUtil_TerminateBufferProcessor.
 
- 
+
  <h4>Using the buffer processor for a callback stream</h4>
 
  The buffer processor's role in a callback stream is to take host input buffers
@@ -176,7 +176,7 @@
     host buffer(s), so the above steps need to be repeated until the user
     buffer(s) are full.
 
- 
+
  To copy data to the host output buffer from the user buffers(s) supplied
  to Pa_WriteStream use the following calling sequence.
 
@@ -192,7 +192,7 @@
      -# Call PaUtil_CopyOutput with the user buffer pointer (or a copy of the
         array of buffer pointers for a non-interleaved stream) passed to
         Pa_WriteStream, along with the number of frames in the user buffer(s).
-        Be careful to pass a <i>copy</i> of the user buffer pointers to 
+        Be careful to pass a <i>copy</i> of the user buffer pointers to
         PaUtil_CopyOutput because PaUtil_CopyOutput advances the pointers to
         the start of the next region to copy.
  - PaUtil_CopyOutput will not copy more data than fits in the host buffer(s),
@@ -266,7 +266,7 @@ typedef struct {
     int userInputIsInterleaved;
     PaUtilConverter *inputConverter;
     PaUtilZeroer *inputZeroer;
-    
+
     unsigned int outputChannelCount;
     unsigned int bytesPerHostOutputSample;
     unsigned int bytesPerUserOutputSample;
@@ -327,7 +327,7 @@ typedef struct {
 
  @param userInputSampleFormat Format of user input samples, as passed to
  Pa_OpenStream. This parameter is ignored for ouput-only streams.
- 
+
  @param hostInputSampleFormat Format of host input samples. This parameter is
  ignored for output-only streams. See note about host buffer interleave below.
 
@@ -336,17 +336,17 @@ typedef struct {
 
  @param userOutputSampleFormat Format of user output samples, as passed to
  Pa_OpenStream. This parameter is ignored for input-only streams.
- 
+
  @param hostOutputSampleFormat Format of host output samples. This parameter is
  ignored for input-only streams. See note about host buffer interleave below.
 
  @param sampleRate Sample rate of the stream. The more accurate this is the
  better - it is used for updating time stamps when adapting buffers.
- 
+
  @param streamFlags Stream flags as passed to Pa_OpenStream, this parameter is
  used for selecting special sample conversion options such as clipping and
  dithering.
- 
+
  @param framesPerUserBuffer Number of frames per user buffer, as requested
  by the framesPerBuffer parameter to Pa_OpenStream. This parameter may be
  zero to indicate that the user will accept any (and varying) buffer sizes.
@@ -359,11 +359,11 @@ typedef struct {
  @param hostBufferSizeMode A mode flag indicating the size variability of
  host buffers that will be passed to the buffer processor. See
  PaUtilHostBufferSizeMode for further details.
- 
+
  @param streamCallback The user stream callback passed to Pa_OpenStream.
 
  @param userData The user data field passed to Pa_OpenStream.
-    
+
  @note The interleave flag is ignored for host buffer formats. Host
  interleave is determined by the use of different SetInput and SetOutput
  functions.
@@ -371,7 +371,7 @@ typedef struct {
  @return An error code indicating whether the initialization was successful.
  If the error code is not PaNoError, the buffer processor was not initialized
  and should not be used.
- 
+
  @see Pa_OpenStream, PaUtilHostBufferSizeMode, PaUtil_TerminateBufferProcessor
 */
 PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bufferProcessor,
@@ -389,7 +389,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bufferProcessor
 
 /** Terminate a buffer processor's representation. Deallocates any temporary
  buffers allocated by PaUtil_InitializeBufferProcessor.
- 
+
  @param bufferProcessor The buffer processor structure to terminate.
 
  @see PaUtil_InitializeBufferProcessor.
@@ -434,7 +434,7 @@ unsigned long PaUtil_GetBufferProcessorOutputLatencyFrames( PaUtilBufferProcesso
  Functions to set host input and output buffers, used by both callback streams
  and blocking read/write streams.
 */
-/*@{*/ 
+/*@{*/
 
 
 /** Set the number of frames in the input host buffer(s) specified by the
@@ -451,7 +451,7 @@ unsigned long PaUtil_GetBufferProcessorOutputLatencyFrames( PaUtilBufferProcesso
 void PaUtil_SetInputFrameCount( PaUtilBufferProcessor* bufferProcessor,
         unsigned long frameCount );
 
-        
+
 /** Indicate that no input is available. This function should be used when
  priming the output of a full-duplex stream opened with the
  paPrimeOutputBuffersUsingStreamCallback flag. Note that it is not necessary
@@ -524,7 +524,7 @@ void PaUtil_Set2ndInterleavedInputChannels( PaUtilBufferProcessor* bufferProcess
 void PaUtil_Set2ndNonInterleavedInputChannel( PaUtilBufferProcessor* bufferProcessor,
         unsigned int channel, void *data );
 
-        
+
 /** Set the number of frames in the output host buffer(s) specified by the
  PaUtil_Set*OutputChannel functions.
 
@@ -574,7 +574,7 @@ void PaUtil_SetOutputChannel( PaUtilBufferProcessor* bufferProcessor,
 void PaUtil_SetInterleavedOutputChannels( PaUtilBufferProcessor* bufferProcessor,
         unsigned int firstChannel, void *data, unsigned int channelCount );
 
-        
+
 /** Provide the buffer processor with a pointer to one non-interleaved host
  output channel.
 
@@ -632,12 +632,12 @@ void PaUtil_Set2ndNonInterleavedOutputChannel( PaUtilBufferProcessor* bufferProc
 void PaUtil_BeginBufferProcessing( PaUtilBufferProcessor* bufferProcessor,
         PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags callbackStatusFlags );
 
-        
+
 /** Finish processing a host buffer (or a pair of host buffers in the
  full-duplex case) for a callback stream.
 
  @param bufferProcessor The buffer processor.
- 
+
  @param callbackResult On input, indicates a previous callback result, and on
  exit, the result of the user stream callback, if it is called.
  On entry callbackResult should contain one of { paContinue, paComplete, or
@@ -666,7 +666,7 @@ unsigned long PaUtil_EndBufferProcessing( PaUtilBufferProcessor* bufferProcessor
  a callbackResult of paComplete.
 
  @param bufferProcessor The buffer processor.
- 
+
  @return Returns non-zero when callback generated output remains in the internal
  buffer and zero (0) when there internal buffer contains no callback generated
  data.
@@ -738,7 +738,7 @@ unsigned long PaUtil_CopyOutput( PaUtilBufferProcessor* bufferProcessor,
  @param bufferProcessor The buffer processor.
 
  @param frameCount The maximum number of frames to zero.
- 
+
  @return The number of frames zeroed.
 */
 unsigned long PaUtil_ZeroOutput( PaUtilBufferProcessor* bufferProcessor,

--- a/src/common/pa_ringbuffer.c
+++ b/src/common/pa_ringbuffer.c
@@ -7,7 +7,7 @@
  * modified for SMP safety on Mac OS X by Bjorn Roche
  * modified for SMP safety on Linux by Leland Lucius
  * also, allowed for const where possible
- * modified for multiple-byte-sized data elements by Sven Fischer 
+ * modified for multiple-byte-sized data elements by Sven Fischer
  *
  * Note that this is safe only for a single-thread reader and a
  * single-thread writer.
@@ -37,13 +37,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -138,7 +138,7 @@ ring_buffer_size_t PaUtil_GetRingBufferWriteRegions( PaUtilRingBuffer *rbuf, rin
 */
 ring_buffer_size_t PaUtil_AdvanceRingBufferWriteIndex( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount )
 {
-    /* ensure that previous writes are seen before we update the write index 
+    /* ensure that previous writes are seen before we update the write index
        (write after write)
     */
     PaUtil_WriteMemoryBarrier();
@@ -176,7 +176,7 @@ ring_buffer_size_t PaUtil_GetRingBufferReadRegions( PaUtilRingBuffer *rbuf, ring
         *dataPtr2 = NULL;
         *sizePtr2 = 0;
     }
-    
+
     if( available )
         PaUtil_ReadMemoryBarrier(); /* (read-after-read) => read barrier */
 
@@ -186,7 +186,7 @@ ring_buffer_size_t PaUtil_GetRingBufferReadRegions( PaUtilRingBuffer *rbuf, ring
 */
 ring_buffer_size_t PaUtil_AdvanceRingBufferReadIndex( PaUtilRingBuffer *rbuf, ring_buffer_size_t elementCount )
 {
-    /* ensure that previous reads (copies out of the ring buffer) are always completed before updating (writing) the read index. 
+    /* ensure that previous reads (copies out of the ring buffer) are always completed before updating (writing) the read index.
        (write-after-read) => full barrier
     */
     PaUtil_FullMemoryBarrier();

--- a/src/common/pa_ringbuffer.h
+++ b/src/common/pa_ringbuffer.h
@@ -8,7 +8,7 @@
  * Author: Phil Burk, http://www.softsynth.com
  * modified for SMP safety on OS X by Bjorn Roche.
  * also allowed for const where possible.
- * modified for multiple-byte-sized data elements by Sven Fischer 
+ * modified for multiple-byte-sized data elements by Sven Fischer
  *
  * Note that this is safe only for a single-thread reader
  * and a single-thread writer.
@@ -38,13 +38,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -58,15 +58,15 @@
  a single reader and a single writer (ie. one thread or callback writes
  to the ring buffer, another thread or callback reads from it).
 
- The PaUtilRingBuffer structure manages a ring buffer containing N 
- elements, where N must be a power of two. An element may be any size 
+ The PaUtilRingBuffer structure manages a ring buffer containing N
+ elements, where N must be a power of two. An element may be any size
  (specified in bytes).
 
- The memory area used to store the buffer elements must be allocated by 
+ The memory area used to store the buffer elements must be allocated by
  the client prior to calling PaUtil_InitializeRingBuffer() and must outlive
  the use of the ring buffer.
- 
- @note The ring buffer functions are not normally exposed in the PortAudio libraries. 
+
+ @note The ring buffer functions are not normally exposed in the PortAudio libraries.
  If you want to call them then you will need to add pa_ringbuffer.c to your application source code.
 */
 

--- a/src/common/pa_stream.c
+++ b/src/common/pa_stream.c
@@ -27,13 +27,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 

--- a/src/common/pa_stream.h
+++ b/src/common/pa_stream.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -164,7 +164,7 @@ void PaUtil_InitializeStreamRepresentation(
         PaUtilStreamInterface *streamInterface,
         PaStreamCallback *streamCallback,
         void *userData );
-        
+
 
 /** Clean up a PaUtilStreamRepresentation structure previously initialized
  by a call to PaUtil_InitializeStreamRepresentation.
@@ -198,7 +198,7 @@ PaError PaUtil_ValidateStreamPointer( PaStream *stream );
     PA_STREAM_REP( (stream) )->streamInterface
 
 
-    
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/common/pa_trace.c
+++ b/src/common/pa_trace.c
@@ -27,13 +27,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -233,6 +233,6 @@ void PaUtil_DiscardHighSpeedLog( LogHandle hLog )
  */
 int PaUtil_TraceStubToSatisfyLinker(void)
 {
-	return 0;
+    return 0;
 }
 #endif /* TRACE_REALTIME_EVENTS */

--- a/src/common/pa_trace.h
+++ b/src/common/pa_trace.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -45,8 +45,8 @@
  @brief Real-time safe event trace logging facility for debugging.
 
  Allows data to be logged to a fixed size trace buffer in a real-time
- execution context (such as at interrupt time). Each log entry consists 
- of a message comprising a string pointer and an int.  The trace buffer 
+ execution context (such as at interrupt time). Each log entry consists
+ of a message comprising a string pointer and an int.  The trace buffer
  may be dumped to stdout later.
 
  This facility is only active if PA_TRACE_REALTIME_EVENTS is set to 1,
@@ -57,8 +57,8 @@
 
  @fn PaUtil_AddTraceMessage
  @brief Add a message to the trace buffer. A message consists of string and an int.
- @param msg The string pointer must remain valid until PaUtil_DumpTraceMessages 
-    is called. As a result, usually only string literals should be passed as 
+ @param msg The string pointer must remain valid until PaUtil_DumpTraceMessages
+    is called. As a result, usually only string literals should be passed as
     the msg parameter.
 
  @fn PaUtil_DumpTraceMessages
@@ -70,7 +70,7 @@
 #endif
 
 #ifndef PA_MAX_TRACE_RECORDS
-#define PA_MAX_TRACE_RECORDS      (2048)   /**< Maximum number of records stored in trace buffer */   
+#define PA_MAX_TRACE_RECORDS      (2048)   /**< Maximum number of records stored in trace buffer */
 #endif
 
 #ifdef __cplusplus

--- a/src/common/pa_types.h
+++ b/src/common/pa_types.h
@@ -1,7 +1,7 @@
 #ifndef PA_TYPES_H
 #define PA_TYPES_H
 
-/* 
+/*
  * Portable Audio I/O Library
  * integer type definitions
  *
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 

--- a/src/common/pa_util.h
+++ b/src/common/pa_util.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -112,7 +112,7 @@ void PaUtil_SetLastHostErrorInfo( PaHostApiTypeId hostApiType, long errorCode,
         const char *errorText );
 
 
-        
+
 /* the following functions are implemented in a platform platform specific
  .c file
 */


### PR DESCRIPTION
Convert tabs to 4 spaces. Indent by 4 spaces. Strip trailing whitespace.