### PR TITLE
Clean up whitespace in src/hostapi/{asihpi, jack, oss, skeleton} in preparation for .editorconfig.

### DIFF
--- a/src/hostapi/asihpi/pa_linux_asihpi.c
+++ b/src/hostapi/asihpi/pa_linux_asihpi.c
@@ -556,7 +556,7 @@ static PaError PaAsiHpi_BuildDeviceList( PaAsiHpiHostApiRepresentation *hpiHostA
             continue;
         }
         hpiError = HPI_AdapterGetInfo( NULL, idx, &outStreams, &inStreams,
-                    &version, &serial, &type );
+                                       &version, &serial, &type );
         /* Skip to next device on failure */
         if( hpiError )
         {
@@ -738,7 +738,7 @@ PaError PaAsiHpi_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
          * interface and paNoError */
         PA_DEBUG(( "Could not open HPI interface\n" ));
 
-    *hostApi = NULL;
+        *hostApi = NULL;
         return paNoError;
     }
     else
@@ -1584,7 +1584,7 @@ static PaError PaAsiHpi_SetupBuffers( PaAsiHpiStreamComponent *streamComp, uint3
             /* If BBM not supported, foreground transfers will be used, but not a show-stopper */
             /* Anything else is an error */
             else if (( hpiError != HPI_ERROR_INVALID_OPERATION ) &&
-             ( hpiError != HPI_ERROR_INVALID_FUNC ))
+                    ( hpiError != HPI_ERROR_INVALID_FUNC ))
             {
                 PA_ASIHPI_REPORT_ERROR_( hpiError );
                 result = paUnanticipatedHostError;

--- a/src/hostapi/asihpi/pa_linux_asihpi.c
+++ b/src/hostapi/asihpi/pa_linux_asihpi.c
@@ -199,27 +199,27 @@
         /* If HPI error occurred */ \
         if( UNLIKELY( hpiError ) ) \
         { \
-	    char szError[256]; \
-	    HPI_GetErrorText( hpiError, szError ); \
-	    PA_DEBUG(( "HPI error %d occurred: %s\n", hpiError, szError )); \
-	    /* This message will always be displayed, even if debug info is disabled */ \
+        char szError[256]; \
+        HPI_GetErrorText( hpiError, szError ); \
+        PA_DEBUG(( "HPI error %d occurred: %s\n", hpiError, szError )); \
+        /* This message will always be displayed, even if debug info is disabled */ \
             PA_DEBUG(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
             if( (paError) == paUnanticipatedHostError ) \
-	    { \
-	        PA_DEBUG(( "Host error description: %s\n", szError )); \
-	        /* PaUtil_SetLastHostErrorInfo should only be used in the main thread */ \
-	        if( pthread_equal( pthread_self(), paUnixMainThread ) ) \
+        { \
+            PA_DEBUG(( "Host error description: %s\n", szError )); \
+            /* PaUtil_SetLastHostErrorInfo should only be used in the main thread */ \
+            if( pthread_equal( pthread_self(), paUnixMainThread ) ) \
                 { \
-		    PaUtil_SetLastHostErrorInfo( paInDevelopment, hpiError, szError ); \
+            PaUtil_SetLastHostErrorInfo( paInDevelopment, hpiError, szError ); \
                 } \
-	    } \
-	    /* If paNoError is specified, continue as usual */ \
+        } \
+        /* If paNoError is specified, continue as usual */ \
             /* (useful if you only want to print out the debug messages above) */ \
-	    if( (paError) < 0 ) \
-	    { \
-	        result = (paError); \
-	        goto error; \
-	    } \
+        if( (paError) < 0 ) \
+        { \
+            result = (paError); \
+            goto error; \
+        } \
         } \
     } while( 0 );
 
@@ -231,9 +231,9 @@
         PA_DEBUG(( "HPI error %d occurred: %s\n", hpiError, szError )); \
         /* PaUtil_SetLastHostErrorInfo should only be used in the main thread */ \
         if( pthread_equal( pthread_self(), paUnixMainThread ) ) \
-	{ \
-	    PaUtil_SetLastHostErrorInfo( paInDevelopment, (hpiErrorCode), szError ); \
-	} \
+    { \
+        PaUtil_SetLastHostErrorInfo( paInDevelopment, (hpiErrorCode), szError ); \
+    } \
     } while( 0 );
 
 /* Defaults */
@@ -556,7 +556,7 @@ static PaError PaAsiHpi_BuildDeviceList( PaAsiHpiHostApiRepresentation *hpiHostA
             continue;
         }
         hpiError = HPI_AdapterGetInfo( NULL, idx, &outStreams, &inStreams,
-					&version, &serial, &type );
+                    &version, &serial, &type );
         /* Skip to next device on failure */
         if( hpiError )
         {
@@ -738,7 +738,7 @@ PaError PaAsiHpi_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
          * interface and paNoError */
         PA_DEBUG(( "Could not open HPI interface\n" ));
 
-	*hostApi = NULL;
+    *hostApi = NULL;
         return paNoError;
     }
     else
@@ -1584,7 +1584,7 @@ static PaError PaAsiHpi_SetupBuffers( PaAsiHpiStreamComponent *streamComp, uint3
             /* If BBM not supported, foreground transfers will be used, but not a show-stopper */
             /* Anything else is an error */
             else if (( hpiError != HPI_ERROR_INVALID_OPERATION ) &&
-		     ( hpiError != HPI_ERROR_INVALID_FUNC ))
+             ( hpiError != HPI_ERROR_INVALID_FUNC ))
             {
                 PA_ASIHPI_REPORT_ERROR_( hpiError );
                 result = paUnanticipatedHostError;

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -277,10 +277,10 @@ static PaError BlockingTermFIFO( PaUtilRingBuffer *rbuf )
 static int
 BlockingCallback( const void                      *inputBuffer,
                   void                            *outputBuffer,
-          unsigned long                    framesPerBuffer,
-          const PaStreamCallbackTimeInfo*  timeInfo,
-          PaStreamCallbackFlags            statusFlags,
-          void                             *userData )
+                  unsigned long                    framesPerBuffer,
+                  const PaStreamCallbackTimeInfo*  timeInfo,
+                  PaStreamCallbackFlags            statusFlags,
+                  void                             *userData )
 {
     struct PaJackStream *stream = (PaJackStream *)userData;
     long numBytes = stream->bytesPerFrame * framesPerBuffer;

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -277,10 +277,10 @@ static PaError BlockingTermFIFO( PaUtilRingBuffer *rbuf )
 static int
 BlockingCallback( const void                      *inputBuffer,
                   void                            *outputBuffer,
-		  unsigned long                    framesPerBuffer,
-		  const PaStreamCallbackTimeInfo*  timeInfo,
-		  PaStreamCallbackFlags            statusFlags,
-		  void                             *userData )
+          unsigned long                    framesPerBuffer,
+          const PaStreamCallbackTimeInfo*  timeInfo,
+          PaStreamCallbackFlags            statusFlags,
+          void                             *userData )
 {
     struct PaJackStream *stream = (PaJackStream *)userData;
     long numBytes = stream->bytesPerFrame * framesPerBuffer;
@@ -918,7 +918,7 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
 
 #define ABS(x) ( (x) > 0 ? (x) : -(x) )
     if( ABS(sampleRate - jack_get_sample_rate(((PaJackHostApiRepresentation *) hostApi)->jack_client )) > 1 )
-       return paInvalidSampleRate;
+        return paInvalidSampleRate;
 #undef ABS
 
     return paFormatIsSupported;
@@ -1161,7 +1161,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 
 #define ABS(x) ( (x) > 0 ? (x) : -(x) )
     if( ABS(sampleRate - jackSr) > 1 )
-       return paInvalidSampleRate;
+        return paInvalidSampleRate;
 #undef ABS
 
     UNLESS( stream = (PaJackStream*)PaUtil_AllocateMemory( sizeof(PaJackStream) ), paInsufficientMemory );
@@ -1610,7 +1610,7 @@ static PaError StartStream( PaStream *s )
         {
             int r = jack_connect( stream->jack_client, jack_port_name( stream->remote_output_ports[i] ),
                     jack_port_name( stream->local_input_ports[i] ) );
-           UNLESS( 0 == r || EEXIST == r, paUnanticipatedHostError );
+            UNLESS( 0 == r || EEXIST == r, paUnanticipatedHostError );
         }
     }
 
@@ -1620,7 +1620,7 @@ static PaError StartStream( PaStream *s )
         {
             int r = jack_connect( stream->jack_client, jack_port_name( stream->local_output_ports[i] ),
                     jack_port_name( stream->remote_input_ports[i] ) );
-           UNLESS( 0 == r || EEXIST == r, paUnanticipatedHostError );
+            UNLESS( 0 == r || EEXIST == r, paUnanticipatedHostError );
         }
     }
 

--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -734,8 +734,7 @@ static PaError ValidateParameters( const PaStreamParameters *parameters, const P
         return paInvalidDevice;
     }
 
-    maxChans = (mode == StreamMode_In ? deviceInfo->maxInputChannels :
-        deviceInfo->maxOutputChannels);
+    maxChans = (mode == StreamMode_In ? deviceInfo->maxInputChannels : deviceInfo->maxOutputChannels);
     if( parameters->channelCount > maxChans )
     {
         return paInvalidChannelCount;
@@ -1948,19 +1947,19 @@ static PaError ReadStream( PaStream* s,
     {
         framesRequested = PA_MIN( frames, stream->capture->hostFrames );
 
-    bytesRequested = framesRequested * PaOssStreamComponent_FrameSize( stream->capture );
-    ENSURE_( (bytesRead = read( stream->capture->fd, stream->capture->buffer, bytesRequested )),
-                 paUnanticipatedHostError );
-    if ( bytesRequested != bytesRead )
-    {
-        PA_DEBUG(( "Requested %d bytes, read %d\n", bytesRequested, bytesRead ));
-        return paUnanticipatedHostError;
-    }
+        bytesRequested = framesRequested * PaOssStreamComponent_FrameSize( stream->capture );
+        ENSURE_( (bytesRead = read( stream->capture->fd, stream->capture->buffer, bytesRequested )),
+                    paUnanticipatedHostError );
+        if ( bytesRequested != bytesRead )
+        {
+            PA_DEBUG(( "Requested %d bytes, read %d\n", bytesRequested, bytesRead ));
+            return paUnanticipatedHostError;
+        }
 
-    PaUtil_SetInputFrameCount( &stream->bufferProcessor, stream->capture->hostFrames );
-    PaUtil_SetInterleavedInputChannels( &stream->bufferProcessor, 0, stream->capture->buffer, stream->capture->hostChannelCount );
+        PaUtil_SetInputFrameCount( &stream->bufferProcessor, stream->capture->hostFrames );
+        PaUtil_SetInterleavedInputChannels( &stream->bufferProcessor, 0, stream->capture->buffer, stream->capture->hostChannelCount );
         PaUtil_CopyInput( &stream->bufferProcessor, &userBuffer, framesRequested );
-    frames -= framesRequested;
+        frames -= framesRequested;
     }
 
 error:
@@ -1989,21 +1988,21 @@ static PaError WriteStream( PaStream *s, const void *buffer, unsigned long frame
 
     while( frames )
     {
-    PaUtil_SetOutputFrameCount( &stream->bufferProcessor, stream->playback->hostFrames );
-    PaUtil_SetInterleavedOutputChannels( &stream->bufferProcessor, 0, stream->playback->buffer, stream->playback->hostChannelCount );
+        PaUtil_SetOutputFrameCount( &stream->bufferProcessor, stream->playback->hostFrames );
+        PaUtil_SetInterleavedOutputChannels( &stream->bufferProcessor, 0, stream->playback->buffer, stream->playback->hostChannelCount );
 
-    framesConverted = PaUtil_CopyOutput( &stream->bufferProcessor, &userBuffer, frames );
-    frames -= framesConverted;
+        framesConverted = PaUtil_CopyOutput( &stream->bufferProcessor, &userBuffer, frames );
+        frames -= framesConverted;
 
-    bytesRequested = framesConverted * PaOssStreamComponent_FrameSize( stream->playback );
-    ENSURE_( (bytesWritten = write( stream->playback->fd, stream->playback->buffer, bytesRequested )),
-                 paUnanticipatedHostError );
+        bytesRequested = framesConverted * PaOssStreamComponent_FrameSize( stream->playback );
+        ENSURE_( (bytesWritten = write( stream->playback->fd, stream->playback->buffer, bytesRequested )),
+                    paUnanticipatedHostError );
 
-    if ( bytesRequested != bytesWritten )
-    {
-        PA_DEBUG(( "Requested %d bytes, wrote %d\n", bytesRequested, bytesWritten ));
-        return paUnanticipatedHostError;
-    }
+        if ( bytesRequested != bytesWritten )
+        {
+            PA_DEBUG(( "Requested %d bytes, wrote %d\n", bytesRequested, bytesWritten ));
+            return paUnanticipatedHostError;
+        }
     }
 
 error:

--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -537,40 +537,40 @@ static PaError BuildDeviceList( PaOSSHostApiRepresentation *ossApi )
 
     for( i = -1; i < 100; i++ )
     {
-       char deviceName[32];
-       PaDeviceInfo *deviceInfo;
-       int testResult;
+        char deviceName[32];
+        PaDeviceInfo *deviceInfo;
+        int testResult;
 
-       if( i == -1 )
-          snprintf(deviceName, sizeof (deviceName), "%s", DEVICE_NAME_BASE);
-       else
-          snprintf(deviceName, sizeof (deviceName), "%s%d", DEVICE_NAME_BASE, i);
+        if( i == -1 )
+            snprintf(deviceName, sizeof (deviceName), "%s", DEVICE_NAME_BASE);
+        else
+            snprintf(deviceName, sizeof (deviceName), "%s%d", DEVICE_NAME_BASE, i);
 
-       /* PA_DEBUG(("%s: trying device %s\n", __FUNCTION__, deviceName )); */
-       if( (testResult = QueryDevice( deviceName, ossApi, &deviceInfo )) != paNoError )
-       {
-           if( testResult != paDeviceUnavailable )
-               PA_ENSURE( testResult );
+        /* PA_DEBUG(("%s: trying device %s\n", __FUNCTION__, deviceName )); */
+        if( (testResult = QueryDevice( deviceName, ossApi, &deviceInfo )) != paNoError )
+        {
+            if( testResult != paDeviceUnavailable )
+                PA_ENSURE( testResult );
 
-           continue;
-       }
+            continue;
+        }
 
-       ++numDevices;
-       if( !deviceInfos || numDevices > maxDeviceInfos )
-       {
-           maxDeviceInfos *= 2;
-           PA_UNLESS( deviceInfos = (PaDeviceInfo **) realloc( deviceInfos, maxDeviceInfos * sizeof (PaDeviceInfo *) ),
-                   paInsufficientMemory );
-       }
-       {
-           int devIdx = numDevices - 1;
-           deviceInfos[devIdx] = deviceInfo;
+        ++numDevices;
+        if( !deviceInfos || numDevices > maxDeviceInfos )
+        {
+            maxDeviceInfos *= 2;
+            PA_UNLESS( deviceInfos = (PaDeviceInfo **) realloc( deviceInfos, maxDeviceInfos * sizeof (PaDeviceInfo *) ),
+                    paInsufficientMemory );
+        }
+        {
+            int devIdx = numDevices - 1;
+            deviceInfos[devIdx] = deviceInfo;
 
-           if( commonApi->info.defaultInputDevice == paNoDevice && deviceInfo->maxInputChannels > 0 )
-               commonApi->info.defaultInputDevice = devIdx;
-           if( commonApi->info.defaultOutputDevice == paNoDevice && deviceInfo->maxOutputChannels > 0 )
-               commonApi->info.defaultOutputDevice = devIdx;
-       }
+            if( commonApi->info.defaultInputDevice == paNoDevice && deviceInfo->maxInputChannels > 0 )
+                commonApi->info.defaultInputDevice = devIdx;
+            if( commonApi->info.defaultOutputDevice == paNoDevice && deviceInfo->maxOutputChannels > 0 )
+                commonApi->info.defaultOutputDevice = devIdx;
+        }
     }
 
     /* Make an array of PaDeviceInfo pointers out of the linked list */
@@ -670,14 +670,14 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
     /* if full duplex, make sure that they're the same device */
 
     if (inputChannelCount > 0 && outputChannelCount > 0 &&
-        inputParameters->device != outputParameters->device)
+            inputParameters->device != outputParameters->device)
         return paInvalidDevice;
 
     /* if full duplex, also make sure that they're the same number of channels */
 
     if (inputChannelCount > 0 && outputChannelCount > 0 &&
-        inputChannelCount != outputChannelCount)
-       return paInvalidChannelCount;
+            inputChannelCount != outputChannelCount)
+        return paInvalidChannelCount;
 
     /* open the device so we can do more tests */
 
@@ -699,11 +699,11 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
 
     flags = O_NONBLOCK;
     if (inputChannelCount > 0 && outputChannelCount > 0)
-       flags |= O_RDWR;
+        flags |= O_RDWR;
     else if (inputChannelCount > 0)
-       flags |= O_RDONLY;
+        flags |= O_RDONLY;
     else
-       flags |= O_WRONLY;
+        flags |= O_WRONLY;
 
     ENSURE_( tempDevHandle = open( deviceInfo->name, flags ), paDeviceUnavailable );
 
@@ -712,7 +712,7 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
 
     /* everything succeeded! */
 
- error:
+error:
     if( tempDevHandle >= 0 )
         close( tempDevHandle );
 
@@ -1617,7 +1617,7 @@ static void *PaOSS_AudioThreadProc( void *userData )
 
     assert( stream );
 
-    pthread_cleanup_push( &OnExit, stream );	/* Execute OnExit when exiting */
+    pthread_cleanup_push( &OnExit, stream );    /* Execute OnExit when exiting */
 
     /* The first time the stream is started we use SNDCTL_DSP_TRIGGER to accurately start capture and
      * playback in sync, when the stream is restarted after being stopped we simply start by reading/
@@ -1948,19 +1948,19 @@ static PaError ReadStream( PaStream* s,
     {
         framesRequested = PA_MIN( frames, stream->capture->hostFrames );
 
-	bytesRequested = framesRequested * PaOssStreamComponent_FrameSize( stream->capture );
-	ENSURE_( (bytesRead = read( stream->capture->fd, stream->capture->buffer, bytesRequested )),
+    bytesRequested = framesRequested * PaOssStreamComponent_FrameSize( stream->capture );
+    ENSURE_( (bytesRead = read( stream->capture->fd, stream->capture->buffer, bytesRequested )),
                  paUnanticipatedHostError );
-	if ( bytesRequested != bytesRead )
-	{
-	    PA_DEBUG(( "Requested %d bytes, read %d\n", bytesRequested, bytesRead ));
-	    return paUnanticipatedHostError;
-	}
+    if ( bytesRequested != bytesRead )
+    {
+        PA_DEBUG(( "Requested %d bytes, read %d\n", bytesRequested, bytesRead ));
+        return paUnanticipatedHostError;
+    }
 
-	PaUtil_SetInputFrameCount( &stream->bufferProcessor, stream->capture->hostFrames );
-	PaUtil_SetInterleavedInputChannels( &stream->bufferProcessor, 0, stream->capture->buffer, stream->capture->hostChannelCount );
+    PaUtil_SetInputFrameCount( &stream->bufferProcessor, stream->capture->hostFrames );
+    PaUtil_SetInterleavedInputChannels( &stream->bufferProcessor, 0, stream->capture->buffer, stream->capture->hostChannelCount );
         PaUtil_CopyInput( &stream->bufferProcessor, &userBuffer, framesRequested );
-	frames -= framesRequested;
+    frames -= framesRequested;
     }
 
 error:
@@ -1989,21 +1989,21 @@ static PaError WriteStream( PaStream *s, const void *buffer, unsigned long frame
 
     while( frames )
     {
-	PaUtil_SetOutputFrameCount( &stream->bufferProcessor, stream->playback->hostFrames );
-	PaUtil_SetInterleavedOutputChannels( &stream->bufferProcessor, 0, stream->playback->buffer, stream->playback->hostChannelCount );
+    PaUtil_SetOutputFrameCount( &stream->bufferProcessor, stream->playback->hostFrames );
+    PaUtil_SetInterleavedOutputChannels( &stream->bufferProcessor, 0, stream->playback->buffer, stream->playback->hostChannelCount );
 
-	framesConverted = PaUtil_CopyOutput( &stream->bufferProcessor, &userBuffer, frames );
-	frames -= framesConverted;
+    framesConverted = PaUtil_CopyOutput( &stream->bufferProcessor, &userBuffer, frames );
+    frames -= framesConverted;
 
-	bytesRequested = framesConverted * PaOssStreamComponent_FrameSize( stream->playback );
-	ENSURE_( (bytesWritten = write( stream->playback->fd, stream->playback->buffer, bytesRequested )),
+    bytesRequested = framesConverted * PaOssStreamComponent_FrameSize( stream->playback );
+    ENSURE_( (bytesWritten = write( stream->playback->fd, stream->playback->buffer, bytesRequested )),
                  paUnanticipatedHostError );
 
-	if ( bytesRequested != bytesWritten )
-	{
-	    PA_DEBUG(( "Requested %d bytes, wrote %d\n", bytesRequested, bytesWritten ));
-	    return paUnanticipatedHostError;
-	}
+    if ( bytesRequested != bytesWritten )
+    {
+        PA_DEBUG(( "Requested %d bytes, wrote %d\n", bytesRequested, bytesWritten ));
+        return paUnanticipatedHostError;
+    }
     }
 
 error:

--- a/src/hostapi/oss/recplay.c
+++ b/src/hostapi/oss/recplay.c
@@ -2,7 +2,7 @@
  * recplay.c
  * Phil Burk
  * Minimal record and playback test.
- * 
+ *
  */
 #include <stdio.h>
 #include <unistd.h>

--- a/src/hostapi/skeleton/pa_hostapi_skeleton.c
+++ b/src/hostapi/skeleton/pa_hostapi_skeleton.c
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -152,10 +152,10 @@ PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiI
     (*hostApi)->info.defaultInputDevice = paNoDevice;  /* IMPLEMENT ME */
     (*hostApi)->info.defaultOutputDevice = paNoDevice; /* IMPLEMENT ME */
 
-    (*hostApi)->info.deviceCount = 0;  
+    (*hostApi)->info.deviceCount = 0;
 
     deviceCount = 0; /* IMPLEMENT ME */
-    
+
     if( deviceCount > 0 )
     {
         (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
@@ -193,14 +193,14 @@ PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiI
 
             deviceInfo->maxInputChannels = 0;  /* IMPLEMENT ME */
             deviceInfo->maxOutputChannels = 0;  /* IMPLEMENT ME */
-            
+
             deviceInfo->defaultLowInputLatency = 0.;  /* IMPLEMENT ME */
             deviceInfo->defaultLowOutputLatency = 0.;  /* IMPLEMENT ME */
             deviceInfo->defaultHighInputLatency = 0.;  /* IMPLEMENT ME */
-            deviceInfo->defaultHighOutputLatency = 0.;  /* IMPLEMENT ME */  
+            deviceInfo->defaultHighOutputLatency = 0.;  /* IMPLEMENT ME */
 
             deviceInfo->defaultSampleRate = 0.; /* IMPLEMENT ME */
-            
+
             (*hostApi)->deviceInfos[i] = deviceInfo;
             ++(*hostApi)->info.deviceCount;
         }
@@ -231,7 +231,7 @@ error:
             PaUtil_FreeAllAllocations( skeletonHostApi->allocations );
             PaUtil_DestroyAllocationGroup( skeletonHostApi->allocations );
         }
-                
+
         PaUtil_FreeMemory( skeletonHostApi );
     }
     return result;
@@ -264,7 +264,7 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
 {
     int inputChannelCount, outputChannelCount;
     PaSampleFormat inputSampleFormat, outputSampleFormat;
-    
+
     if( inputParameters )
     {
         inputChannelCount = inputParameters->channelCount;
@@ -274,7 +274,7 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
             this implementation doesn't support any custom sample formats */
         if( inputSampleFormat & paCustomFormat )
             return paSampleFormatNotSupported;
-            
+
         /* unless alternate device specification is supported, reject the use of
             paUseHostApiSpecificDeviceSpecification */
 
@@ -303,7 +303,7 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
             this implementation doesn't support any custom sample formats */
         if( outputSampleFormat & paCustomFormat )
             return paSampleFormatNotSupported;
-            
+
         /* unless alternate device specification is supported, reject the use of
             paUseHostApiSpecificDeviceSpecification */
 
@@ -322,7 +322,7 @@ static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
     {
         outputChannelCount = 0;
     }
-    
+
     /*
         IMPLEMENT ME:
 
@@ -420,7 +420,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     {
         outputChannelCount = outputParameters->channelCount;
         outputSampleFormat = outputParameters->sampleFormat;
-        
+
         /* unless alternate device specification is supported, reject the use of
             paUseHostApiSpecificDeviceSpecification */
 
@@ -499,10 +499,10 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 
 
     /* we assume a fixed host buffer size in this example, but the buffer processor
-        can also support bounded and unknown host buffer sizes by passing 
+        can also support bounded and unknown host buffer sizes by passing
         paUtilBoundedHostBufferSize or paUtilUnknownHostBufferSize instead of
         paUtilFixedHostBufferSize below. */
-        
+
     result =  PaUtil_InitializeBufferProcessor( &stream->bufferProcessor,
               inputChannelCount, inputSampleFormat, hostInputSampleFormat,
               outputChannelCount, outputSampleFormat, hostOutputSampleFormat,
@@ -523,7 +523,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             (PaTime)PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor) / sampleRate; /* outputLatency is specified in _seconds_ */
     stream->streamRepresentation.streamInfo.sampleRate = sampleRate;
 
-    
+
     /*
         IMPLEMENT ME:
             - additional stream setup + opening
@@ -545,7 +545,7 @@ error:
 /*
     ExampleHostProcessingLoop() illustrates the kind of processing which may
     occur in a host implementation.
- 
+
 */
 static void ExampleHostProcessingLoop( void *inputBuffer, void *outputBuffer, void *userData )
 {
@@ -553,9 +553,9 @@ static void ExampleHostProcessingLoop( void *inputBuffer, void *outputBuffer, vo
     PaStreamCallbackTimeInfo timeInfo = {0,0,0}; /* IMPLEMENT ME */
     int callbackResult;
     unsigned long framesProcessed;
-    
+
     PaUtil_BeginCpuLoadMeasurement( &stream->cpuLoadMeasurer );
-    
+
     /*
         IMPLEMENT ME:
             - generate timing information
@@ -576,7 +576,7 @@ static void ExampleHostProcessingLoop( void *inputBuffer, void *outputBuffer, vo
         or a mixture, you will want to call PaUtil_SetInterleaved*Channels(),
         PaUtil_SetNonInterleaved*Channel() or PaUtil_Set*Channel() here.
     */
-    
+
     PaUtil_SetInputFrameCount( &stream->bufferProcessor, 0 /* default to host buffer size */ );
     PaUtil_SetInterleavedInputChannels( &stream->bufferProcessor,
             0, /* first channel of inputBuffer is channel 0 */
@@ -598,7 +598,7 @@ static void ExampleHostProcessingLoop( void *inputBuffer, void *outputBuffer, vo
     callbackResult = paContinue;
     framesProcessed = PaUtil_EndBufferProcessing( &stream->bufferProcessor, &callbackResult );
 
-    
+
     /*
         If you need to byte swap or shift outputBuffer to convert it to
         host format, do it here.
@@ -694,7 +694,7 @@ static PaError AbortStream( PaStream *s )
 
     /* suppress unused variable warnings */
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior */
 
     return result;
@@ -707,7 +707,7 @@ static PaError IsStreamStopped( PaStream *s )
 
     /* suppress unused variable warnings */
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior */
 
     return 0;
@@ -720,7 +720,7 @@ static PaError IsStreamActive( PaStream *s )
 
     /* suppress unused variable warnings */
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior */
 
     return 0;
@@ -733,7 +733,7 @@ static PaTime GetStreamTime( PaStream *s )
 
     /* suppress unused variable warnings */
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior*/
 
     return 0;
@@ -764,7 +764,7 @@ static PaError ReadStream( PaStream* s,
     (void) buffer;
     (void) frames;
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior*/
 
     return paNoError;
@@ -781,7 +781,7 @@ static PaError WriteStream( PaStream* s,
     (void) buffer;
     (void) frames;
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior*/
 
     return paNoError;
@@ -794,7 +794,7 @@ static signed long GetStreamReadAvailable( PaStream* s )
 
     /* suppress unused variable warnings */
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior*/
 
     return 0;
@@ -807,7 +807,7 @@ static signed long GetStreamWriteAvailable( PaStream* s )
 
     /* suppress unused variable warnings */
     (void) stream;
-    
+
     /* IMPLEMENT ME, see portaudio.h for required behavior*/
 
     return 0;


### PR DESCRIPTION
Convert tabs to 4 spaces. Indent by 4 spaces. Strip trailing whitespace. Ensure EOL at EOF.