### PR TITLE
Clean up whitespace in include/ in preparation for .editorconfig. 

### DIFF
--- a/include/pa_asio.h
+++ b/include/pa_asio.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -68,7 +68,7 @@ extern "C"
  #define that maps PaAsio_GetAvailableLatencyValues to this function for backwards compatibility.
 */
 PaError PaAsio_GetAvailableBufferSizes( PaDeviceIndex device,
-		long *minBufferSizeFrames, long *maxBufferSizeFrames, long *preferredBufferSizeFrames, long *granularity );
+        long *minBufferSizeFrames, long *maxBufferSizeFrames, long *preferredBufferSizeFrames, long *granularity );
 
 
 /** Backwards compatibility alias for PaAsio_GetAvailableBufferSizes
@@ -97,7 +97,7 @@ PaError PaAsio_ShowControlPanel( PaDeviceIndex device, void* systemSpecific );
 PaError PaAsio_GetInputChannelName( PaDeviceIndex device, int channelIndex,
         const char** channelName );
 
-        
+
 /** Retrieve a pointer to a string containing the name of the specified
  input channel. The string is valid until Pa_Terminate is called.
 
@@ -108,11 +108,11 @@ PaError PaAsio_GetOutputChannelName( PaDeviceIndex device, int channelIndex,
 
 
 /** Set the sample rate of an open paASIO stream.
- 
- @param stream The stream to operate on.
- @param sampleRate The new sample rate. 
 
- Note that this function may fail if the stream is already running and the 
+ @param stream The stream to operate on.
+ @param sampleRate The new sample rate.
+
+ Note that this function may fail if the stream is already running and the
  ASIO driver does not support switching the sample rate of a running stream.
 
  Returns paIncompatibleStreamHostApi if stream is not a paASIO stream.

--- a/include/pa_jack.h
+++ b/include/pa_jack.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 

--- a/include/pa_linux_alsa.h
+++ b/include/pa_linux_alsa.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 

--- a/include/pa_mac_core.h
+++ b/include/pa_mac_core.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -66,8 +66,8 @@ typedef struct
     PaHostApiTypeId hostApiType;  /**host API for which this data is intended */
     unsigned long version;        /**structure version */
     unsigned long flags;          /** flags to modify behaviour */
-    SInt32 const * channelMap;    /** Channel map for HAL channel mapping , if not needed, use NULL;*/ 
-    unsigned long channelMapSize; /** Channel map size for HAL channel mapping , if not needed, use 0;*/ 
+    SInt32 const * channelMap;    /** Channel map for HAL channel mapping , if not needed, use NULL;*/
+    unsigned long channelMapSize; /** Channel map size for HAL channel mapping , if not needed, use 0;*/
 } PaMacCoreStreamInfo;
 
 /**
@@ -98,7 +98,7 @@ void PaMacCore_SetupChannelMap( PaMacCoreStreamInfo *data, const SInt32 * const 
  * @return A valid AudioDeviceID, or NULL if an error occurred.
  */
 AudioDeviceID PaMacCore_GetStreamInputDevice( PaStream* s );
- 
+
 /**
  * Retrieve the AudioDeviceID of the output device assigned to an open stream
  *
@@ -124,13 +124,13 @@ AudioDeviceID PaMacCore_GetStreamOutputDevice( PaStream* s );
  */
 const char *PaMacCore_GetChannelName( int device, int channelIndex, bool input );
 
-    
+
 /** Retrieve the range of legal native buffer sizes for the specified device, in sample frames.
- 
+
  @param device The global index of the PortAudio device about which the query is being made.
  @param minBufferSizeFrames A pointer to the location which will receive the minimum buffer size value.
  @param maxBufferSizeFrames A pointer to the location which will receive the maximum buffer size value.
- 
+
  @see kAudioDevicePropertyBufferFrameSizeRange in the CoreAudio SDK.
  */
 PaError PaMacCore_GetBufferSizeRange( PaDeviceIndex device,

--- a/include/pa_win_ds.h
+++ b/include/pa_win_ds.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -63,11 +63,11 @@ typedef struct PaWinDirectSoundStreamInfo{
 
     unsigned long flags;            /**< enable other features of this struct */
 
-    /** 
+    /**
        low-level latency setting support
        Sets the size of the DirectSound host buffer.
        When flags contains the paWinDirectSoundUseLowLevelLatencyParameters
-       this size will be used instead of interpreting the generic latency 
+       this size will be used instead of interpreting the generic latency
        parameters to Pa_OpenStream(). If the flag is not set this value is ignored.
 
        If the stream is a full duplex stream the implementation requires that
@@ -77,7 +77,7 @@ typedef struct PaWinDirectSoundStreamInfo{
 
     /**
         support for WAVEFORMATEXTENSIBLE channel masks. If flags contains
-        paWinDirectSoundUseChannelMask this allows you to specify which speakers 
+        paWinDirectSoundUseChannelMask this allows you to specify which speakers
         to address in a multichannel stream. Constants for channelMask
         are specified in pa_win_waveformat.h
 
@@ -92,4 +92,4 @@ typedef struct PaWinDirectSoundStreamInfo{
 }
 #endif /* __cplusplus */
 
-#endif /* PA_WIN_DS_H */                                  
+#endif /* PA_WIN_DS_H */

--- a/include/pa_win_wasapi.h
+++ b/include/pa_win_wasapi.h
@@ -551,7 +551,7 @@ PaError PaWasapi_SetStreamStateHandler( PaStream *pStream, PaWasapiStreamStateCa
  @param  bOutput TRUE (1) for output (render), FALSE (0) for input (capture).
 
  @return Error code indicating success or failure. Will return paIncompatibleStreamHostApi if library is not compiled
-         for UWP/WinRT platform. If Id is longer than PA_WASAPI_DEVICE_ID_LEN characters paBufferTooBig will 
+         for UWP/WinRT platform. If Id is longer than PA_WASAPI_DEVICE_ID_LEN characters paBufferTooBig will
          be returned.
 */
 PaError PaWasapiWinrt_SetDefaultDeviceId( const unsigned short *pId, int bOutput );
@@ -559,11 +559,11 @@ PaError PaWasapiWinrt_SetDefaultDeviceId( const unsigned short *pId, int bOutput
 
 /** Populate the device list.
 
-    By default the implementation will rely on DEVINTERFACE_AUDIO_RENDER and DEVINTERFACE_AUDIO_CAPTURE as 
-    default devices. If device Id is provided by PaWasapiWinrt_SetDefaultDeviceId() then those 
+    By default the implementation will rely on DEVINTERFACE_AUDIO_RENDER and DEVINTERFACE_AUDIO_CAPTURE as
+    default devices. If device Id is provided by PaWasapiWinrt_SetDefaultDeviceId() then those
     device Ids will be used as default and only devices for the device list.
 
-    By populating the device list you can provide an additional available audio devices of the system to PA 
+    By populating the device list you can provide an additional available audio devices of the system to PA
     which are obtainable by:
     Windows::Devices::Enumeration::DeviceInformation::FindAllAsync(selector) where selector is obtainable by
     Windows::Media::Devices::MediaDevice::GetAudioRenderSelector() or
@@ -571,14 +571,14 @@ PaError PaWasapiWinrt_SetDefaultDeviceId( const unsigned short *pId, int bOutput
 
     After the call completes, memory referenced by pointers can be freed, as implementation keeps its own copy.
 
-    You must call PaWasapi_UpdateDeviceList() to update the internal device list of the implementation after 
+    You must call PaWasapi_UpdateDeviceList() to update the internal device list of the implementation after
     calling this function.
 
     See an example in the IMPORTANT notes.
 
  @note   UWP/WinRT platform only.
 
- @param  pId     Array of device Ids, pointer to the array of pointers of 16-bit Unicode string (WCHAR). If NULL 
+ @param  pId     Array of device Ids, pointer to the array of pointers of 16-bit Unicode string (WCHAR). If NULL
                  and count is also 0 then device Ids will be reset to the default. Required.
  @param  pName   Array of device Names, pointer to the array of pointers of 16-bit Unicode string (WCHAR). Optional.
  @param  pRole   Array of device Roles, see PaWasapiDeviceRole and PaWasapi_GetDeviceRole() for more details. Optional.
@@ -587,11 +587,11 @@ PaError PaWasapiWinrt_SetDefaultDeviceId( const unsigned short *pId, int bOutput
  @param  bOutput TRUE (1) for output (render), FALSE (0) for input (capture).
 
  @return Error code indicating success or failure. Will return paIncompatibleStreamHostApi if library is not compiled
-         for UWP/WinRT platform. If Id is longer than PA_WASAPI_DEVICE_ID_LEN characters paBufferTooBig will 
-         be returned. If Name is longer than PA_WASAPI_DEVICE_NAME_LEN characters paBufferTooBig will 
+         for UWP/WinRT platform. If Id is longer than PA_WASAPI_DEVICE_ID_LEN characters paBufferTooBig will
+         be returned. If Name is longer than PA_WASAPI_DEVICE_NAME_LEN characters paBufferTooBig will
          be returned.
 */
-PaError PaWasapiWinrt_PopulateDeviceList( const unsigned short **pId, const unsigned short **pName, 
+PaError PaWasapiWinrt_PopulateDeviceList( const unsigned short **pId, const unsigned short **pName,
     const PaWasapiDeviceRole *pRole, unsigned int count, int bOutput );
 
 
@@ -676,11 +676,11 @@ PaError PaWasapiWinrt_PopulateDeviceList( const unsigned short **pId, const unsi
 
     UWP/WinRT:
 
-        This platform has number of limitations which do not allow to enumerate audio devices without 
+        This platform has number of limitations which do not allow to enumerate audio devices without
         an additional external help. Enumeration is possible though from C++/CX, check the related API
         Windows::Devices::Enumeration::DeviceInformation::FindAllAsync().
 
-        The main limitation is an absence of the device enumeration from inside the PA's implementation. 
+        The main limitation is an absence of the device enumeration from inside the PA's implementation.
         This problem can be solved by using the following functions:
 
         PaWasapiWinrt_SetDefaultDeviceId() - to set default input/output device,
@@ -706,7 +706,7 @@ PaError PaWasapiWinrt_PopulateDeviceList( const unsigned short **pId, const unsi
         }
 
         PaWasapiWinrt_SetDefaultDeviceId((const UINT16 *)default_device_id.c_str(), !capture);
-        PaWasapiWinrt_PopulateDeviceList(ids.data(), names.data(), role.data(), count, !capture);        
+        PaWasapiWinrt_PopulateDeviceList(ids.data(), names.data(), role.data(), count, !capture);
         PaWasapi_UpdateDeviceList();
 
         ----------------

--- a/include/pa_win_waveformat.h
+++ b/include/pa_win_waveformat.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -49,87 +49,87 @@ extern "C" {
 #endif
 
 /*
-	The following #defines for speaker channel masks are the same
-	as those in ksmedia.h, except with PAWIN_ prepended, KSAUDIO_ removed
-	in some cases, and casts to PaWinWaveFormatChannelMask added.
+    The following #defines for speaker channel masks are the same
+    as those in ksmedia.h, except with PAWIN_ prepended, KSAUDIO_ removed
+    in some cases, and casts to PaWinWaveFormatChannelMask added.
 */
 
 typedef unsigned long PaWinWaveFormatChannelMask;
 
 /* Speaker Positions: */
-#define PAWIN_SPEAKER_FRONT_LEFT				((PaWinWaveFormatChannelMask)0x1)
-#define PAWIN_SPEAKER_FRONT_RIGHT				((PaWinWaveFormatChannelMask)0x2)
-#define PAWIN_SPEAKER_FRONT_CENTER				((PaWinWaveFormatChannelMask)0x4)
-#define PAWIN_SPEAKER_LOW_FREQUENCY				((PaWinWaveFormatChannelMask)0x8)
-#define PAWIN_SPEAKER_BACK_LEFT					((PaWinWaveFormatChannelMask)0x10)
-#define PAWIN_SPEAKER_BACK_RIGHT				((PaWinWaveFormatChannelMask)0x20)
-#define PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER		((PaWinWaveFormatChannelMask)0x40)
-#define PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER		((PaWinWaveFormatChannelMask)0x80)
-#define PAWIN_SPEAKER_BACK_CENTER				((PaWinWaveFormatChannelMask)0x100)
-#define PAWIN_SPEAKER_SIDE_LEFT					((PaWinWaveFormatChannelMask)0x200)
-#define PAWIN_SPEAKER_SIDE_RIGHT				((PaWinWaveFormatChannelMask)0x400)
-#define PAWIN_SPEAKER_TOP_CENTER				((PaWinWaveFormatChannelMask)0x800)
-#define PAWIN_SPEAKER_TOP_FRONT_LEFT			((PaWinWaveFormatChannelMask)0x1000)
-#define PAWIN_SPEAKER_TOP_FRONT_CENTER			((PaWinWaveFormatChannelMask)0x2000)
-#define PAWIN_SPEAKER_TOP_FRONT_RIGHT			((PaWinWaveFormatChannelMask)0x4000)
-#define PAWIN_SPEAKER_TOP_BACK_LEFT				((PaWinWaveFormatChannelMask)0x8000)
-#define PAWIN_SPEAKER_TOP_BACK_CENTER			((PaWinWaveFormatChannelMask)0x10000)
-#define PAWIN_SPEAKER_TOP_BACK_RIGHT			((PaWinWaveFormatChannelMask)0x20000)
+#define PAWIN_SPEAKER_FRONT_LEFT                ((PaWinWaveFormatChannelMask)0x1)
+#define PAWIN_SPEAKER_FRONT_RIGHT                ((PaWinWaveFormatChannelMask)0x2)
+#define PAWIN_SPEAKER_FRONT_CENTER                ((PaWinWaveFormatChannelMask)0x4)
+#define PAWIN_SPEAKER_LOW_FREQUENCY                ((PaWinWaveFormatChannelMask)0x8)
+#define PAWIN_SPEAKER_BACK_LEFT                    ((PaWinWaveFormatChannelMask)0x10)
+#define PAWIN_SPEAKER_BACK_RIGHT                ((PaWinWaveFormatChannelMask)0x20)
+#define PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER        ((PaWinWaveFormatChannelMask)0x40)
+#define PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER        ((PaWinWaveFormatChannelMask)0x80)
+#define PAWIN_SPEAKER_BACK_CENTER                ((PaWinWaveFormatChannelMask)0x100)
+#define PAWIN_SPEAKER_SIDE_LEFT                    ((PaWinWaveFormatChannelMask)0x200)
+#define PAWIN_SPEAKER_SIDE_RIGHT                ((PaWinWaveFormatChannelMask)0x400)
+#define PAWIN_SPEAKER_TOP_CENTER                ((PaWinWaveFormatChannelMask)0x800)
+#define PAWIN_SPEAKER_TOP_FRONT_LEFT            ((PaWinWaveFormatChannelMask)0x1000)
+#define PAWIN_SPEAKER_TOP_FRONT_CENTER            ((PaWinWaveFormatChannelMask)0x2000)
+#define PAWIN_SPEAKER_TOP_FRONT_RIGHT            ((PaWinWaveFormatChannelMask)0x4000)
+#define PAWIN_SPEAKER_TOP_BACK_LEFT                ((PaWinWaveFormatChannelMask)0x8000)
+#define PAWIN_SPEAKER_TOP_BACK_CENTER            ((PaWinWaveFormatChannelMask)0x10000)
+#define PAWIN_SPEAKER_TOP_BACK_RIGHT            ((PaWinWaveFormatChannelMask)0x20000)
 
 /* Bit mask locations reserved for future use */
-#define PAWIN_SPEAKER_RESERVED					((PaWinWaveFormatChannelMask)0x7FFC0000)
+#define PAWIN_SPEAKER_RESERVED                    ((PaWinWaveFormatChannelMask)0x7FFC0000)
 
 /* Used to specify that any possible permutation of speaker configurations */
-#define PAWIN_SPEAKER_ALL						((PaWinWaveFormatChannelMask)0x80000000)
+#define PAWIN_SPEAKER_ALL                        ((PaWinWaveFormatChannelMask)0x80000000)
 
 /* DirectSound Speaker Config */
-#define PAWIN_SPEAKER_DIRECTOUT					0
-#define PAWIN_SPEAKER_MONO						(PAWIN_SPEAKER_FRONT_CENTER)
-#define PAWIN_SPEAKER_STEREO					(PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT)
-#define PAWIN_SPEAKER_QUAD						(PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-												PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
-#define PAWIN_SPEAKER_SURROUND					(PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-												PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_BACK_CENTER)
-#define PAWIN_SPEAKER_5POINT1					(PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-												PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-												PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
-#define PAWIN_SPEAKER_7POINT1					(PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-												PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-												PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
-												PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER | PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER)
-#define PAWIN_SPEAKER_5POINT1_SURROUND			(PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-												PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-												PAWIN_SPEAKER_SIDE_LEFT  | PAWIN_SPEAKER_SIDE_RIGHT)
-#define PAWIN_SPEAKER_7POINT1_SURROUND			(PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-												PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-												PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
-												PAWIN_SPEAKER_SIDE_LEFT | PAWIN_SPEAKER_SIDE_RIGHT)
+#define PAWIN_SPEAKER_DIRECTOUT                    0
+#define PAWIN_SPEAKER_MONO                        (PAWIN_SPEAKER_FRONT_CENTER)
+#define PAWIN_SPEAKER_STEREO                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT)
+#define PAWIN_SPEAKER_QUAD                        (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
+#define PAWIN_SPEAKER_SURROUND                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_BACK_CENTER)
+#define PAWIN_SPEAKER_5POINT1                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
+#define PAWIN_SPEAKER_7POINT1                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
+                                                PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER | PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER)
+#define PAWIN_SPEAKER_5POINT1_SURROUND            (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                PAWIN_SPEAKER_SIDE_LEFT  | PAWIN_SPEAKER_SIDE_RIGHT)
+#define PAWIN_SPEAKER_7POINT1_SURROUND            (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
+                                                PAWIN_SPEAKER_SIDE_LEFT | PAWIN_SPEAKER_SIDE_RIGHT)
 /*
  According to the Microsoft documentation:
  The following are obsolete 5.1 and 7.1 settings (they lack side speakers).  Note this means
  that the default 5.1 and 7.1 settings (KSAUDIO_SPEAKER_5POINT1 and KSAUDIO_SPEAKER_7POINT1 are
  similarly obsolete but are unchanged for compatibility reasons).
 */
-#define PAWIN_SPEAKER_5POINT1_BACK				PAWIN_SPEAKER_5POINT1
-#define PAWIN_SPEAKER_7POINT1_WIDE				PAWIN_SPEAKER_7POINT1
+#define PAWIN_SPEAKER_5POINT1_BACK                PAWIN_SPEAKER_5POINT1
+#define PAWIN_SPEAKER_7POINT1_WIDE                PAWIN_SPEAKER_7POINT1
 
 /* DVD Speaker Positions */
-#define PAWIN_SPEAKER_GROUND_FRONT_LEFT			PAWIN_SPEAKER_FRONT_LEFT
-#define PAWIN_SPEAKER_GROUND_FRONT_CENTER		PAWIN_SPEAKER_FRONT_CENTER
-#define PAWIN_SPEAKER_GROUND_FRONT_RIGHT		PAWIN_SPEAKER_FRONT_RIGHT
-#define PAWIN_SPEAKER_GROUND_REAR_LEFT			PAWIN_SPEAKER_BACK_LEFT
-#define PAWIN_SPEAKER_GROUND_REAR_RIGHT			PAWIN_SPEAKER_BACK_RIGHT
-#define PAWIN_SPEAKER_TOP_MIDDLE				PAWIN_SPEAKER_TOP_CENTER
-#define PAWIN_SPEAKER_SUPER_WOOFER				PAWIN_SPEAKER_LOW_FREQUENCY
+#define PAWIN_SPEAKER_GROUND_FRONT_LEFT            PAWIN_SPEAKER_FRONT_LEFT
+#define PAWIN_SPEAKER_GROUND_FRONT_CENTER        PAWIN_SPEAKER_FRONT_CENTER
+#define PAWIN_SPEAKER_GROUND_FRONT_RIGHT        PAWIN_SPEAKER_FRONT_RIGHT
+#define PAWIN_SPEAKER_GROUND_REAR_LEFT            PAWIN_SPEAKER_BACK_LEFT
+#define PAWIN_SPEAKER_GROUND_REAR_RIGHT            PAWIN_SPEAKER_BACK_RIGHT
+#define PAWIN_SPEAKER_TOP_MIDDLE                PAWIN_SPEAKER_TOP_CENTER
+#define PAWIN_SPEAKER_SUPER_WOOFER                PAWIN_SPEAKER_LOW_FREQUENCY
 
 
 /*
-	PaWinWaveFormat is defined here to provide compatibility with
-	compilation environments which don't have headers defining 
-	WAVEFORMATEXTENSIBLE (e.g. older versions of MSVC, Borland C++ etc.
+    PaWinWaveFormat is defined here to provide compatibility with
+    compilation environments which don't have headers defining
+    WAVEFORMATEXTENSIBLE (e.g. older versions of MSVC, Borland C++ etc.
 
-	The fields for WAVEFORMATEX and WAVEFORMATEXTENSIBLE are declared as an
-    unsigned char array here to avoid clients who include this file having 
+    The fields for WAVEFORMATEX and WAVEFORMATEXTENSIBLE are declared as an
+    unsigned char array here to avoid clients who include this file having
     a dependency on windows.h and mmsystem.h, and also to to avoid having
     to write separate packing pragmas for each compiler.
 */
@@ -138,24 +138,24 @@ typedef unsigned long PaWinWaveFormatChannelMask;
 
 typedef struct{
     unsigned char fields[ PAWIN_SIZEOF_WAVEFORMATEXTENSIBLE ];
-    unsigned long extraLongForAlignment; /* ensure that compiler aligns struct to DWORD */ 
+    unsigned long extraLongForAlignment; /* ensure that compiler aligns struct to DWORD */
 } PaWinWaveFormat;
 
 /*
     WAVEFORMATEXTENSIBLE fields:
-    
+
     union  {
-	    WORD  wValidBitsPerSample;    
-	    WORD  wSamplesPerBlock;    
-	    WORD  wReserved;  
+        WORD  wValidBitsPerSample;
+        WORD  wSamplesPerBlock;
+        WORD  wReserved;
     } Samples;
-    DWORD  dwChannelMask;  
+    DWORD  dwChannelMask;
     GUID  SubFormat;
 */
 
-#define PAWIN_INDEXOF_WVALIDBITSPERSAMPLE	(PAWIN_SIZEOF_WAVEFORMATEX+0)
-#define PAWIN_INDEXOF_DWCHANNELMASK			(PAWIN_SIZEOF_WAVEFORMATEX+2)
-#define PAWIN_INDEXOF_SUBFORMAT				(PAWIN_SIZEOF_WAVEFORMATEX+6)
+#define PAWIN_INDEXOF_WVALIDBITSPERSAMPLE    (PAWIN_SIZEOF_WAVEFORMATEX+0)
+#define PAWIN_INDEXOF_DWCHANNELMASK            (PAWIN_SIZEOF_WAVEFORMATEX+2)
+#define PAWIN_INDEXOF_SUBFORMAT                (PAWIN_SIZEOF_WAVEFORMATEX+6)
 
 
 /*
@@ -176,16 +176,16 @@ typedef struct{
 int PaWin_SampleFormatToLinearWaveFormatTag( PaSampleFormat sampleFormat );
 
 /*
-	Use the following two functions to initialize the waveformat structure.
+    Use the following two functions to initialize the waveformat structure.
 */
 
-void PaWin_InitializeWaveFormatEx( PaWinWaveFormat *waveFormat, 
-		int numChannels, PaSampleFormat sampleFormat, int waveFormatTag, double sampleRate );
+void PaWin_InitializeWaveFormatEx( PaWinWaveFormat *waveFormat,
+        int numChannels, PaSampleFormat sampleFormat, int waveFormatTag, double sampleRate );
 
 
-void PaWin_InitializeWaveFormatExtensible( PaWinWaveFormat *waveFormat, 
-		int numChannels, PaSampleFormat sampleFormat, int waveFormatTag, double sampleRate,
-	    PaWinWaveFormatChannelMask channelMask );
+void PaWin_InitializeWaveFormatExtensible( PaWinWaveFormat *waveFormat,
+        int numChannels, PaSampleFormat sampleFormat, int waveFormatTag, double sampleRate,
+        PaWinWaveFormatChannelMask channelMask );
 
 
 /* Map a channel count to a speaker channel mask */

--- a/include/pa_win_waveformat.h
+++ b/include/pa_win_waveformat.h
@@ -58,69 +58,69 @@ typedef unsigned long PaWinWaveFormatChannelMask;
 
 /* Speaker Positions: */
 #define PAWIN_SPEAKER_FRONT_LEFT                ((PaWinWaveFormatChannelMask)0x1)
-#define PAWIN_SPEAKER_FRONT_RIGHT                ((PaWinWaveFormatChannelMask)0x2)
-#define PAWIN_SPEAKER_FRONT_CENTER                ((PaWinWaveFormatChannelMask)0x4)
-#define PAWIN_SPEAKER_LOW_FREQUENCY                ((PaWinWaveFormatChannelMask)0x8)
-#define PAWIN_SPEAKER_BACK_LEFT                    ((PaWinWaveFormatChannelMask)0x10)
+#define PAWIN_SPEAKER_FRONT_RIGHT               ((PaWinWaveFormatChannelMask)0x2)
+#define PAWIN_SPEAKER_FRONT_CENTER              ((PaWinWaveFormatChannelMask)0x4)
+#define PAWIN_SPEAKER_LOW_FREQUENCY             ((PaWinWaveFormatChannelMask)0x8)
+#define PAWIN_SPEAKER_BACK_LEFT                 ((PaWinWaveFormatChannelMask)0x10)
 #define PAWIN_SPEAKER_BACK_RIGHT                ((PaWinWaveFormatChannelMask)0x20)
-#define PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER        ((PaWinWaveFormatChannelMask)0x40)
-#define PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER        ((PaWinWaveFormatChannelMask)0x80)
-#define PAWIN_SPEAKER_BACK_CENTER                ((PaWinWaveFormatChannelMask)0x100)
-#define PAWIN_SPEAKER_SIDE_LEFT                    ((PaWinWaveFormatChannelMask)0x200)
+#define PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER      ((PaWinWaveFormatChannelMask)0x40)
+#define PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER     ((PaWinWaveFormatChannelMask)0x80)
+#define PAWIN_SPEAKER_BACK_CENTER               ((PaWinWaveFormatChannelMask)0x100)
+#define PAWIN_SPEAKER_SIDE_LEFT                 ((PaWinWaveFormatChannelMask)0x200)
 #define PAWIN_SPEAKER_SIDE_RIGHT                ((PaWinWaveFormatChannelMask)0x400)
 #define PAWIN_SPEAKER_TOP_CENTER                ((PaWinWaveFormatChannelMask)0x800)
 #define PAWIN_SPEAKER_TOP_FRONT_LEFT            ((PaWinWaveFormatChannelMask)0x1000)
-#define PAWIN_SPEAKER_TOP_FRONT_CENTER            ((PaWinWaveFormatChannelMask)0x2000)
-#define PAWIN_SPEAKER_TOP_FRONT_RIGHT            ((PaWinWaveFormatChannelMask)0x4000)
-#define PAWIN_SPEAKER_TOP_BACK_LEFT                ((PaWinWaveFormatChannelMask)0x8000)
-#define PAWIN_SPEAKER_TOP_BACK_CENTER            ((PaWinWaveFormatChannelMask)0x10000)
+#define PAWIN_SPEAKER_TOP_FRONT_CENTER          ((PaWinWaveFormatChannelMask)0x2000)
+#define PAWIN_SPEAKER_TOP_FRONT_RIGHT           ((PaWinWaveFormatChannelMask)0x4000)
+#define PAWIN_SPEAKER_TOP_BACK_LEFT             ((PaWinWaveFormatChannelMask)0x8000)
+#define PAWIN_SPEAKER_TOP_BACK_CENTER           ((PaWinWaveFormatChannelMask)0x10000)
 #define PAWIN_SPEAKER_TOP_BACK_RIGHT            ((PaWinWaveFormatChannelMask)0x20000)
 
 /* Bit mask locations reserved for future use */
-#define PAWIN_SPEAKER_RESERVED                    ((PaWinWaveFormatChannelMask)0x7FFC0000)
+#define PAWIN_SPEAKER_RESERVED                  ((PaWinWaveFormatChannelMask)0x7FFC0000)
 
 /* Used to specify that any possible permutation of speaker configurations */
-#define PAWIN_SPEAKER_ALL                        ((PaWinWaveFormatChannelMask)0x80000000)
+#define PAWIN_SPEAKER_ALL                       ((PaWinWaveFormatChannelMask)0x80000000)
 
 /* DirectSound Speaker Config */
-#define PAWIN_SPEAKER_DIRECTOUT                    0
-#define PAWIN_SPEAKER_MONO                        (PAWIN_SPEAKER_FRONT_CENTER)
+#define PAWIN_SPEAKER_DIRECTOUT                 0
+#define PAWIN_SPEAKER_MONO                      (PAWIN_SPEAKER_FRONT_CENTER)
 #define PAWIN_SPEAKER_STEREO                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT)
-#define PAWIN_SPEAKER_QUAD                        (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-                                                PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
-#define PAWIN_SPEAKER_SURROUND                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_BACK_CENTER)
-#define PAWIN_SPEAKER_5POINT1                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-                                                PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
-#define PAWIN_SPEAKER_7POINT1                    (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-                                                PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
-                                                PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER | PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER)
-#define PAWIN_SPEAKER_5POINT1_SURROUND            (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-                                                PAWIN_SPEAKER_SIDE_LEFT  | PAWIN_SPEAKER_SIDE_RIGHT)
-#define PAWIN_SPEAKER_7POINT1_SURROUND            (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
-                                                PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
-                                                PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
-                                                PAWIN_SPEAKER_SIDE_LEFT | PAWIN_SPEAKER_SIDE_RIGHT)
+#define PAWIN_SPEAKER_QUAD                      (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                    PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
+#define PAWIN_SPEAKER_SURROUND                  (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                    PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_BACK_CENTER)
+#define PAWIN_SPEAKER_5POINT1                   (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                    PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                    PAWIN_SPEAKER_BACK_LEFT  | PAWIN_SPEAKER_BACK_RIGHT)
+#define PAWIN_SPEAKER_7POINT1                   (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                    PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                    PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
+                                                    PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER | PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER)
+#define PAWIN_SPEAKER_5POINT1_SURROUND          (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                    PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                    PAWIN_SPEAKER_SIDE_LEFT  | PAWIN_SPEAKER_SIDE_RIGHT)
+#define PAWIN_SPEAKER_7POINT1_SURROUND          (PAWIN_SPEAKER_FRONT_LEFT | PAWIN_SPEAKER_FRONT_RIGHT | \
+                                                    PAWIN_SPEAKER_FRONT_CENTER | PAWIN_SPEAKER_LOW_FREQUENCY | \
+                                                    PAWIN_SPEAKER_BACK_LEFT | PAWIN_SPEAKER_BACK_RIGHT | \
+                                                    PAWIN_SPEAKER_SIDE_LEFT | PAWIN_SPEAKER_SIDE_RIGHT)
 /*
  According to the Microsoft documentation:
  The following are obsolete 5.1 and 7.1 settings (they lack side speakers).  Note this means
  that the default 5.1 and 7.1 settings (KSAUDIO_SPEAKER_5POINT1 and KSAUDIO_SPEAKER_7POINT1 are
  similarly obsolete but are unchanged for compatibility reasons).
 */
-#define PAWIN_SPEAKER_5POINT1_BACK                PAWIN_SPEAKER_5POINT1
-#define PAWIN_SPEAKER_7POINT1_WIDE                PAWIN_SPEAKER_7POINT1
+#define PAWIN_SPEAKER_5POINT1_BACK              PAWIN_SPEAKER_5POINT1
+#define PAWIN_SPEAKER_7POINT1_WIDE              PAWIN_SPEAKER_7POINT1
 
 /* DVD Speaker Positions */
-#define PAWIN_SPEAKER_GROUND_FRONT_LEFT            PAWIN_SPEAKER_FRONT_LEFT
-#define PAWIN_SPEAKER_GROUND_FRONT_CENTER        PAWIN_SPEAKER_FRONT_CENTER
+#define PAWIN_SPEAKER_GROUND_FRONT_LEFT         PAWIN_SPEAKER_FRONT_LEFT
+#define PAWIN_SPEAKER_GROUND_FRONT_CENTER       PAWIN_SPEAKER_FRONT_CENTER
 #define PAWIN_SPEAKER_GROUND_FRONT_RIGHT        PAWIN_SPEAKER_FRONT_RIGHT
-#define PAWIN_SPEAKER_GROUND_REAR_LEFT            PAWIN_SPEAKER_BACK_LEFT
-#define PAWIN_SPEAKER_GROUND_REAR_RIGHT            PAWIN_SPEAKER_BACK_RIGHT
+#define PAWIN_SPEAKER_GROUND_REAR_LEFT          PAWIN_SPEAKER_BACK_LEFT
+#define PAWIN_SPEAKER_GROUND_REAR_RIGHT         PAWIN_SPEAKER_BACK_RIGHT
 #define PAWIN_SPEAKER_TOP_MIDDLE                PAWIN_SPEAKER_TOP_CENTER
-#define PAWIN_SPEAKER_SUPER_WOOFER                PAWIN_SPEAKER_LOW_FREQUENCY
+#define PAWIN_SPEAKER_SUPER_WOOFER              PAWIN_SPEAKER_LOW_FREQUENCY
 
 
 /*
@@ -153,9 +153,9 @@ typedef struct{
     GUID  SubFormat;
 */
 
-#define PAWIN_INDEXOF_WVALIDBITSPERSAMPLE    (PAWIN_SIZEOF_WAVEFORMATEX+0)
-#define PAWIN_INDEXOF_DWCHANNELMASK            (PAWIN_SIZEOF_WAVEFORMATEX+2)
-#define PAWIN_INDEXOF_SUBFORMAT                (PAWIN_SIZEOF_WAVEFORMATEX+6)
+#define PAWIN_INDEXOF_WVALIDBITSPERSAMPLE       (PAWIN_SIZEOF_WAVEFORMATEX+0)
+#define PAWIN_INDEXOF_DWCHANNELMASK             (PAWIN_SIZEOF_WAVEFORMATEX+2)
+#define PAWIN_INDEXOF_SUBFORMAT                 (PAWIN_SIZEOF_WAVEFORMATEX+6)
 
 
 /*
@@ -163,10 +163,10 @@ typedef struct{
     PaWin_InitializeWaveFormatExtensible functions below. These must match
     the standard Windows WAVE_FORMAT_* values.
 */
-#define PAWIN_WAVE_FORMAT_PCM               (1)
-#define PAWIN_WAVE_FORMAT_IEEE_FLOAT        (3)
-#define PAWIN_WAVE_FORMAT_DOLBY_AC3_SPDIF   (0x0092)
-#define PAWIN_WAVE_FORMAT_WMA_SPDIF         (0x0164)
+#define PAWIN_WAVE_FORMAT_PCM                   (1)
+#define PAWIN_WAVE_FORMAT_IEEE_FLOAT            (3)
+#define PAWIN_WAVE_FORMAT_DOLBY_AC3_SPDIF       (0x0092)
+#define PAWIN_WAVE_FORMAT_WMA_SPDIF             (0x0164)
 
 
 /*

--- a/include/pa_win_wdmks.h
+++ b/include/pa_win_wdmks.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -134,4 +134,4 @@ extern "C"
 }
 #endif /* __cplusplus */
 
-#endif /* PA_WIN_DS_H */                                  
+#endif /* PA_WIN_DS_H */

--- a/include/pa_win_wmme.h
+++ b/include/pa_win_wmme.h
@@ -28,13 +28,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -52,7 +52,7 @@ extern "C"
 #endif /* __cplusplus */
 
 
-/* The following are flags which can be set in 
+/* The following are flags which can be set in
   PaWinMmeStreamInfo's flags field.
 */
 
@@ -100,7 +100,7 @@ typedef struct PaWinMmeStreamInfo{
         Pa_OpenStream().
     */
     unsigned long framesPerBuffer;
-    unsigned long bufferCount;  /* formerly numBuffers */ 
+    unsigned long bufferCount;  /* formerly numBuffers */
 
     /* multiple devices per direction support
         If flags contains the PaWinMmeUseMultipleDevices flag,
@@ -118,7 +118,7 @@ typedef struct PaWinMmeStreamInfo{
 
     /*
         support for WAVEFORMATEXTENSIBLE channel masks. If flags contains
-        paWinMmeUseChannelMask this allows you to specify which speakers 
+        paWinMmeUseChannelMask this allows you to specify which speakers
         to address in a multichannel stream. Constants for channelMask
         are specified in pa_win_waveformat.h
 
@@ -155,7 +155,7 @@ HWAVEIN PaWinMME_GetStreamInputHandle( PaStream* stream, int handleIndex );
 
 /** Retrieve the number of wave out handles used by a PortAudio WinMME stream.
  Returns zero if the stream is input only.
- 
+
  @return A non-negative value indicating the number of wave out handles
  or, a PaErrorCode (which are always negative) if PortAudio is not initialized
  or an error is encountered.
@@ -182,4 +182,4 @@ HWAVEOUT PaWinMME_GetStreamOutputHandle( PaStream* stream, int handleIndex );
 }
 #endif /* __cplusplus */
 
-#endif /* PA_WIN_WMME_H */                                  
+#endif /* PA_WIN_WMME_H */

--- a/include/portaudio.h
+++ b/include/portaudio.h
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -100,7 +100,7 @@ typedef struct PaVersionInfo {
     /** Version as a string, for example "PortAudio V19.5.0-devel, revision 1952M" */
     const char *versionText;
 } PaVersionInfo;
-    
+
 /** Retrieve version information for the currently running PortAudio build.
  @return A pointer to an immutable PaVersionInfo structure.
 
@@ -167,9 +167,9 @@ const char *Pa_GetErrorText( PaError errorCode );
  and Pa_GetErrorText(), this function MUST be called before using any other
  PortAudio API functions.
 
- If Pa_Initialize() is called multiple times, each successful 
- call must be matched with a corresponding call to Pa_Terminate(). 
- Pairs of calls to Pa_Initialize()/Pa_Terminate() may overlap, and are not 
+ If Pa_Initialize() is called multiple times, each successful
+ call must be matched with a corresponding call to Pa_Terminate().
+ Pairs of calls to Pa_Initialize()/Pa_Terminate() may overlap, and are not
  required to be fully nested.
 
  Note that if Pa_Initialize() returns an error code, Pa_Terminate() should
@@ -196,7 +196,7 @@ PaError Pa_Initialize( void );
 
  @return paNoError if successful, otherwise an error code indicating the cause
  of failure.
- 
+
  @see Pa_Initialize
 */
 PaError Pa_Terminate( void );
@@ -320,7 +320,7 @@ typedef struct PaHostApiInfo
      if no default output device is available.
     */
     PaDeviceIndex defaultOutputDevice;
-    
+
 } PaHostApiInfo;
 
 
@@ -349,7 +349,7 @@ const PaHostApiInfo * Pa_GetHostApiInfo( PaHostApiIndex hostApi );
  @return A valid PaHostApiIndex ranging from 0 to (Pa_GetHostApiCount()-1) or,
  a PaErrorCode (which are always negative) if PortAudio is not initialized
  or an error is encountered.
- 
+
  The paHostApiNotFound error code indicates that the host API specified by the
  type parameter is not available.
 
@@ -376,7 +376,7 @@ PaHostApiIndex Pa_HostApiTypeIdToHostApiIndex( PaHostApiTypeId type );
 
  A paInvalidDevice error code indicates that the hostApiDeviceIndex parameter
  is out of range.
- 
+
  @see PaHostApiInfo
 */
 PaDeviceIndex Pa_HostApiDeviceIndexToDeviceIndex( PaHostApiIndex hostApi,
@@ -449,12 +449,12 @@ PaDeviceIndex Pa_GetDefaultInputDevice( void );
 PaDeviceIndex Pa_GetDefaultOutputDevice( void );
 
 
-/** The type used to represent monotonic time in seconds. PaTime is 
- used for the fields of the PaStreamCallbackTimeInfo argument to the 
+/** The type used to represent monotonic time in seconds. PaTime is
+ used for the fields of the PaStreamCallbackTimeInfo argument to the
  PaStreamCallback and as the result of Pa_GetStreamTime().
 
  PaTime values have unspecified origin.
-     
+
  @see PaStreamCallback, PaStreamCallbackTimeInfo, Pa_GetStreamTime
 */
 typedef double PaTime;
@@ -472,7 +472,7 @@ typedef double PaTime;
 
  paUInt8 is an unsigned 8 bit format where 128 is considered "ground"
 
- The paNonInterleaved flag indicates that audio data is passed as an array 
+ The paNonInterleaved flag indicates that audio data is passed as an array
  of pointers to separate buffers, one buffer for each channel. Usually,
  when this flag is not used, audio data is passed as a single buffer with
  all channels interleaved.
@@ -502,7 +502,7 @@ typedef struct PaDeviceInfo
     int structVersion;  /* this is struct version 2 */
     const char *name;
     PaHostApiIndex hostApi; /**< note this is a host API index, not a type id*/
-    
+
     int maxInputChannels;
     int maxOutputChannels;
 
@@ -544,7 +544,7 @@ typedef struct PaStreamParameters
      This field must not be set to paNoDevice.
     */
     PaDeviceIndex device;
-    
+
     /** The number of channels of sound to be delivered to the
      stream callback or accessed by Pa_ReadStream() or Pa_WriteStream().
      It can range from 1 to the value of maxInputChannels in the
@@ -619,9 +619,9 @@ PaError Pa_IsFormatSupported( const PaStreamParameters *inputParameters,
  A single PaStream can provide multiple channels of real-time
  streaming audio input and output to a client application. A stream
  provides access to audio hardware represented by one or more
- PaDevices. Depending on the underlying Host API, it may be possible 
- to open multiple streams using the same device, however this behavior 
- is implementation defined. Portable applications should assume that 
+ PaDevices. Depending on the underlying Host API, it may be possible
+ to open multiple streams using the same device, however this behavior
+ is implementation defined. Portable applications should assume that
  a PaDevice may be simultaneously used by at most one PaStream.
 
  Pointers to PaStream objects are passed between PortAudio functions that
@@ -679,7 +679,7 @@ typedef unsigned long PaStreamFlags;
 /** Call the stream callback to fill initial output buffers, rather than the
  default behavior of priming the buffers with zeros (silence). This flag has
  no effect for input-only and blocking read/write streams.
- 
+
  @see PaStreamFlags
 */
 #define   paPrimeOutputBuffersUsingStreamCallback ((PaStreamFlags) 0x00000008)
@@ -693,7 +693,7 @@ typedef unsigned long PaStreamFlags;
  Timing information for the buffers passed to the stream callback.
 
  Time values are expressed in seconds and are synchronised with the time base used by Pa_GetStreamTime() for the associated stream.
- 
+
  @see PaStreamCallback, Pa_GetStreamTime
 */
 typedef struct PaStreamCallbackTimeInfo{
@@ -764,41 +764,41 @@ typedef enum PaStreamCallbackResult
  active PortAudio stream.
 
  When a stream is running, PortAudio calls the stream callback periodically.
- The callback function is responsible for processing buffers of audio samples 
+ The callback function is responsible for processing buffers of audio samples
  passed via the input and output parameters.
 
  The PortAudio stream callback runs at very high or real-time priority.
- It is required to consistently meet its time deadlines. Do not allocate 
- memory, access the file system, call library functions or call other functions 
+ It is required to consistently meet its time deadlines. Do not allocate
+ memory, access the file system, call library functions or call other functions
  from the stream callback that may block or take an unpredictable amount of
  time to complete.
 
  In order for a stream to maintain glitch-free operation the callback
  must consume and return audio data faster than it is recorded and/or
- played. PortAudio anticipates that each callback invocation may execute for 
- a duration approaching the duration of frameCount audio frames at the stream 
+ played. PortAudio anticipates that each callback invocation may execute for
+ a duration approaching the duration of frameCount audio frames at the stream
  sample rate. It is reasonable to expect to be able to utilise 70% or more of
- the available CPU time in the PortAudio callback. However, due to buffer size 
- adaption and other factors, not all host APIs are able to guarantee audio 
- stability under heavy CPU load with arbitrary fixed callback buffer sizes. 
- When high callback CPU utilisation is required the most robust behavior 
- can be achieved by using paFramesPerBufferUnspecified as the 
+ the available CPU time in the PortAudio callback. However, due to buffer size
+ adaption and other factors, not all host APIs are able to guarantee audio
+ stability under heavy CPU load with arbitrary fixed callback buffer sizes.
+ When high callback CPU utilisation is required the most robust behavior
+ can be achieved by using paFramesPerBufferUnspecified as the
  Pa_OpenStream() framesPerBuffer parameter.
-     
+
  @param input and @param output are either arrays of interleaved samples or;
- if non-interleaved samples were requested using the paNonInterleaved sample 
- format flag, an array of buffer pointers, one non-interleaved buffer for 
+ if non-interleaved samples were requested using the paNonInterleaved sample
+ format flag, an array of buffer pointers, one non-interleaved buffer for
  each channel.
 
  The format, packing and number of channels used by the buffers are
  determined by parameters to Pa_OpenStream().
-     
+
  @param frameCount The number of sample frames to be processed by
  the stream callback.
 
  @param timeInfo Timestamps indicating the ADC capture time of the first sample
  in the input buffer, the DAC output time of the first sample in the output buffer
- and the time the callback was invoked. 
+ and the time the callback was invoked.
  See PaStreamCallbackTimeInfo and Pa_GetStreamTime()
 
  @param statusFlags Flags indicating whether input and/or output buffers
@@ -836,10 +836,10 @@ typedef int PaStreamCallback(
 
 
 /** Opens a stream for either input, output or both.
-     
+
  @param stream The address of a PaStream pointer which will receive
  a pointer to the newly opened stream.
-     
+
  @param inputParameters A structure that describes the input parameters used by
  the opened stream. See PaStreamParameters for a description of these parameters.
  inputParameters must be NULL for output-only streams.
@@ -847,10 +847,10 @@ typedef int PaStreamCallback(
  @param outputParameters A structure that describes the output parameters used by
  the opened stream. See PaStreamParameters for a description of these parameters.
  outputParameters must be NULL for input-only streams.
- 
+
  @param sampleRate The desired sampleRate. For full-duplex streams it is the
  sample rate for both input and output
-     
+
  @param framesPerBuffer The number of frames passed to the stream callback
  function, or the preferred block granularity for a blocking read/write stream.
  The special value paFramesPerBufferUnspecified (0) may be used to request that
@@ -862,11 +862,11 @@ typedef int PaStreamCallback(
  will be kept to the theoretical minimum however, it is strongly recommended
  that a non-zero framesPerBuffer value only be used when your algorithm
  requires a fixed number of frames per stream callback.
- 
+
  @param streamFlags Flags which modify the behavior of the streaming process.
  This parameter may contain a combination of flags ORed together. Some flags may
  only be relevant to certain buffer formats.
-     
+
  @param streamCallback A pointer to a client supplied function that is responsible
  for processing and filling input and output buffers. If this parameter is NULL
  the stream will be opened in 'blocking read/write' mode. In blocking mode,
@@ -879,7 +879,7 @@ typedef int PaStreamCallback(
  function. It could for example, contain a pointer to instance data necessary
  for processing the audio buffers. This parameter is ignored if streamCallback
  is NULL.
-     
+
  @return
  Upon success Pa_OpenStream() returns paNoError and places a pointer to a
  valid PaStream in the stream argument. The stream is inactive (stopped).
@@ -904,7 +904,7 @@ PaError Pa_OpenStream( PaStream** stream,
 
  @param stream The address of a PaStream pointer which will receive
  a pointer to the newly opened stream.
- 
+
  @param numInputChannels  The number of channels of sound that will be supplied
  to the stream callback or returned by Pa_ReadStream. It can range from 1 to
  the value of maxInputChannels in the PaDeviceInfo record for the default input
@@ -919,7 +919,7 @@ PaError Pa_OpenStream( PaStream** stream,
  provided to the callback or passed to and from Pa_ReadStream and Pa_WriteStream.
  sampleFormat may be any of the formats described by the PaSampleFormat
  enumeration.
- 
+
  @param sampleRate Same as Pa_OpenStream parameter of the same name.
  @param framesPerBuffer Same as Pa_OpenStream parameter of the same name.
  @param streamCallback Same as Pa_OpenStream parameter of the same name.
@@ -945,7 +945,7 @@ PaError Pa_OpenDefaultStream( PaStream** stream,
 PaError Pa_CloseStream( PaStream *stream );
 
 
-/** Functions of type PaStreamFinishedCallback are implemented by PortAudio 
+/** Functions of type PaStreamFinishedCallback are implemented by PortAudio
  clients. They can be registered with a stream using the Pa_SetStreamFinishedCallback
  function. Once registered they are called when the stream becomes inactive
  (ie once a call to Pa_StopStream() will not block).
@@ -954,7 +954,7 @@ PaError Pa_CloseStream( PaStream *stream );
  output, if the stream callback returns paComplete, or Pa_StopStream() is called,
  the stream finished callback will not be called until all generated sample data
  has been played.
- 
+
  @param userData The userData parameter supplied to Pa_OpenStream()
 
  @see Pa_SetStreamFinishedCallback
@@ -962,12 +962,12 @@ PaError Pa_CloseStream( PaStream *stream );
 typedef void PaStreamFinishedCallback( void *userData );
 
 
-/** Register a stream finished callback function which will be called when the 
- stream becomes inactive. See the description of PaStreamFinishedCallback for 
+/** Register a stream finished callback function which will be called when the
+ stream becomes inactive. See the description of PaStreamFinishedCallback for
  further details about when the callback will be called.
 
  @param stream a pointer to a PaStream that is in the stopped state - if the
- stream is not stopped, the stream's finished callback will remain unchanged 
+ stream is not stopped, the stream's finished callback will remain unchanged
  and an error code will be returned.
 
  @param streamFinishedCallback a pointer to a function with the same signature
@@ -980,7 +980,7 @@ typedef void PaStreamFinishedCallback( void *userData );
 
  @see PaStreamFinishedCallback
 */
-PaError Pa_SetStreamFinishedCallback( PaStream *stream, PaStreamFinishedCallback* streamFinishedCallback ); 
+PaError Pa_SetStreamFinishedCallback( PaStream *stream, PaStreamFinishedCallback* streamFinishedCallback );
 
 
 /** Commences audio processing.
@@ -1065,7 +1065,7 @@ typedef struct PaStreamInfo
      parameter passed to Pa_OpenStream().
     */
     double sampleRate;
-    
+
 } PaStreamInfo;
 
 
@@ -1087,15 +1087,15 @@ const PaStreamInfo* Pa_GetStreamInfo( PaStream *stream );
 
 /** Returns the current time in seconds for a stream according to the same clock used
  to generate callback PaStreamCallbackTimeInfo timestamps. The time values are
- monotonically increasing and have unspecified origin. 
- 
+ monotonically increasing and have unspecified origin.
+
  Pa_GetStreamTime returns valid time values for the entire life of the stream,
  from when the stream is opened until it is closed. Starting and stopping the stream
  does not affect the passage of time returned by Pa_GetStreamTime.
 
- This time may be used for synchronizing other events to the audio stream, for 
+ This time may be used for synchronizing other events to the audio stream, for
  example synchronizing audio to MIDI.
-                                        
+
  @return The stream's current time in seconds, or 0 if an error occurred.
 
  @see PaTime, PaStreamCallback, PaStreamCallbackTimeInfo
@@ -1110,7 +1110,7 @@ PaTime Pa_GetStreamTime( PaStream *stream );
 
  This function may be called from the stream callback function or the
  application.
-     
+
  @return
  A floating point value, typically between 0.0 and 1.0, where 1.0 indicates
  that the stream callback is consuming the maximum number of CPU cycles possible
@@ -1127,12 +1127,12 @@ double Pa_GetStreamCpuLoad( PaStream* stream );
  system to supply the data.
 
  @param stream A pointer to an open stream previously created with Pa_OpenStream.
- 
+
  @param buffer A pointer to a buffer of sample frames. The buffer contains
  samples in the format specified by the inputParameters->sampleFormat field
  used to open the stream, and the number of channels specified by
  inputParameters->numChannels. If non-interleaved samples were requested using
- the paNonInterleaved sample format flag, buffer is a pointer to the first element 
+ the paNonInterleaved sample format flag, buffer is a pointer to the first element
  of an array of buffer pointers, one non-interleaved buffer for each channel.
 
  @param frames The number of frames to be read into buffer. This parameter
@@ -1158,7 +1158,7 @@ PaError Pa_ReadStream( PaStream* stream,
  samples in the format specified by the outputParameters->sampleFormat field
  used to open the stream, and the number of channels specified by
  outputParameters->numChannels. If non-interleaved samples were requested using
- the paNonInterleaved sample format flag, buffer is a pointer to the first element 
+ the paNonInterleaved sample format flag, buffer is a pointer to the first element
  of an array of buffer pointers, one non-interleaved buffer for each channel.
 
  @param frames The number of frames to be written from buffer. This parameter


### PR DESCRIPTION
Convert tabs to 4 spaces. Indent by 4 spaces. Strip trailing whitespace. Ensure EOL at EOF.