### PR TITLE
Clean up whitespace in test/ in preparation for .editorconfig. 

### DIFF
--- a/test/pa_minlat.c
+++ b/test/pa_minlat.c
@@ -1,8 +1,8 @@
 /** @file pa_minlat.c
-	@ingroup test_src
+    @ingroup test_src
     @brief Experiment with different numbers of buffers to determine the
-	minimum latency for a computer.
-	@author Phil Burk  http://www.softsynth.com
+    minimum latency for a computer.
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -32,13 +32,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -107,7 +107,7 @@ int main( int argc, char **argv )
     int    framesPerBuffer;
     double sampleRate = 44100.0;
     char   str[256];
-	char  *line;
+    char  *line;
 
     printf("pa_minlat - Determine minimum latency for your computer.\n");
     printf("  usage:         pa_minlat {userBufferSize}\n");
@@ -136,7 +136,7 @@ int main( int argc, char **argv )
         outputParameters.sampleFormat              = paFloat32;                   /* 32 bit floating point output. */
         outputParameters.suggestedLatency          = (double)outLatency / sampleRate; /* In seconds. */
         outputParameters.hostApiSpecificStreamInfo = NULL;
-        
+
         printf("Latency = %d frames = %6.1f msec.\n", outLatency, outputParameters.suggestedLatency * 1000.0 );
 
         err = Pa_OpenStream(
@@ -159,33 +159,33 @@ int main( int argc, char **argv )
         printf("\nMove windows around to see if the sound glitches.\n");
         printf("Latency now %d, enter new number of frames, or 'q' to quit: ", outLatency );
         line = fgets( str, 256, stdin );
-		if( line == NULL )
-		{
-			go = 0;
-		}
-		else
-		{
-			{
-				/* Get rid of newline */
-				size_t l = strlen( str ) - 1;
-				if( str[ l ] == '\n')
-					str[ l ] = '\0';
-			}
-			
-			
-			if( str[0] == 'q' ) go = 0;
-			else
-			{
-				outLatency = atol( str );
-				if( outLatency < minLatency )
-				{
-					printf( "Latency below minimum of %d! Set to minimum!!!\n", minLatency );
-					outLatency = minLatency;
-				}
-			}
-			
-		}
-		/* Stop sound until ENTER hit. */
+        if( line == NULL )
+        {
+            go = 0;
+        }
+        else
+        {
+            {
+                /* Get rid of newline */
+                size_t l = strlen( str ) - 1;
+                if( str[ l ] == '\n')
+                    str[ l ] = '\0';
+            }
+
+
+            if( str[0] == 'q' ) go = 0;
+            else
+            {
+                outLatency = atol( str );
+                if( outLatency < minLatency )
+                {
+                    printf( "Latency below minimum of %d! Set to minimum!!!\n", minLatency );
+                    outLatency = minLatency;
+                }
+            }
+
+        }
+        /* Stop sound until ENTER hit. */
         err = Pa_StopStream( stream );
         if( err != paNoError ) goto error;
         err = Pa_CloseStream( stream );

--- a/test/patest1.c
+++ b/test/patest1.c
@@ -1,7 +1,7 @@
 /** @file patest1.c
-	@ingroup test_src
-	@brief Ring modulate the audio input with a sine wave for 20 seconds.
-	@author Ross Bencina <rossb@audiomulch.com>
+    @ingroup test_src
+    @brief Ring modulate the audio input with a sine wave for 20 seconds.
+    @author Ross Bencina <rossb@audiomulch.com>
 */
 /*
  * $Id$
@@ -31,13 +31,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -98,7 +98,7 @@ static int patest1Callback( const void *inputBuffer, void *outputBuffer,
         *out++ = 0; /* left */
         *out++ = 0; /* right */
     }
-    
+
     return finished;
 }
 
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
 
     printf("patest1.c\n"); fflush(stdout);
     printf("Ring modulate input for 20 seconds.\n"); fflush(stdout);
-    
+
     /* initialise sinusoidal wavetable */
     for( i=0; i<100; i++ )
         data.sine[i] = sin( ((double)i/100.) * M_PI * 2. );
@@ -126,8 +126,8 @@ int main(int argc, char* argv[])
 
     inputParameters.device = Pa_GetDefaultInputDevice();    /* default input device */
     if (inputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No input default device.\n");
-      goto done;
+        printf(stderr,"Error: No input default device.\n");
+        goto done;
     }
     inputParameters.channelCount = 2;                       /* stereo input */
     inputParameters.sampleFormat = paFloat32;               /* 32 bit floating point input */
@@ -136,8 +136,8 @@ int main(int argc, char* argv[])
 
     outputParameters.device = Pa_GetDefaultOutputDevice();  /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto done;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto done;
     }
     outputParameters.channelCount = 2;                      /* stereo output */
     outputParameters.sampleFormat = paFloat32;              /* 32 bit floating point output */
@@ -157,14 +157,14 @@ int main(int argc, char* argv[])
 
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto done;
-    
+
     printf( "Press any key to end.\n" ); fflush(stdout);
-         
+
     getc( stdin ); /* wait for input before exiting */
 
     err = Pa_AbortStream( stream );
     if( err != paNoError ) goto done;
-    
+
     printf( "Waiting for stream to complete...\n" );
 
     /* sleep until playback has finished */

--- a/test/patest_buffer.c
+++ b/test/patest_buffer.c
@@ -1,7 +1,7 @@
 /** @file patest_buffer.c
-	@ingroup test_src
-	@brief Test opening streams with different buffer sizes.
-	@author Phil Burk  http://www.softsynth.com
+    @ingroup test_src
+    @brief Test opening streams with different buffer sizes.
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -31,13 +31,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -128,10 +128,10 @@ int main(int argc, char **args)
     PaError err;
     printf("Test opening streams with different buffer sizes\n");
     if( argc > 1 ) {
-       device=atoi( args[1] );
-       printf("Using device number %d.\n\n", device );
+        device=atoi( args[1] );
+        printf("Using device number %d.\n\n", device );
     } else {
-       printf("Using default device.\n\n" );
+        printf("Using default device.\n\n" );
     }
 
     for (i = 0 ; i < BUFFER_TABLE; i++)
@@ -162,15 +162,15 @@ PaError TestOnce( int buffersize, PaDeviceIndex device )
     data.sampsToGo = totalSamps =  NUM_SECONDS * SAMPLE_RATE; /* Play for a few seconds. */
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
-    
+
     if( device == -1 )
         outputParameters.device = Pa_GetDefaultOutputDevice(); /* default output device */
     else
         outputParameters.device = device ;
 
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
 
     outputParameters.channelCount = 2;                      /* stereo output */

--- a/test/patest_callbackstop.c
+++ b/test/patest_callbackstop.c
@@ -1,7 +1,7 @@
 /** @file patest_callbackstop.c
-	@ingroup test_src
-	@brief Test the paComplete callback result code.
-	@author Ross Bencina <rossb@audiomulch.com>
+    @ingroup test_src
+    @brief Test the paComplete callback result code.
+    @author Ross Bencina <rossb@audiomulch.com>
 */
 /*
  * $Id$
@@ -31,13 +31,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -86,18 +86,18 @@ static int TestCallback( const void *input, void *output,
     (void) timeInfo;
     (void) statusFlags;
 
-    
+
     if( data->callbackReturnedPaComplete )
         data->callbackInvokedAfterReturningPaComplete = 1;
 
     for( i=0; i<frameCount; i++ )
     {
         /* generate tone */
-        
+
         x = data->sine[ data->phase++ ];
         if( data->phase >= TABLE_SIZE )
             data->phase -= TABLE_SIZE;
-        
+
         *out++ = x;  /* left */
         *out++ = x;  /* right */
     }
@@ -119,8 +119,8 @@ static int TestCallback( const void *input, void *output,
  */
 static void StreamFinished( void* userData )
 {
-   TestData *data = (TestData *) userData;
-   printf( "Stream Completed: %s\n", data->message );
+    TestData *data = (TestData *) userData;
+    printf( "Stream Completed: %s\n", data->message );
 }
 
 
@@ -134,23 +134,23 @@ int main(void)
     TestData data;
     int i, j;
 
-    
+
     printf( "PortAudio Test: output sine wave. SR = %d, BufSize = %d\n",
             SAMPLE_RATE, FRAMES_PER_BUFFER );
-    
+
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
     {
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
     outputParameters.device                    = Pa_GetDefaultOutputDevice();
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount              = 2;               /* stereo output */
     outputParameters.sampleFormat              = paFloat32;       /* 32 bit floating point output */
@@ -173,7 +173,7 @@ int main(void)
     if( err != paNoError ) goto error;
 
     printf("Repeating test %d times.\n", NUM_LOOPS );
-    
+
     for( i=0; i < NUM_LOOPS; ++i )
     {
         data.phase = 0;
@@ -201,7 +201,7 @@ int main(void)
         /* wait for stream to become inactive,
            or for a timeout of approximately NUM_SECONDS
          */
-     
+
         j = 0;
         while( (err = Pa_IsStreamActive( stream )) == 1 && j < NUM_SECONDS * 2 )
         {
@@ -241,7 +241,7 @@ int main(void)
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_clip.c
+++ b/test/patest_clip.c
@@ -1,9 +1,9 @@
 /** @file patest_clip.c
-	@ingroup test_src
-	@brief Play a sine wave for several seconds at an amplitude 
-	that would require clipping.
+    @ingroup test_src
+    @brief Play a sine wave for several seconds at an amplitude
+    that would require clipping.
 
-	@author Phil Burk  http://www.softsynth.com
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -132,7 +132,7 @@ int main(void)
     fflush(stdout);
     err = PlaySine( &data, paClipOff, 1.1f );
     if( err < 0 ) goto error;
-    
+
     return 0;
 error:
     fprintf( stderr, "An error occurred while using the portaudio stream\n" );
@@ -149,20 +149,20 @@ PaError PlaySine( paTestData *data, unsigned long flags, float amplitude )
 
     data->left_phase = data->right_phase = 0;
     data->amplitude = amplitude;
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;       /* stereo output */
     outputParameters.sampleFormat = paFloat32; /* 32 bit floating point output */
     outputParameters.suggestedLatency = Pa_GetDeviceInfo( outputParameters.device )->defaultLowOutputLatency;
     outputParameters.hostApiSpecificStreamInfo = NULL;
-    
+
     err = Pa_OpenStream(
               &stream,
               NULL, /* no input */
@@ -182,7 +182,7 @@ PaError PlaySine( paTestData *data, unsigned long flags, float amplitude )
 
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
-    
+
     Pa_Terminate();
     return paNoError;
 error:

--- a/test/patest_converters.c
+++ b/test/patest_converters.c
@@ -1,7 +1,7 @@
 /** @file patest_converters.c
-	@ingroup test_src
-	@brief Tests the converter functions in pa_converters.c
-	@author Ross Bencina <rossb@audiomulch.com>
+    @ingroup test_src
+    @brief Tests the converter functions in pa_converters.c
+    @author Ross Bencina <rossb@audiomulch.com>
 
     Link with pa_dither.c and pa_converters.c
 
@@ -35,13 +35,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>
@@ -65,14 +65,14 @@
 
 #define SAMPLE_FORMAT_COUNT (6)
 
-static PaSampleFormat sampleFormats_[ SAMPLE_FORMAT_COUNT ] = 
+static PaSampleFormat sampleFormats_[ SAMPLE_FORMAT_COUNT ] =
     { paFloat32, paInt32, paInt24, paInt16, paInt8, paUInt8 }; /* all standard PA sample formats */
 
-static const char* sampleFormatNames_[SAMPLE_FORMAT_COUNT] = 
+static const char* sampleFormatNames_[SAMPLE_FORMAT_COUNT] =
     { "paFloat32", "paInt32", "paInt24", "paInt16", "paInt8", "paUInt8" };
 
 
-static const char* abbreviatedSampleFormatNames_[SAMPLE_FORMAT_COUNT] = 
+static const char* abbreviatedSampleFormatNames_[SAMPLE_FORMAT_COUNT] =
     { "f32", "i32", "i24", "i16", " i8", "ui8" };
 
 
@@ -140,7 +140,7 @@ static void GenerateOneCycleSine( PaSampleFormat format, void *buffer, int frame
                 unsigned char *out = (unsigned char*)buffer;
                 for( i=0; i < frameCount; ++i ){
                     signed long temp = (PaInt32)(.9 * sin( ((double)i/(double)frameCount) * 2. * M_PI ) * 0x7FFFFFFF);
-                    
+
                     #if defined(PA_LITTLE_ENDIAN)
                             out[0] = (unsigned char)(temp >> 8) & 0xFF;
                             out[1] = (unsigned char)(temp >> 16) & 0xFF;
@@ -193,11 +193,11 @@ int TestNonZeroPresent( void *buffer, int size )
     int i;
 
     for( i=0; i < size; ++i ){
-    
+
         if( *p != 0 )
             return 1;
         ++p;
-    }   
+    }
 
     return 0;
 }
@@ -213,7 +213,7 @@ float MaximumAbsDifference( float* sourceBuffer, float* referenceBuffer, int cou
     }
 
     return result;
-}  
+}
 
 int main( const char **argv, int argc )
 {
@@ -286,7 +286,7 @@ int main( const char **argv, int argc )
                     passFailMatrix[sourceFormatIndex][destinationFormatIndex] = 0;
                 }
 
-                
+
                 /* try to measure the noise floor (comparing output signal to a float32 sine wave) */
 
                 if( passFailMatrix[sourceFormatIndex][destinationFormatIndex] ){
@@ -298,9 +298,9 @@ int main( const char **argv, int argc )
                     (*converter)( sourceBuffer, 1, destinationBuffer, 1, MAX_PER_CHANNEL_FRAME_COUNT, &ditherState );
 
                     if( TestNonZeroPresent( sourceBuffer, MAX_PER_CHANNEL_FRAME_COUNT * My_Pa_GetSampleSize( paFloat32 ) ) ){
-    
+
                         noiseAmplitudeMatrix[sourceFormatIndex][destinationFormatIndex] = MaximumAbsDifference( (float*)sourceBuffer, (float*)referenceBuffer, MAX_PER_CHANNEL_FRAME_COUNT );
-                        
+
                     }else{
                         /* can't test noise floor because there is no conversion from dest format to float available */
                         noiseAmplitudeMatrix[sourceFormatIndex][destinationFormatIndex] = -1; // mark as failed

--- a/test/patest_dither.c
+++ b/test/patest_dither.c
@@ -1,10 +1,10 @@
 /** @file patest_dither.c
-	@ingroup test_src
-	@brief Attempt to hear difference between dithered and non-dithered signal.
+    @ingroup test_src
+    @brief Attempt to hear difference between dithered and non-dithered signal.
 
-	This only has an effect if the native format is 16 bit.
+    This only has an effect if the native format is 16 bit.
 
-	@author Phil Burk  http://www.softsynth.com
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -34,13 +34,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -64,22 +64,22 @@ typedef struct paTestData
     int   right_phase;
 }
 paTestData;
-                         
+
 /* This routine will be called by the PortAudio engine when audio is needed.
 ** It may called at interrupt level on some machines so don't do anything
 ** that could mess up the system like calling malloc() or free().
 */
 static int sineCallback( const void *inputBuffer, void *outputBuffer,
                          unsigned long framesPerBuffer,
-			             const PaStreamCallbackTimeInfo *timeInfo,
-			             PaStreamCallbackFlags statusFlags, void *userData )
+                         const PaStreamCallbackTimeInfo *timeInfo,
+                         PaStreamCallbackFlags statusFlags, void *userData )
 {
     paTestData *data = (paTestData*)userData;
     float *out = (float*)outputBuffer;
     float amplitude = data->amplitude;
     unsigned int i;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         *out++ = amplitude * data->sine[data->left_phase];  /* left */
@@ -113,14 +113,14 @@ PaError PlaySine( paTestData *data, PaStreamFlags flags, float amplitude )
 
     outputParameters.device = Pa_GetDefaultOutputDevice();  /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto done;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto done;
     }
     outputParameters.channelCount = 2;                      /* stereo output */
     outputParameters.hostApiSpecificStreamInfo = NULL;
     outputParameters.sampleFormat = paFloat32;      /* 32 bit floating point output. */
                                                     /* When you change this, also    */
-                                                    /* adapt the callback routine!   */ 
+                                                    /* adapt the callback routine!   */
     outputParameters.suggestedLatency = Pa_GetDeviceInfo( outputParameters.device )
                                         ->defaultLowOutputLatency;   /* Low latency. */
     err = Pa_OpenStream( &stream,
@@ -140,7 +140,7 @@ PaError PlaySine( paTestData *data, PaStreamFlags flags, float amplitude )
 
     Pa_Sleep( NUM_SECONDS * 1000 );
     printf("CPULoad = %8.6f\n", Pa_GetStreamCpuLoad(stream));
-    
+
     err = Pa_CloseStream( stream );
 done:
     Pa_Sleep( 250 );  /* Just a small silence. */
@@ -157,7 +157,7 @@ int main(void)
     paTestData  DATA;
     int         i;
     float       amplitude = 4.0 / (1<<15);
-    
+
     printf("PortAudio Test: output EXTREMELY QUIET sine wave with and without dithering.\n");
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )

--- a/test/patest_dsound_find_best_latency_params.c
+++ b/test/patest_dsound_find_best_latency_params.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -40,7 +40,7 @@
 #include <time.h>
 #include <math.h>
 
-#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */ 
+#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */
 #include <windows.h>
 //#include <mmsystem.h>   /* required when using pa_win_wmme.h */
 
@@ -102,11 +102,11 @@ static void printWindowsVersionInfo( FILE *fp )
     osVersionInfoEx.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
     GetVersionEx( &osVersionInfoEx );
 
-    
+
     if( osVersionInfoEx.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS ){
         switch( osVersionInfoEx.dwMinorVersion ){
             case 0: osName = "Windows 95"; break;
-            case 10: osName = "Windows 98"; break;  // could also be 98SE (I've seen code discriminate based 
+            case 10: osName = "Windows 98"; break;  // could also be 98SE (I've seen code discriminate based
                                                     // on osInfo.Version.Revision.ToString() == "2222A")
             case 90: osName = "Windows Me"; break;
         }
@@ -132,13 +132,13 @@ static void printWindowsVersionInfo( FILE *fp )
                             }break;
                     }break;
             case 6:switch( osVersionInfoEx.dwMinorVersion ){
-                        case 0: 
+                        case 0:
                             if( osVersionInfoEx.wProductType == VER_NT_WORKSTATION )
                                 osName = "Windows Vista";
                             else
                                 osName = "Windows Server 2008";
                             break;
-                        case 1: 
+                        case 1:
                             if( osVersionInfoEx.wProductType == VER_NT_WORKSTATION )
                                 osName = "Windows 7";
                             else
@@ -166,7 +166,7 @@ static void printWindowsVersionInfo( FILE *fp )
         }
         else if(osVersionInfoEx.wProductType == VER_NT_SERVER)
         {
-            if(osVersionInfoEx.dwMinorVersion == 0) 
+            if(osVersionInfoEx.dwMinorVersion == 0)
             {
                 if((osVersionInfoEx.wSuiteMask & VER_SUITE_DATACENTER) == VER_SUITE_DATACENTER)
                     osProductType = "Datacenter Server"; // Windows 2000 Datacenter Server
@@ -201,8 +201,8 @@ static void printWindowsVersionInfo( FILE *fp )
 
 
     fprintf( fp, "OS name and edition: %s %s\n", osName, osProductType );
-    fprintf( fp, "OS version: %d.%d.%d %S\n", 
-                osVersionInfoEx.dwMajorVersion, osVersionInfoEx.dwMinorVersion, 
+    fprintf( fp, "OS version: %d.%d.%d %S\n",
+                osVersionInfoEx.dwMajorVersion, osVersionInfoEx.dwMinorVersion,
                 osVersionInfoEx.dwBuildNumber, osVersionInfoEx.szCSDVersion );
     fprintf( fp, "Processor architecture: %s\n", processorArchitecture );
     fprintf( fp, "WoW64 process: %s\n", IsWow64() ? "Yes" : "No" );
@@ -225,7 +225,7 @@ static void printTimeAndDate( FILE *fp )
 typedef struct
 {
     float sine[TABLE_SIZE];
-	double phase;
+    double phase;
     double phaseIncrement;
     volatile int fadeIn;
     volatile int fadeOut;
@@ -252,14 +252,14 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         float x = data->sine[(int)data->phase];
         data->phase += data->phaseIncrement;
         if( data->phase >= TABLE_SIZE ){
-			data->phase -= TABLE_SIZE;
-		}
+            data->phase -= TABLE_SIZE;
+        }
 
         x *= data->amp;
         if( data->fadeIn ){
@@ -271,11 +271,11 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
                 data->amp -= .001;
         }
 
-		for( j = 0; j < CHANNEL_COUNT; ++j ){
+        for( j = 0; j < CHANNEL_COUNT; ++j ){
             *out++ = x;
-		}
-	}
-    
+        }
+    }
+
     if( data->amp > 0 )
         return paContinue;
     else
@@ -287,7 +287,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
 #define NO      0
 
 
-static int playUntilKeyPress( int deviceIndex, float sampleRate, 
+static int playUntilKeyPress( int deviceIndex, float sampleRate,
                              int framesPerUserBuffer, int framesPerDSoundBuffer )
 {
     PaStreamParameters outputParameters;
@@ -303,7 +303,7 @@ static int playUntilKeyPress( int deviceIndex, float sampleRate,
     outputParameters.hostApiSpecificStreamInfo = NULL;
 
     directSoundStreamInfo.size = sizeof(PaWinDirectSoundStreamInfo);
-    directSoundStreamInfo.hostApiType = paDirectSound; 
+    directSoundStreamInfo.hostApiType = paDirectSound;
     directSoundStreamInfo.version = 2;
     directSoundStreamInfo.flags = paWinDirectSoundUseLowLevelLatencyParameters;
     directSoundStreamInfo.framesPerBuffer = framesPerDSoundBuffer;
@@ -373,7 +373,7 @@ static void usage( int dsoundHostApiIndex )
 }
 
 /*
-    ideas: 
+    ideas:
         o- could be testing with 80% CPU load
         o- could test with different channel counts
 */
@@ -401,15 +401,15 @@ int main(int argc, char* argv[])
     if( argc > 3 )
         usage(dsoundHostApiIndex);
 
-	deviceIndex = dsoundHostApiInfo->defaultOutputDevice;
-	if( argc >= 2 ){
+    deviceIndex = dsoundHostApiInfo->defaultOutputDevice;
+    if( argc >= 2 ){
         deviceIndex = -1;
-		if( sscanf( argv[1], "%d", &deviceIndex ) != 1 )
+        if( sscanf( argv[1], "%d", &deviceIndex ) != 1 )
             usage(dsoundHostApiInfo);
         if( deviceIndex < 0 || deviceIndex >= Pa_GetDeviceCount() || Pa_GetDeviceInfo(deviceIndex)->hostApi != dsoundHostApiIndex ){
             usage(dsoundHostApiInfo);
         }
-	}
+    }
 
     printf( "Using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
 
@@ -420,7 +420,7 @@ int main(int argc, char* argv[])
 
     printf( "Testing with sample rate %f.\n", (float)sampleRate );
 
- 
+
 
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
@@ -428,14 +428,14 @@ int main(int argc, char* argv[])
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
 
-	data.phase = 0;
+    data.phase = 0;
 
     resultsFp = fopen( "results.txt", "at" );
     fprintf( resultsFp, "*** DirectSound smallest working output buffer sizes\n" );
 
     printTimeAndDate( resultsFp );
     printWindowsVersionInfo( resultsFp );
-    
+
     fprintf( resultsFp, "audio device: %s\n", Pa_GetDeviceInfo( deviceIndex )->name );
     fflush( resultsFp );
 
@@ -463,7 +463,7 @@ int main(int argc, char* argv[])
         }else{
             min = mid + 1;
         }
-         
+
     }while( (min <= max) && (testResult == YES || testResult == NO) );
 
     smallestWorkingBufferingLatencyFrames = smallestWorkingBufferSize; /* not strictly true, but we're using an unspecified callback size, so kind of */
@@ -490,7 +490,7 @@ int main(int argc, char* argv[])
         }
 
     }while( (dsoundBufferSize <= (int)(sampleRate * .3)) && testResult == NO );
-    
+
     smallestWorkingBufferingLatencyFrames = smallestWorkingBufferSize; /* not strictly true, but we're using an unspecified callback size, so kind of */
 
     fprintf( resultsFp, "%d, %d, %f\n", smallestWorkingBufferSize, smallestWorkingBufferingLatencyFrames, smallestWorkingBufferingLatencyFrames / sampleRate );
@@ -499,10 +499,10 @@ int main(int argc, char* argv[])
 
     fprintf( resultsFp, "###\n" );
     fclose( resultsFp );
-    
+
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_dsound_low_level_latency_params.c
+++ b/test/patest_dsound_low_level_latency_params.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -61,7 +61,7 @@
 typedef struct
 {
     float sine[TABLE_SIZE];
-	double phase;
+    double phase;
 }
 paTestData;
 
@@ -82,20 +82,20 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         float x = data->sine[(int)data->phase];
         data->phase += 20;
         if( data->phase >= TABLE_SIZE ){
-			data->phase -= TABLE_SIZE;
-		}
+            data->phase -= TABLE_SIZE;
+        }
 
-		for( j = 0; j < CHANNEL_COUNT; ++j ){
+        for( j = 0; j < CHANNEL_COUNT; ++j ){
             *out++ = x;
-		}
-	}
-    
+        }
+    }
+
     return paContinue;
 }
 
@@ -115,12 +115,12 @@ int main(int argc, char* argv[])
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
-	deviceIndex = Pa_GetHostApiInfo( Pa_HostApiTypeIdToHostApiIndex( paDirectSound ) )->defaultOutputDevice;
-	if( argc == 2 ){
-		sscanf( argv[1], "%d", &deviceIndex );
-	}
+    deviceIndex = Pa_GetHostApiInfo( Pa_HostApiTypeIdToHostApiIndex( paDirectSound ) )->defaultOutputDevice;
+    if( argc == 2 ){
+        sscanf( argv[1], "%d", &deviceIndex );
+    }
 
-	printf( "using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
+    printf( "using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
 
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
 
-	data.phase = 0;
+    data.phase = 0;
 
     outputParameters.device = deviceIndex;
     outputParameters.channelCount = CHANNEL_COUNT;
@@ -137,18 +137,18 @@ int main(int argc, char* argv[])
     outputParameters.hostApiSpecificStreamInfo = NULL;
 
     dsoundStreamInfo.size = sizeof(PaWinDirectSoundStreamInfo);
-    dsoundStreamInfo.hostApiType = paDirectSound; 
+    dsoundStreamInfo.hostApiType = paDirectSound;
     dsoundStreamInfo.version = 2;
     dsoundStreamInfo.flags = paWinDirectSoundUseLowLevelLatencyParameters;
     dsoundStreamInfo.framesPerBuffer = DSOUND_FRAMES_PER_HOST_BUFFER;
     outputParameters.hostApiSpecificStreamInfo = &dsoundStreamInfo;
-   
 
-	if( Pa_IsFormatSupported( 0, &outputParameters, SAMPLE_RATE ) == paFormatIsSupported  ){
-		printf( "Pa_IsFormatSupported reports device will support %d channels.\n", CHANNEL_COUNT );
-	}else{
-		printf( "Pa_IsFormatSupported reports device will not support %d channels.\n", CHANNEL_COUNT );
-	}
+
+    if( Pa_IsFormatSupported( 0, &outputParameters, SAMPLE_RATE ) == paFormatIsSupported  ){
+        printf( "Pa_IsFormatSupported reports device will support %d channels.\n", CHANNEL_COUNT );
+    }else{
+        printf( "Pa_IsFormatSupported reports device will not support %d channels.\n", CHANNEL_COUNT );
+    }
 
     err = Pa_OpenStream(
               &stream,
@@ -175,7 +175,7 @@ int main(int argc, char* argv[])
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_dsound_surround.c
+++ b/test/patest_dsound_surround.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -62,9 +62,9 @@
 typedef struct
 {
     float sine[TABLE_SIZE];
-	int phase;
-	int currentChannel;
-	int cycleCount;
+    int phase;
+    int currentChannel;
+    int cycleCount;
 }
 paTestData;
 
@@ -85,31 +85,31 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
-		for( j = 0; j < CHANNEL_COUNT; ++j ){
-			if( j == data->currentChannel && data->cycleCount < 4410 ){
-				*out++ = data->sine[data->phase];
-				data->phase += 1 + j;	// play each channel at a different pitch so they can be distinguished
-				if( data->phase >= TABLE_SIZE ){
-					data->phase -= TABLE_SIZE;
-				}
-			}else{
-				*out++ = 0;
-			}
-		}
-    
-		data->cycleCount++;
-		if( data->cycleCount > 44100 ){
-			data->cycleCount = 0;
+        for( j = 0; j < CHANNEL_COUNT; ++j ){
+            if( j == data->currentChannel && data->cycleCount < 4410 ){
+                *out++ = data->sine[data->phase];
+                data->phase += 1 + j;    // play each channel at a different pitch so they can be distinguished
+                if( data->phase >= TABLE_SIZE ){
+                    data->phase -= TABLE_SIZE;
+                }
+            }else{
+                *out++ = 0;
+            }
+        }
 
-			++data->currentChannel;
-			if( data->currentChannel >= CHANNEL_COUNT )
-				data->currentChannel -= CHANNEL_COUNT;
-		}
-	}
-    
+        data->cycleCount++;
+        if( data->cycleCount > 44100 ){
+            data->cycleCount = 0;
+
+            ++data->currentChannel;
+            if( data->currentChannel >= CHANNEL_COUNT )
+                data->currentChannel -= CHANNEL_COUNT;
+        }
+    }
+
     return paContinue;
 }
 
@@ -129,12 +129,12 @@ int main(int argc, char* argv[])
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
-	deviceIndex = Pa_GetHostApiInfo( Pa_HostApiTypeIdToHostApiIndex( paDirectSound ) )->defaultOutputDevice;
-	if( argc == 2 ){
-		sscanf( argv[1], "%d", &deviceIndex );
-	}
+    deviceIndex = Pa_GetHostApiInfo( Pa_HostApiTypeIdToHostApiIndex( paDirectSound ) )->defaultOutputDevice;
+    if( argc == 2 ){
+        sscanf( argv[1], "%d", &deviceIndex );
+    }
 
-	printf( "using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
+    printf( "using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
 
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
@@ -142,9 +142,9 @@ int main(int argc, char* argv[])
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
 
-	data.phase = 0;
-	data.currentChannel = 0;
-	data.cycleCount = 0;
+    data.phase = 0;
+    data.currentChannel = 0;
+    data.cycleCount = 0;
 
     outputParameters.device = deviceIndex;
     outputParameters.channelCount = CHANNEL_COUNT;
@@ -156,17 +156,17 @@ int main(int argc, char* argv[])
        output. But if you want to be sure which channel mask PortAudio will use
        then you should supply one */
     directSoundStreamInfo.size = sizeof(PaWinDirectSoundStreamInfo);
-    directSoundStreamInfo.hostApiType = paDirectSound; 
+    directSoundStreamInfo.hostApiType = paDirectSound;
     directSoundStreamInfo.version = 1;
     directSoundStreamInfo.flags = paWinDirectSoundUseChannelMask;
     directSoundStreamInfo.channelMask = PAWIN_SPEAKER_5POINT1; /* request 5.1 output format */
     outputParameters.hostApiSpecificStreamInfo = &directSoundStreamInfo;
 
-	if( Pa_IsFormatSupported( 0, &outputParameters, SAMPLE_RATE ) == paFormatIsSupported  ){
-		printf( "Pa_IsFormatSupported reports device will support %d channels.\n", CHANNEL_COUNT );
-	}else{
-		printf( "Pa_IsFormatSupported reports device will not support %d channels.\n", CHANNEL_COUNT );
-	}
+    if( Pa_IsFormatSupported( 0, &outputParameters, SAMPLE_RATE ) == paFormatIsSupported  ){
+        printf( "Pa_IsFormatSupported reports device will support %d channels.\n", CHANNEL_COUNT );
+    }else{
+        printf( "Pa_IsFormatSupported reports device will not support %d channels.\n", CHANNEL_COUNT );
+    }
 
     err = Pa_OpenStream(
               &stream,
@@ -193,7 +193,7 @@ int main(int argc, char* argv[])
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_hang.c
+++ b/test/patest_hang.c
@@ -1,8 +1,8 @@
 /** @file patest_hang.c
-	@ingroup test_src
-	@brief Play a sine then hang audio callback to test watchdog.
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @ingroup test_src
+    @brief Play a sine then hang audio callback to test watchdog.
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -32,13 +32,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -77,7 +77,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     int finished = 0;
     double phaseInc = 0.02;
     double phase = data->phase;
-    
+
     (void) inputBuffer; /* Prevent unused argument warning. */
 
     for( i=0; i<framesPerBuffer; i++ )
@@ -87,12 +87,12 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
         /* This is not a very efficient way to calc sines. */
         *out++ = (float) sin( phase ); /* mono */
     }
-    
+
     if( data->sleepFor > 0 )
     {
         Pa_Sleep( data->sleepFor );
     }
-    
+
     data->phase = phase;
     return finished;
 }
@@ -106,7 +106,7 @@ int main(void)
     PaError             err;
     int                 i;
     paTestData          data = {0};
-    
+
     printf("PortAudio Test: output sine wave. SR = %d, BufSize = %d\n",
         SAMPLE_RATE, FRAMES_PER_BUFFER );
 
@@ -115,8 +115,8 @@ int main(void)
 
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* Default output device. */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 1;                     /* Mono output. */
     outputParameters.sampleFormat = paFloat32;             /* 32 bit floating point. */
@@ -132,7 +132,7 @@ int main(void)
                         patestCallback,
                         &data);
     if (err != paNoError) goto error;
-    
+
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;
 
@@ -144,10 +144,10 @@ int main(void)
         data.sleepFor = i;
         Pa_Sleep( ((i<1000) ? 1000 : i) );
     }
-    
+
     printf("Suffer for 10 seconds.\n");
     Pa_Sleep( 10000 );
-    
+
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
     err = Pa_CloseStream( stream );

--- a/test/patest_in_overflow.c
+++ b/test/patest_in_overflow.c
@@ -1,14 +1,14 @@
 /** @file patest_in_overflow.c
-	@ingroup test_src
-	@brief Count input overflows (using paInputOverflow flag) under 
-	overloaded and normal conditions.
+    @ingroup test_src
+    @brief Count input overflows (using paInputOverflow flag) under
+    overloaded and normal conditions.
     This test uses the same method to overload the stream as does
     patest_out_underflow.c -- it generates sine waves until the cpu load
     exceeds a certain level. However this test is only concerned with
     input and so doesn't output any sound.
-    
+
     @author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -38,13 +38,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -141,8 +141,8 @@ int main(void)
 
     inputParameters.device = Pa_GetDefaultInputDevice();  /* default input device */
     if (inputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default input device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default input device.\n");
+        goto error;
     }
     inputParameters.channelCount = 1;                      /* mono output */
     inputParameters.sampleFormat = paFloat32;              /* 32 bit floating point output */
@@ -157,7 +157,7 @@ int main(void)
               FRAMES_PER_BUFFER,
               paClipOff,    /* we won't output out of range samples so don't bother clipping them */
               patestCallback,
-              &data );    
+              &data );
     if( err != paNoError ) goto error;
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;
@@ -187,7 +187,7 @@ int main(void)
         load = Pa_GetStreamCpuLoad( stream );
         printf("STRESSING: sineCount = %d, CPU load = %f\n", data.sineCount, load );
     }
-    
+
     printf("Counting overflows for 5 seconds.\n");
     data.countOverflows = 1;
     Pa_Sleep( 5000 );
@@ -209,14 +209,14 @@ int main(void)
     Pa_Sleep( 5000 );
 
     safeOverflowCount = data.inputOverflowCount;
-    
+
     printf("Stop stream.\n");
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
-    
+
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
-    
+
     Pa_Terminate();
 
     if( stressedOverflowCount == 0 )

--- a/test/patest_jack_wasapi.c
+++ b/test/patest_jack_wasapi.c
@@ -1,7 +1,7 @@
 /** @file pa_test_jack_wasapi.c
-	@ingroup test_src
-	@brief Print out jack information for WASAPI endpoints
-	@author Reid Bishop <rbish@attglobal.net>
+    @ingroup test_src
+    @brief Print out jack information for WASAPI endpoints
+    @author Reid Bishop <rbish@attglobal.net>
 */
 /*
  * $Id: pa_test_jack_wasapi.c 1368 2008-03-01 00:38:27Z rbishop $
@@ -31,13 +31,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>
@@ -51,7 +51,7 @@
 */
 static int IsInMask(int val, int val2)
 {
-	return ((val & val2) == val2);
+    return ((val & val2) == val2);
 }
 
 /*
@@ -60,50 +60,50 @@ static int IsInMask(int val, int val2)
 
 static void EnumIJackChannels(int channelMapping)
 {
-	printf("Channel Mapping: ");
-	if(channelMapping == PAWIN_SPEAKER_DIRECTOUT)
-	{
-		printf("DIRECTOUT\n");
-		return;
-	}
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_LEFT))
-		printf("FRONT_LEFT, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_RIGHT))
-		printf("FRONT_RIGHT, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_CENTER))
-		printf("FRONT_CENTER, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_LOW_FREQUENCY))
-		printf("LOW_FREQUENCY, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_BACK_LEFT))
-		printf("BACK_LEFT, ");
-	if(IsInMask(channelMapping,PAWIN_SPEAKER_BACK_RIGHT))
-		printf("BACK_RIGHT, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER))
-		printf("FRONT_LEFT_OF_CENTER, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER))
-		printf("FRONT_RIGHT_OF_CENTER, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_BACK_CENTER))
-		printf("BACK_CENTER, ");
-	if(IsInMask(channelMapping,PAWIN_SPEAKER_SIDE_LEFT))
-		printf("SIDE_LEFT, ");
-	if(IsInMask(channelMapping,PAWIN_SPEAKER_SIDE_RIGHT))
-		printf("SIDE_RIGHT, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_CENTER))
-		printf("TOP_CENTER, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_FRONT_LEFT))
-		printf("TOP_FRONT_LEFT, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_FRONT_CENTER))
-		printf("TOP_FRONT_CENTER, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_FRONT_RIGHT))
-		printf("TOP_FRONT_RIGHT, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_BACK_LEFT))
-		printf("TOP_BACK_LEFT, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_BACK_CENTER))
-		printf("TOP_BACK_CENTER, ");
-	if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_BACK_RIGHT))
-		printf("TOP_BACK_RIGHT, ");
+    printf("Channel Mapping: ");
+    if(channelMapping == PAWIN_SPEAKER_DIRECTOUT)
+    {
+        printf("DIRECTOUT\n");
+        return;
+    }
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_LEFT))
+        printf("FRONT_LEFT, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_RIGHT))
+        printf("FRONT_RIGHT, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_CENTER))
+        printf("FRONT_CENTER, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_LOW_FREQUENCY))
+        printf("LOW_FREQUENCY, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_BACK_LEFT))
+        printf("BACK_LEFT, ");
+    if(IsInMask(channelMapping,PAWIN_SPEAKER_BACK_RIGHT))
+        printf("BACK_RIGHT, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_LEFT_OF_CENTER))
+        printf("FRONT_LEFT_OF_CENTER, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_FRONT_RIGHT_OF_CENTER))
+        printf("FRONT_RIGHT_OF_CENTER, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_BACK_CENTER))
+        printf("BACK_CENTER, ");
+    if(IsInMask(channelMapping,PAWIN_SPEAKER_SIDE_LEFT))
+        printf("SIDE_LEFT, ");
+    if(IsInMask(channelMapping,PAWIN_SPEAKER_SIDE_RIGHT))
+        printf("SIDE_RIGHT, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_CENTER))
+        printf("TOP_CENTER, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_FRONT_LEFT))
+        printf("TOP_FRONT_LEFT, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_FRONT_CENTER))
+        printf("TOP_FRONT_CENTER, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_FRONT_RIGHT))
+        printf("TOP_FRONT_RIGHT, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_BACK_LEFT))
+        printf("TOP_BACK_LEFT, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_BACK_CENTER))
+        printf("TOP_BACK_CENTER, ");
+    if(IsInMask(channelMapping, PAWIN_SPEAKER_TOP_BACK_RIGHT))
+        printf("TOP_BACK_RIGHT, ");
 
-	printf("\n");
+    printf("\n");
 }
 
 /*
@@ -111,47 +111,47 @@ static void EnumIJackChannels(int channelMapping)
 */
 static void EnumIJackConnectionType(int cType)
 {
-	printf("Connection Type: ");
-	switch(cType)
-	{
-		case eJackConnTypeUnknown:
-			printf("eJackConnTypeUnknown");
-			break;
-		case eJackConnType3Point5mm:
-			printf("eJackConnType3Point5mm");
-			break;
-		case eJackConnTypeQuarter:
-			printf("eJackConnTypeQuarter");
-			break;
-		case eJackConnTypeAtapiInternal:
-			printf("eJackConnTypeAtapiInternal");
-			break;
-		case eJackConnTypeRCA:
-			printf("eJackConnTypeRCA");
-			break;
-		case eJackConnTypeOptical:
-			printf("eJackConnTypeOptical");
-			break;
-		case eJackConnTypeOtherDigital:
-			printf("eJackConnTypeOtherDigital");
-			break;
-		case eJackConnTypeOtherAnalog:
-			printf("eJackConnTypeOtherAnalog");
-			break;
-		case eJackConnTypeMultichannelAnalogDIN:
-			printf("eJackConnTypeMultichannelAnalogDIN");
-			break;
-		case eJackConnTypeXlrProfessional:
-			printf("eJackConnTypeXlrProfessional");
-			break;
-		case eJackConnTypeRJ11Modem:
-			printf("eJackConnTypeRJ11Modem");
-			break;
-		case eJackConnTypeCombination:
-			printf("eJackConnTypeCombination");
-			break;
-	}
-	printf("\n");
+    printf("Connection Type: ");
+    switch(cType)
+    {
+        case eJackConnTypeUnknown:
+            printf("eJackConnTypeUnknown");
+            break;
+        case eJackConnType3Point5mm:
+            printf("eJackConnType3Point5mm");
+            break;
+        case eJackConnTypeQuarter:
+            printf("eJackConnTypeQuarter");
+            break;
+        case eJackConnTypeAtapiInternal:
+            printf("eJackConnTypeAtapiInternal");
+            break;
+        case eJackConnTypeRCA:
+            printf("eJackConnTypeRCA");
+            break;
+        case eJackConnTypeOptical:
+            printf("eJackConnTypeOptical");
+            break;
+        case eJackConnTypeOtherDigital:
+            printf("eJackConnTypeOtherDigital");
+            break;
+        case eJackConnTypeOtherAnalog:
+            printf("eJackConnTypeOtherAnalog");
+            break;
+        case eJackConnTypeMultichannelAnalogDIN:
+            printf("eJackConnTypeMultichannelAnalogDIN");
+            break;
+        case eJackConnTypeXlrProfessional:
+            printf("eJackConnTypeXlrProfessional");
+            break;
+        case eJackConnTypeRJ11Modem:
+            printf("eJackConnTypeRJ11Modem");
+            break;
+        case eJackConnTypeCombination:
+            printf("eJackConnTypeCombination");
+            break;
+    }
+    printf("\n");
 }
 
 /*
@@ -159,50 +159,50 @@ static void EnumIJackConnectionType(int cType)
 */
 static void EnumIJackGeoLocation(int iVal)
 {
-	printf("Geometric Location: ");
-	switch(iVal)
-	{
-	case eJackGeoLocRear:
-		printf("eJackGeoLocRear");
-		break;
-	case eJackGeoLocFront:
-		printf("eJackGeoLocFront");
-		break;
-	case eJackGeoLocLeft:
-		printf("eJackGeoLocLeft");
-		break;
-	case eJackGeoLocRight:
-		printf("eJackGeoLocRight");
-		break;
-	case eJackGeoLocTop:
-		printf("eJackGeoLocTop");
-		break;
-	case eJackGeoLocBottom:
-		printf("eJackGeoLocBottom");
-		break;
-	case eJackGeoLocRearPanel:
-		printf("eJackGeoLocRearPanel");
-		break;
-	case eJackGeoLocRiser:
-		printf("eJackGeoLocRiser");
-		break;
-	case eJackGeoLocInsideMobileLid:
-		printf("eJackGeoLocInsideMobileLid");
-		break;
-	case eJackGeoLocDrivebay:
-		printf("eJackGeoLocDrivebay");
-		break;
-	case eJackGeoLocHDMI:
-		printf("eJackGeoLocHDMI");
-		break;
-	case eJackGeoLocOutsideMobileLid:
-		printf("eJackGeoLocOutsideMobileLid");
-		break;
-	case eJackGeoLocATAPI:
-		printf("eJackGeoLocATAPI");
-		break;
-	}
-	printf("\n");
+    printf("Geometric Location: ");
+    switch(iVal)
+    {
+    case eJackGeoLocRear:
+        printf("eJackGeoLocRear");
+        break;
+    case eJackGeoLocFront:
+        printf("eJackGeoLocFront");
+        break;
+    case eJackGeoLocLeft:
+        printf("eJackGeoLocLeft");
+        break;
+    case eJackGeoLocRight:
+        printf("eJackGeoLocRight");
+        break;
+    case eJackGeoLocTop:
+        printf("eJackGeoLocTop");
+        break;
+    case eJackGeoLocBottom:
+        printf("eJackGeoLocBottom");
+        break;
+    case eJackGeoLocRearPanel:
+        printf("eJackGeoLocRearPanel");
+        break;
+    case eJackGeoLocRiser:
+        printf("eJackGeoLocRiser");
+        break;
+    case eJackGeoLocInsideMobileLid:
+        printf("eJackGeoLocInsideMobileLid");
+        break;
+    case eJackGeoLocDrivebay:
+        printf("eJackGeoLocDrivebay");
+        break;
+    case eJackGeoLocHDMI:
+        printf("eJackGeoLocHDMI");
+        break;
+    case eJackGeoLocOutsideMobileLid:
+        printf("eJackGeoLocOutsideMobileLid");
+        break;
+    case eJackGeoLocATAPI:
+        printf("eJackGeoLocATAPI");
+        break;
+    }
+    printf("\n");
 }
 
 /*
@@ -210,23 +210,23 @@ static void EnumIJackGeoLocation(int iVal)
 */
 static void EnumIJackGenLocation(int iVal)
 {
-	printf("General Location: ");
-	switch(iVal)
-	{
-		case eJackGenLocPrimaryBox:
-			printf("eJackGenLocPrimaryBox");
-			break;
-		case eJackGenLocInternal:
-			printf("eJackGenLocInternal");
-			break;
-		case eJackGenLocSeparate:
-			printf("eJackGenLocSeparate");
-			break;
-		case eJackGenLocOther:
-			printf("eJackGenLocOther");
-			break;
-	}
-	printf("\n");
+    printf("General Location: ");
+    switch(iVal)
+    {
+        case eJackGenLocPrimaryBox:
+            printf("eJackGenLocPrimaryBox");
+            break;
+        case eJackGenLocInternal:
+            printf("eJackGenLocInternal");
+            break;
+        case eJackGenLocSeparate:
+            printf("eJackGenLocSeparate");
+            break;
+        case eJackGenLocOther:
+            printf("eJackGenLocOther");
+            break;
+    }
+    printf("\n");
 }
 
 /*
@@ -234,23 +234,23 @@ static void EnumIJackGenLocation(int iVal)
 */
 static void EnumIJackPortConnection(int iVal)
 {
-	printf("Port Type: ");
-	switch(iVal)
-	{
-		case eJackPortConnJack:
-			printf("eJackPortConnJack");
-			break;
-		case eJackPortConnIntegratedDevice:
-			printf("eJackPortConnIntegratedDevice");
-			break;
-		case eJackPortConnBothIntegratedAndJack:
-			printf("eJackPortConnBothIntegratedAndJack");
-			break;
-		case eJackPortConnUnknown:
-			printf("eJackPortConnUnknown");
-			break;
-	}
-	printf("\n");
+    printf("Port Type: ");
+    switch(iVal)
+    {
+        case eJackPortConnJack:
+            printf("eJackPortConnJack");
+            break;
+        case eJackPortConnIntegratedDevice:
+            printf("eJackPortConnIntegratedDevice");
+            break;
+        case eJackPortConnBothIntegratedAndJack:
+            printf("eJackPortConnBothIntegratedAndJack");
+            break;
+        case eJackPortConnUnknown:
+            printf("eJackPortConnUnknown");
+            break;
+    }
+    printf("\n");
 }
 
 /*
@@ -260,38 +260,38 @@ static void EnumIJackPortConnection(int iVal)
 static PaError GetJackInformation(int deviceId)
 {
     PaError err;
-	int i;
-	int jackCount = 0;
-	PaWasapiJackDescription jackDesc;
+    int i;
+    int jackCount = 0;
+    PaWasapiJackDescription jackDesc;
 
-	err = PaWasapi_GetJackCount(deviceId, &jackCount);
-	if( err != paNoError ) return err;
+    err = PaWasapi_GetJackCount(deviceId, &jackCount);
+    if( err != paNoError ) return err;
 
-	fprintf( stderr,"Number of Jacks: %d \n", jackCount );
+    fprintf( stderr,"Number of Jacks: %d \n", jackCount );
 
-	for( i = 0; i<jackCount; i++ )
-	{
-		fprintf( stderr,"Jack #%d:\n", i );
+    for( i = 0; i<jackCount; i++ )
+    {
+        fprintf( stderr,"Jack #%d:\n", i );
 
-		err = PaWasapi_GetJackDescription(deviceId, i, &jackDesc);
-		if( err != paNoError ) 
-		{
-			fprintf( stderr,"Failed getting description." );
-			continue;
-		}
-		else
-		{
-			printf("Is connected: %s\n",(jackDesc.isConnected)?"true":"false");
-			EnumIJackChannels(jackDesc.channelMapping);
-			EnumIJackConnectionType(jackDesc.connectionType);
-			EnumIJackGeoLocation(jackDesc.geoLocation);
-			EnumIJackGenLocation(jackDesc.genLocation);
-			EnumIJackPortConnection(jackDesc.portConnection);
-			printf("Jack Color: 0x%06X\n", jackDesc.color);
-			printf("\n");
-		}
-	}
-	return 0;
+        err = PaWasapi_GetJackDescription(deviceId, i, &jackDesc);
+        if( err != paNoError )
+        {
+            fprintf( stderr,"Failed getting description." );
+            continue;
+        }
+        else
+        {
+            printf("Is connected: %s\n",(jackDesc.isConnected)?"true":"false");
+            EnumIJackChannels(jackDesc.channelMapping);
+            EnumIJackConnectionType(jackDesc.connectionType);
+            EnumIJackGeoLocation(jackDesc.geoLocation);
+            EnumIJackGenLocation(jackDesc.genLocation);
+            EnumIJackPortConnection(jackDesc.portConnection);
+            printf("Jack Color: 0x%06X\n", jackDesc.color);
+            printf("\n");
+        }
+    }
+    return 0;
 }
 
 
@@ -300,36 +300,36 @@ int main(void);
 int main(void)
 {
     PaError err;
-	const PaDeviceInfo *device;
+    const PaDeviceInfo *device;
     int i;
-	int jackCount = 0;
-	int isInput = 0;
+    int jackCount = 0;
+    int isInput = 0;
 
-	printf("PortAudio Test: WASAPI Jack Configuration");
+    printf("PortAudio Test: WASAPI Jack Configuration");
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
-	/* Find all WASAPI devices */
-	for( i = 0; i < Pa_GetDeviceCount(); ++i )
-	{
-		device = Pa_GetDeviceInfo(i);
-		if( Pa_GetDeviceInfo(i)->hostApi == Pa_HostApiTypeIdToHostApiIndex(paWASAPI) )
-		{
-			if( device->maxOutputChannels == 0 )
-			{
-				isInput = 1;
-			}
-			printf("------------------------------------------\n");
-			printf("Device: %s",device->name);
-			if(isInput)
-				printf("  (Input) %d Channels\n",device->maxInputChannels);
-			else
-				printf("  (Output) %d Channels\n",device->maxOutputChannels);
-			// Try to see if this WASAPI device can provide Jack information
-			err = GetJackInformation(i);
-			if( err != paNoError ) goto error;
-		}
-	}
+    /* Find all WASAPI devices */
+    for( i = 0; i < Pa_GetDeviceCount(); ++i )
+    {
+        device = Pa_GetDeviceInfo(i);
+        if( Pa_GetDeviceInfo(i)->hostApi == Pa_HostApiTypeIdToHostApiIndex(paWASAPI) )
+        {
+            if( device->maxOutputChannels == 0 )
+            {
+                isInput = 1;
+            }
+            printf("------------------------------------------\n");
+            printf("Device: %s",device->name);
+            if(isInput)
+                printf("  (Input) %d Channels\n",device->maxInputChannels);
+            else
+                printf("  (Output) %d Channels\n",device->maxOutputChannels);
+            // Try to see if this WASAPI device can provide Jack information
+            err = GetJackInformation(i);
+            if( err != paNoError ) goto error;
+        }
+    }
     Pa_Terminate();
     printf("Test finished.\n");
     return err;

--- a/test/patest_latency.c
+++ b/test/patest_latency.c
@@ -1,8 +1,8 @@
 /** @file
-	@ingroup test_src
-	@brief Hear the latency caused by big buffers.
-	Play a sine wave and change frequency based on letter input.
-	@author Phil Burk <philburk@softsynth.com>, and Darren Gibbs
+    @ingroup test_src
+    @brief Hear the latency caused by big buffers.
+    Play a sine wave and change frequency based on letter input.
+    @author Phil Burk <philburk@softsynth.com>, and Darren Gibbs
 */
 /*
  * $Id$
@@ -32,13 +32,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -136,14 +136,14 @@ int main(void)
 
     outputParameters.device = OUTPUT_DEVICE;
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;         /* stereo output */
     outputParameters.sampleFormat = paFloat32; /* 32 bit floating point output */
     outputParameters.suggestedLatency = Pa_GetDeviceInfo( outputParameters.device )->defaultLowOutputLatency;
     outputParameters.hostApiSpecificStreamInfo = NULL;
-    
+
     printf("Requested output latency = %.4f seconds.\n", outputParameters.suggestedLatency );
     printf("%d frames per buffer.\n.", FRAMES_PER_BUFFER );
 

--- a/test/patest_leftright.c
+++ b/test/patest_leftright.c
@@ -1,12 +1,12 @@
 /** @file patest_leftright.c
-	@ingroup test_src
-	@brief Play different tone sine waves that 
-		alternate between left and right channel.
+    @ingroup test_src
+    @brief Play different tone sine waves that
+        alternate between left and right channel.
 
-	The low tone should be on the left channel.
+    The low tone should be on the left channel.
 
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -36,13 +36,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -88,19 +88,19 @@ static int patestCallback( const void *inputBuffer,
 
     for( i=0; i<framesPerBuffer; i++ )
     {
-		// Smoothly pan between left and right.
-		if( data->currentBalance < data->targetBalance )
-		{
-			data->currentBalance += BALANCE_DELTA;
-		}
-		else if( data->currentBalance > data->targetBalance )
-		{
-			data->currentBalance -= BALANCE_DELTA;
-		}
-		// Apply left/right balance.
+        // Smoothly pan between left and right.
+        if( data->currentBalance < data->targetBalance )
+        {
+            data->currentBalance += BALANCE_DELTA;
+        }
+        else if( data->currentBalance > data->targetBalance )
+        {
+            data->currentBalance -= BALANCE_DELTA;
+        }
+        // Apply left/right balance.
         *out++ = data->sine[data->left_phase] * (1.0f - data->currentBalance);  /* left */
-		*out++ = data->sine[data->right_phase] * data->currentBalance;  /* right */
-		
+        *out++ = data->sine[data->right_phase] * data->currentBalance;  /* right */
+
         data->left_phase += 1;
         if( data->left_phase >= TABLE_SIZE ) data->left_phase -= TABLE_SIZE;
         data->right_phase += 3; /* higher pitch so we can distinguish left and right. */
@@ -118,10 +118,10 @@ int main(void)
     PaStreamParameters outputParameters;
     PaError err;
     paTestData data;
-    int i;    
+    int i;
     printf("Play different tone sine waves that alternate between left and right channel.\n");
     printf("The low tone should be on the left channel.\n");
-    
+
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
     {
@@ -136,8 +136,8 @@ int main(void)
 
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;       /* stereo output */
     outputParameters.sampleFormat = paFloat32; /* 32 bit floating point output */
@@ -153,21 +153,21 @@ int main(void)
                          patestCallback,
                          &data );
     if( err != paNoError ) goto error;
-    
+
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;
-    
+
     printf("Play for several seconds.\n");
     for( i=0; i<4; i++ )
-	{
-		printf("Hear low sound on left side.\n");
-		data.targetBalance = 0.01;
+    {
+        printf("Hear low sound on left side.\n");
+        data.targetBalance = 0.01;
         Pa_Sleep( 1000 );
-		
-		printf("Hear high sound on right side.\n");
-		data.targetBalance = 0.99;
-        Pa_Sleep( 1000 ); 
-	}
+
+        printf("Hear high sound on right side.\n");
+        data.targetBalance = 0.99;
+        Pa_Sleep( 1000 );
+    }
 
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;

--- a/test/patest_longsine.c
+++ b/test/patest_longsine.c
@@ -1,7 +1,7 @@
 /** @file patest_longsine.c
-	@ingroup test_src
-	@brief Play a sine wave until ENTER hit.
-	@author Phil Burk  http://www.softsynth.com
+    @ingroup test_src
+    @brief Play a sine wave until ENTER hit.
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -31,16 +31,16 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
- 
+
 #include <stdio.h>
 #include <math.h>
 
@@ -111,8 +111,8 @@ int main(void)
 
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;                     /* stereo output */
     outputParameters.sampleFormat = paFloat32;             /* 32 bit floating point output */

--- a/test/patest_many.c
+++ b/test/patest_many.c
@@ -1,7 +1,7 @@
 /** @file patest_many.c
-	@ingroup test_src
-	@brief Start and stop the PortAudio Driver multiple times.
-	@author Phil Burk  http://www.softsynth.com
+    @ingroup test_src
+    @brief Start and stop the PortAudio Driver multiple times.
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -31,13 +31,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -175,8 +175,8 @@ PaError TestOnce( void )
 
     outputParameters.device = Pa_GetDefaultOutputDevice();  /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;                      /* stereo output */
     outputParameters.sampleFormat = paInt16;

--- a/test/patest_maxsines.c
+++ b/test/patest_maxsines.c
@@ -1,8 +1,8 @@
 /** @file patest_maxsines.c
-	@ingroup test_src
-	@brief How many sine waves can we calculate and play in less than 80% CPU Load.
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @ingroup test_src
+    @brief How many sine waves can we calculate and play in less than 80% CPU Load.
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -32,13 +32,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -110,7 +110,7 @@ static int patestCallback(const void*                     inputBuffer,
     numForScale = data->numSines;
     if( numForScale < 8 ) numForScale = 8;  /* prevent pops at beginning */
     scaler = 1.0f / numForScale;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         float output = 0.0;
@@ -123,9 +123,9 @@ static int patestCallback(const void*                     inputBuffer,
             phase += phaseInc;
             if( phase >= 1.0 ) phase -= 1.0;
 
-            output += LookupSine(data, phase); 
+            output += LookupSine(data, phase);
             data->phases[j] = phase;
-            
+
             phaseInc *= 1.02f;
             if( phaseInc > MAX_PHASE_INC ) phaseInc = MIN_PHASE_INC;
         }
@@ -141,7 +141,7 @@ static int patestCallback(const void*                     inputBuffer,
 int main(void);
 int main(void)
 {
-	int                 i;
+    int                 i;
     PaStream*           stream;
     PaStreamParameters  outputParameters;
     PaError             err;
@@ -162,8 +162,8 @@ int main(void)
         goto error;
     outputParameters.device                    = Pa_GetDefaultOutputDevice(); /* Default output device. */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount              = 2;                           /* Stereo output. */
     outputParameters.sampleFormat              = paFloat32;                   /* 32 bit floating point output. */

--- a/test/patest_mono.c
+++ b/test/patest_mono.c
@@ -1,7 +1,7 @@
 /** @file patest_mono.c
-	@ingroup test_src
-	@brief Play a monophonic sine wave using the Portable Audio api for several seconds.
-	@author Phil Burk  http://www.softsynth.com
+    @ingroup test_src
+    @brief Play a monophonic sine wave using the Portable Audio api for several seconds.
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -35,13 +35,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -110,7 +110,7 @@ int main(void)
         data.sine[i] = (float) (AMPLITUDE * sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. ));
     }
     data.phase = 0;
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
@@ -133,16 +133,16 @@ int main(void)
 
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;
-    
+
     printf("Play for %d seconds.\n", NUM_SECONDS ); fflush(stdout);
     Pa_Sleep( NUM_SECONDS * 1000 );
 
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
-    
+
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
-    
+
     Pa_Terminate();
     printf("Test finished.\n");
     return err;

--- a/test/patest_multi_sine.c
+++ b/test/patest_multi_sine.c
@@ -1,7 +1,7 @@
 /** @file patest_multi_sine.c
-	@ingroup test_src
-	@brief Play a different sine wave on each channel.
-	@author Phil Burk  http://www.softsynth.com
+    @ingroup test_src
+    @brief Play a different sine wave on each channel.
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -31,16 +31,16 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
- 
+
 #include <stdio.h>
 #include <math.h>
 
@@ -125,8 +125,8 @@ int test(short interleaved)
 
     outputParameters.device = Pa_GetDefaultOutputDevice();  /* Default output device, max channels. */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      return paInvalidDevice;
+        fprintf(stderr,"Error: No default output device.\n");
+        return paInvalidDevice;
     }
     pdi = Pa_GetDeviceInfo(outputParameters.device);
     outputParameters.channelCount = pdi->maxOutputChannels;
@@ -135,7 +135,7 @@ int test(short interleaved)
     outputParameters.sampleFormat = paFloat32;              /* 32 bit floating point output */
     outputParameters.suggestedLatency = pdi->defaultLowOutputLatency;
     outputParameters.hostApiSpecificStreamInfo = NULL;
-    
+
     data.interleaved = interleaved;
     data.numChannels = outputParameters.channelCount;
     for (n = 0; n < data.numChannels; n++)
@@ -169,7 +169,7 @@ int test(short interleaved)
             }
         Pa_CloseStream( stream );
         }
-    return err;    
+    return err;
 }
 
 

--- a/test/patest_out_underflow.c
+++ b/test/patest_out_underflow.c
@@ -1,9 +1,9 @@
 /** @file patest_out_underflow.c
-	@ingroup test_src
-	@brief Count output underflows (using paOutputUnderflow flag) 
-	under overloaded and normal conditions.
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @ingroup test_src
+    @brief Count output underflows (using paOutputUnderflow flag)
+    under overloaded and normal conditions.
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -134,11 +134,11 @@ int main(void)
 
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
-    
+
     outputParameters.device = Pa_GetDefaultOutputDevice();  /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 1;                      /* mono output */
     outputParameters.sampleFormat = paFloat32;              /* 32 bit floating point output */
@@ -154,7 +154,7 @@ int main(void)
               FRAMES_PER_BUFFER,
               paClipOff,    /* we won't output out of range samples so don't bother clipping them */
               patestCallback,
-              &data );    
+              &data );
     if( err != paNoError ) goto error;
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;
@@ -163,12 +163,12 @@ int main(void)
 
     /* Determine number of sines required to get to 50% */
     do
-    {        
+    {
         Pa_Sleep( 100 );
 
         load = Pa_GetStreamCpuLoad( stream );
         printf("sineCount = %d, CPU load = %f\n", data.sineCount, load );
-		
+
         if( load < 0.3 )
         {
             data.sineCount += 10;
@@ -198,7 +198,7 @@ int main(void)
         load = Pa_GetStreamCpuLoad( stream );
         printf("STRESSING: sineCount = %d, CPU load = %f\n", sineCount, load );
     }
-    
+
     printf("Counting underflows for 2 seconds.\n");
     data.countUnderflows = 1;
     Pa_Sleep( 2000 );
@@ -220,14 +220,14 @@ int main(void)
     Pa_Sleep( 5000 );
 
     safeUnderflowCount = data.outputUnderflowCount;
-    
+
     printf("Stop stream.\n");
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
-    
+
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
-    
+
     Pa_Terminate();
 
     printf("suggestedLatency = %f\n", suggestedLatency);

--- a/test/patest_prime.c
+++ b/test/patest_prime.c
@@ -1,7 +1,7 @@
 /** @file patest_prime.c
-	@ingroup test_src
-	@brief Test stream priming mode.
-	@author Ross Bencina http://www.audiomulch.com/~rossb
+    @ingroup test_src
+    @brief Test stream priming mode.
+    @author Ross Bencina http://www.audiomulch.com/~rossb
 */
 
 /*
@@ -32,16 +32,16 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
- 
+
 #include <stdio.h>
 #include <math.h>
 #include "portaudio.h"
@@ -83,8 +83,8 @@ static void InitializeTestData( paTestData *testData )
 */
 static int patestCallback( const void *inputBuffer, void *outputBuffer,
                            unsigned long framesPerBuffer,
-			               const PaStreamCallbackTimeInfo *timeInfo,
-			               PaStreamCallbackFlags statusFlags, void *userData )
+                           const PaStreamCallbackTimeInfo *timeInfo,
+                           PaStreamCallbackFlags statusFlags, void *userData )
 {
     /* Cast data passed through stream to our structure. */
     paTestData *data = (paTestData*)userData;
@@ -105,7 +105,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
             *out++ = 0.0;  /* left */
             *out++ = 0.0;  /* right */
             --data->idleCountdown;
-            
+
             if( data->idleCountdown <= 0 ) result = paComplete;
             break;
 
@@ -133,7 +133,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
             break;
         }
     }
-    
+
     return result;
 }
 
@@ -145,12 +145,12 @@ static PaError DoTest( int flags )
     paTestData data;
     PaStreamParameters outputParameters;
 
-    InitializeTestData( &data );       
+    InitializeTestData( &data );
 
     outputParameters.device = Pa_GetDefaultOutputDevice();
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;
     outputParameters.hostApiSpecificStreamInfo = NULL;
@@ -200,7 +200,7 @@ int main(void)
     /* Initialize library before making any other calls. */
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
-    
+
     printf("PortAudio Test: Testing stream playback with no priming.\n");
     printf("PortAudio Test: you should see BEEP before you hear it.\n");
     printf("BEEP %d times.\n", NUM_BEEPS );

--- a/test/patest_read_record.c
+++ b/test/patest_read_record.c
@@ -1,8 +1,8 @@
 /** @file patest_read_record.c
-	@ingroup test_src
-	@brief Record input into an array; Save array to a file; Playback recorded
+    @ingroup test_src
+    @brief Record input into an array; Save array to a file; Playback recorded
     data. Implemented using the blocking API (Pa_ReadStream(), Pa_WriteStream() )
-	@author Phil Burk  http://www.softsynth.com
+    @author Phil Burk  http://www.softsynth.com
     @author Ross Bencina rossb@audiomulch.com
 */
 /*
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -92,8 +92,8 @@ int main(void)
     int numSamples;
     int numBytes;
     SAMPLE max, average, val;
-    
-    
+
+
     printf("patest_read_record.c\n"); fflush(stdout);
 
     totalFrames = NUM_SECONDS * SAMPLE_RATE; /* Record for a few seconds. */
@@ -113,8 +113,8 @@ int main(void)
 
     inputParameters.device = Pa_GetDefaultInputDevice(); /* default input device */
     if (inputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default input device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default input device.\n");
+        goto error;
     }
     inputParameters.channelCount = NUM_CHANNELS;
     inputParameters.sampleFormat = PA_SAMPLE_TYPE;
@@ -139,7 +139,7 @@ int main(void)
 
     err = Pa_ReadStream( stream, recordedSamples, totalFrames );
     if( err != paNoError ) goto error;
-    
+
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
 
@@ -193,11 +193,11 @@ int main(void)
 #endif
 
     /* Playback recorded data.  -------------------------------------------- */
-    
+
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* default output device */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = NUM_CHANNELS;
     outputParameters.sampleFormat =  PA_SAMPLE_TYPE;

--- a/test/patest_ringmix.c
+++ b/test/patest_ringmix.c
@@ -1,9 +1,9 @@
 /** @file patest_ringmix.c
-	@ingroup test_src
-	@brief Ring modulate inputs to left output, mix inputs to right output.
+    @ingroup test_src
+    @brief Ring modulate inputs to left output, mix inputs to right output.
 */
 /*
- * $Id$ 
+ * $Id$
  *
  * This program uses the PortAudio Portable Audio Library.
  * For more information see: http://www.portaudio.com
@@ -30,13 +30,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -51,7 +51,7 @@ static int myCallback( const void *inputBuffer, void *outputBuffer,
                             void *userData )
 {
     const float *in  = (const float *) inputBuffer;
-	float *out = (float *) outputBuffer;    
+    float *out = (float *) outputBuffer;
     float leftInput, rightInput;
     unsigned int i;
 

--- a/test/patest_sine8.c
+++ b/test/patest_sine8.c
@@ -1,7 +1,7 @@
 /** @file patest_sine8.c
-	@ingroup test_src
-	@brief Test 8 bit data: play a sine wave for several seconds.
-	@author Ross Bencina <rossb@audiomulch.com>
+    @ingroup test_src
+    @brief Test 8 bit data: play a sine wave for several seconds.
+    @author Ross Bencina <rossb@audiomulch.com>
 */
 /*
  * $Id$
@@ -31,13 +31,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -150,8 +150,8 @@ int main(void)
 
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* Default output device. */
     if (outputParameters.device == paNoDevice) {
-      fprintf(stderr,"Error: No default output device.\n");
-      goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;                     /* Stereo output. */
     outputParameters.sampleFormat = TEST_FORMAT;

--- a/test/patest_sine_channelmaps.c
+++ b/test/patest_sine_channelmaps.c
@@ -26,21 +26,21 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
 /** @file patest_sine_channelmaps.c
-	@ingroup test_src
-	@brief Plays sine waves using sme simple channel maps.
+    @ingroup test_src
+    @brief Plays sine waves using sme simple channel maps.
           Designed for use with CoreAudio, but should made to work with other APIs
-	@author Bjorn Roche <bjorn@xowave.com>
+    @author Bjorn Roche <bjorn@xowave.com>
    @author Ross Bencina <rossb@audiomulch.com>
    @author Phil Burk <philburk@softsynth.com>
 */
@@ -87,7 +87,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         *out++ = data->sine[data->left_phase];  /* left */
@@ -97,7 +97,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
         data->right_phase += 3; /* higher pitch so we can distinguish left and right. */
         if( data->right_phase >= TABLE_SIZE ) data->right_phase -= TABLE_SIZE;
     }
-    
+
     return paContinue;
 }
 
@@ -115,17 +115,17 @@ int main(void)
 #endif
     int i;
 
-    
+
     printf("PortAudio Test: output sine wave. SR = %d, BufSize = %d\n", SAMPLE_RATE, FRAMES_PER_BUFFER);
     printf("Output will be mapped to channels 2 and 3 instead of 0 and 1.\n");
-    
+
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
     {
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
     data.left_phase = data.right_phase = 0;
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
@@ -135,7 +135,7 @@ int main(void)
     PaMacCore_SetupChannelMap( &macInfo, channelMap, 4 );
 
     for( i=0; i<4; ++i )
-       printf( "channel %d name: %s\n", i, PaMacCore_GetChannelName( Pa_GetDefaultOutputDevice(), i, false ) );
+        printf( "channel %d name: %s\n", i, PaMacCore_GetChannelName( Pa_GetDefaultOutputDevice(), i, false ) );
 #else
     printf( "Channel mapping not supported on this platform. Reverting to normal sine test.\n" );
 #endif
@@ -179,7 +179,7 @@ int main(void)
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_sine_formats.c
+++ b/test/patest_sine_formats.c
@@ -1,7 +1,7 @@
 /** @file patest_sine_formats.c
-	@ingroup test_src
-	@brief Play a sine wave for several seconds. Test various data formats.
-	@author Phil Burk
+    @ingroup test_src
+    @brief Play a sine wave for several seconds. Test various data formats.
+    @author Phil Burk
 */
 /*
  * $Id$
@@ -31,13 +31,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>

--- a/test/patest_sine_srate.c
+++ b/test/patest_sine_srate.c
@@ -26,22 +26,22 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
 /** @file patest_sine_srate_mac.c
-	@ingroup test_src
-	@brief Plays sine waves at 44100 and 48000,
+    @ingroup test_src
+    @brief Plays sine waves at 44100 and 48000,
           and forces the hardware to change if this is a mac.
           Designed for use with CoreAudio.
-	@author Bjorn Roche <bjorn@xowave.com>
+    @author Bjorn Roche <bjorn@xowave.com>
    @author Ross Bencina <rossb@audiomulch.com>
    @author Phil Burk <philburk@softsynth.com>
 */
@@ -89,7 +89,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         *out++ = data->sine[data->left_phase];  /* left */
@@ -99,7 +99,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
         data->right_phase += 3; /* higher pitch so we can distinguish left and right. */
         if( data->right_phase >= TABLE_SIZE ) data->right_phase -= TABLE_SIZE;
     }
-    
+
     return paContinue;
 }
 
@@ -146,32 +146,32 @@ int main(void)
         outputParameters.hostApiSpecificStreamInfo = NULL;
 #endif
         err = Pa_OpenStream(
-                  &stream,
-                  NULL, /* no input */
-                  &outputParameters,
-                  sr,
-                  FRAMES_PER_BUFFER,
-                  paClipOff,      /* we won't output out of range samples so don't bother clipping them */
-                  patestCallback,
-                  &data );
-       if( err != paNoError ) goto error;
+                &stream,
+                NULL, /* no input */
+                &outputParameters,
+                sr,
+                FRAMES_PER_BUFFER,
+                paClipOff,      /* we won't output out of range samples so don't bother clipping them */
+                patestCallback,
+                &data );
+        if( err != paNoError ) goto error;
 
-       err = Pa_StartStream( stream );
-       if( err != paNoError ) goto error;
+        err = Pa_StartStream( stream );
+        if( err != paNoError ) goto error;
 
-       printf("Play for %d seconds.\n", NUM_SECONDS );
-       Pa_Sleep( NUM_SECONDS * 1000 );
+        printf("Play for %d seconds.\n", NUM_SECONDS );
+        Pa_Sleep( NUM_SECONDS * 1000 );
 
-       err = Pa_StopStream( stream );
-       if( err != paNoError ) goto error;
+        err = Pa_StopStream( stream );
+        if( err != paNoError ) goto error;
 
-       err = Pa_CloseStream( stream );
-       if( err != paNoError ) goto error;
+        err = Pa_CloseStream( stream );
+        if( err != paNoError ) goto error;
     }
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_sine_time.c
+++ b/test/patest_sine_time.c
@@ -1,9 +1,9 @@
 /** @file patest_sine_time.c
-	@ingroup test_src
-	@brief Play a sine wave for several seconds, pausing in the middle.
-	Uses the Pa_GetStreamTime() call.
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @ingroup test_src
+    @brief Play a sine wave for several seconds, pausing in the middle.
+    Uses the Pa_GetStreamTime() call.
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>
@@ -114,7 +114,7 @@ static void ReportStreamTime( PaStream *stream, paTestData *data );
 static void ReportStreamTime( PaStream *stream, paTestData *data )
 {
     PaTime  streamTime, latency, outTime;
-    
+
     streamTime = Pa_GetStreamTime( stream );
     outTime = data->outTime;
     if( outTime < 0.0 )
@@ -167,7 +167,7 @@ int main(void)
               patestCallback,
               &data );
     if( err != paNoError ) goto error;
-          
+
     /* Watch until sound is halfway finished. */
     printf("Play for %d seconds.\n", NUM_SECONDS/2 ); fflush(stdout);
 
@@ -182,11 +182,11 @@ int main(void)
         ReportStreamTime( stream, &data );
         Pa_Sleep(100);
     } while( (Pa_GetStreamTime( stream ) - startTime) < (NUM_SECONDS/2) );
-    
+
     /* Stop sound for 2 seconds. */
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
-    
+
     printf("Pause for 2 seconds.\n"); fflush(stdout);
     Pa_Sleep( 2000 );
 
@@ -195,21 +195,21 @@ int main(void)
     if( err != paNoError ) goto error;
 
     startTime = Pa_GetStreamTime( stream );
-    
+
     printf("Play until sound is finished.\n"); fflush(stdout);
     do
     {
         ReportStreamTime( stream, &data );
         Pa_Sleep(100);
     } while( (Pa_GetStreamTime( stream ) - startTime) < (NUM_SECONDS/2) );
-    
+
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
 
     Pa_Terminate();
     printf("Test finished.\n");
     return err;
-    
+
 error:
     Pa_Terminate();
     fprintf( stderr, "An error occurred while using the portaudio stream\n" );

--- a/test/patest_start_stop.c
+++ b/test/patest_start_stop.c
@@ -1,9 +1,9 @@
 /** @file patest_start_stop.c
-	@ingroup test_src
-	@brief Play a sine wave for several seconds. Start and stop the stream multiple times.
-        
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @ingroup test_src
+    @brief Play a sine wave for several seconds. Start and stop the stream multiple times.
+
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>
@@ -83,7 +83,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         *out++ = data->sine[data->left_phase];  /* left */
@@ -93,7 +93,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
         data->right_phase += 3; /* higher pitch so we can distinguish left and right. */
         if( data->right_phase >= TABLE_SIZE ) data->right_phase -= TABLE_SIZE;
     }
-    
+
     return paContinue;
 }
 
@@ -107,16 +107,16 @@ int main(void)
     paTestData data;
     int i;
 
-    
+
     printf("PortAudio Test: output sine wave. SR = %d, BufSize = %d\n", SAMPLE_RATE, FRAMES_PER_BUFFER);
-    
+
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
     {
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
     data.left_phase = data.right_phase = 0;
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
@@ -163,7 +163,7 @@ int main(void)
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_stop.c
+++ b/test/patest_stop.c
@@ -1,17 +1,17 @@
 /** @file patest_stop.c
-	@ingroup test_src
-	@brief Test different ways of stopping audio.
+    @ingroup test_src
+    @brief Test different ways of stopping audio.
 
-	Test the three ways of stopping audio:
-		- calling Pa_StopStream(),
-		- calling Pa_AbortStream(),
-		- and returning a 1 from the callback function.
+    Test the three ways of stopping audio:
+        - calling Pa_StopStream(),
+        - calling Pa_AbortStream(),
+        - and returning a 1 from the callback function.
 
-	A long latency is set up so that you can hear the difference.
-	Then a simple 8 note sequence is repeated twice.
-	The program will print what you should hear.
+    A long latency is set up so that you can hear the difference.
+    Then a simple 8 note sequence is repeated twice.
+    The program will print what you should hear.
 
-	@author Phil Burk <philburk@softsynth.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -41,13 +41,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>
@@ -96,7 +96,7 @@ int TestStopMode( paTestData *data );
 float LookupWaveform( paTestData *data, float phase );
 
 /******************************************************
- * Convert phase between 0.0 and 1.0 to waveform value 
+ * Convert phase between 0.0 and 1.0 to waveform value
  * using linear interpolation.
  */
 float LookupWaveform( paTestData *data, float phase )
@@ -132,7 +132,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
 
 
     /* data->outTime = outTime; */
-    
+
     if( !data->done )
     {
         for( i=0; i<framesPerBuffer; i++ )
@@ -184,7 +184,7 @@ int main(void)
     paTestData data;
     int i;
     float simpleTune[] = { NOTE_0, NOTE_1, NOTE_2, NOTE_3, NOTE_4, NOTE_3, NOTE_2, NOTE_1 };
-    
+
     printf("PortAudio Test: play song and test stopping. ask for %f seconds latency\n", LATENCY_SECONDS );
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
@@ -237,14 +237,14 @@ int TestStopMode( paTestData *data )
     PaStreamParameters outputParameters;
     PaStream *stream;
     PaError err;
-    
+
     data->done = 0;
     data->phase = 0.0;
     data->frameCounter = 0;
     data->noteCounter = 0;
     data->repeatCounter = 0;
     data->phase_increment = data->tune[data->noteCounter];
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
@@ -257,7 +257,7 @@ int TestStopMode( paTestData *data )
     outputParameters.sampleFormat = paFloat32;  /* 32 bit floating point output */
     outputParameters.suggestedLatency = LATENCY_SECONDS;
     outputParameters.hostApiSpecificStreamInfo = NULL;
-    
+
     err = Pa_OpenStream(
               &stream,
               NULL, /* no input */

--- a/test/patest_stop_playout.c
+++ b/test/patest_stop_playout.c
@@ -1,9 +1,9 @@
 /** @file patest_stop_playout.c
-	@ingroup test_src
-	@brief Test whether all queued samples are played when Pa_StopStream()
+    @ingroup test_src
+    @brief Test whether all queued samples are played when Pa_StopStream()
             is used with a callback or read/write stream, or when the callback
             returns paComplete.
-	@author Ross Bencina <rossb@audiomulch.com>
+    @author Ross Bencina <rossb@audiomulch.com>
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>
@@ -66,10 +66,10 @@ typedef struct
     float sine[TABLE_SIZE+1];
 
     int repeatCount;
-    
+
     double phase;
     double lowIncrement, highIncrement;
-    
+
     int gap1Length, toneLength, toneFadesLength, gap2Length, blipLength;
     int gap1Countdown, toneCountdown, gap2Countdown, blipCountdown;
 }
@@ -105,7 +105,7 @@ static void InitTestSignalGenerator( TestData *data )
     data->sine[TABLE_SIZE] = data->sine[0]; /* guard point for linear interpolation */
 
 
-    
+
     data->lowIncrement = (330. / SAMPLE_RATE) * TABLE_SIZE;
     data->highIncrement = (1760. / SAMPLE_RATE) * TABLE_SIZE;
 
@@ -147,7 +147,7 @@ static void GenerateTestSignal( TestData *data, float *stereo, int frameCount )
             data->gap1Countdown -= count;
             framesGenerated += count;
         }
-    
+
         if( framesGenerated < frameCount && data->toneCountdown > 0 ){
             count = MIN( frameCount - framesGenerated, data->toneCountdown );
             for( i=0; i < count; ++i )
@@ -168,19 +168,19 @@ static void GenerateTestSignal( TestData *data, float *stereo, int frameCount )
                     /* cosine-bell fade out at end */
                     output *= (-cos(((float)data->toneCountdown / (float)data->toneFadesLength) * M_PI) + 1.) * .5;
                 }
-                else if( data->toneCountdown > data->toneLength - data->toneFadesLength ) 
+                else if( data->toneCountdown > data->toneLength - data->toneFadesLength )
                 {
                     /* cosine-bell fade in at start */
                     output *= (cos(((float)(data->toneCountdown - (data->toneLength - data->toneFadesLength)) / (float)data->toneFadesLength) * M_PI) + 1.) * .5;
                 }
 
                 output *= .5; /* play tone half as loud as blip */
-            
+
                 *stereo++ = output;
                 *stereo++ = output;
 
                 data->toneCountdown--;
-            }                         
+            }
 
             framesGenerated += count;
         }
@@ -212,7 +212,7 @@ static void GenerateTestSignal( TestData *data, float *stereo, int frameCount )
 
                 /* cosine-bell envelope over whole blip */
                 output *= (-cos( ((float)data->blipCountdown / (float)data->blipLength) * 2. * M_PI) + 1.) * .5;
-                
+
                 *stereo++ = output;
                 *stereo++ = output;
 
@@ -227,7 +227,7 @@ static void GenerateTestSignal( TestData *data, float *stereo, int frameCount )
         {
             RetriggerTestSignalGenerator( data );
             data->repeatCount++;
-        }        
+        }
     }
 
     if( framesGenerated < frameCount )
@@ -286,7 +286,7 @@ static int TestCallback2( const void *inputBuffer, void *outputBuffer,
 
     if( IsTestSignalFinished( (TestData*)userData ) )
         testCallback2Finished = 1;
-   
+
     return paContinue;
 }
 
@@ -299,11 +299,11 @@ int main(void)
     PaError err;
     TestData data;
     float writeBuffer[ FRAMES_PER_BUFFER * 2 ];
-    
+
     printf("PortAudio Test: check that stopping stream plays out all queued samples. SR = %d, BufSize = %d\n", SAMPLE_RATE, FRAMES_PER_BUFFER);
 
     InitTestSignalGenerator( &data );
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
@@ -391,7 +391,7 @@ int main(void)
     ResetTestSignalGenerator( &data );
 
     testCallback2Finished = 0;
-    
+
     err = Pa_OpenStream(
               &stream,
               NULL, /* no input */
@@ -419,7 +419,7 @@ int main(void)
 
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
-    
+
 
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
@@ -452,23 +452,23 @@ int main(void)
         GenerateTestSignal( &data, writeBuffer, FRAMES_PER_BUFFER );
         err = Pa_WriteStream( stream, writeBuffer, FRAMES_PER_BUFFER );
         if( err != paNoError ) goto error;
-        
+
     }while( !IsTestSignalFinished( &data ) );
 
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
-    
+
 
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
 
 /* -------------------------------------------------------------------------- */
-    
+
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
-    
+
 error:
     Pa_Terminate();
     fprintf( stderr, "An error occurred while using the portaudio stream\n" );

--- a/test/patest_suggested_vs_streaminfo_latency.c
+++ b/test/patest_suggested_vs_streaminfo_latency.c
@@ -1,13 +1,13 @@
 /** @file patest_suggested_vs_streaminfo_latency.c
-	@ingroup test_src
-	@brief Print suggested vs. PaStreamInfo reported actual latency
-	@author Ross Bencina <rossb@audiomulch.com>
+    @ingroup test_src
+    @brief Print suggested vs. PaStreamInfo reported actual latency
+    @author Ross Bencina <rossb@audiomulch.com>
 
-	Opens streams with a sequence of suggested latency values 
-	from 0 to 2 seconds in .5ms intervals and gathers the resulting actual 
-	latency values. Output a csv file and graph suggested vs. actual. Run 
-	with framesPerBuffer unspecified, powers of 2 and multiples of 50 and 
-	prime number buffer sizes.
+    Opens streams with a sequence of suggested latency values
+    from 0 to 2 seconds in .5ms intervals and gathers the resulting actual
+    latency values. Output a csv file and graph suggested vs. actual. Run
+    with framesPerBuffer unspecified, powers of 2 and multiples of 50 and
+    prime number buffer sizes.
 */
 /*
  * $Id: patest_sine.c 1368 2008-03-01 00:38:27Z rossb $
@@ -37,13 +37,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 #include <stdio.h>
@@ -129,8 +129,8 @@ int main( int argc, const char* argv[] )
     if( inputParameters.device == -1 ){
         inputParameters.device = Pa_GetDefaultInputDevice();
         if (inputParameters.device == paNoDevice) {
-          fprintf(stderr,"Error: No default input device available.\n");
-          goto error;
+            fprintf(stderr,"Error: No default input device available.\n");
+            goto error;
         }
     }else{
         deviceInfo = Pa_GetDeviceInfo(inputParameters.device);
@@ -143,7 +143,7 @@ int main( int argc, const char* argv[] )
             usage();
         }
     }
-    
+
     inputParameters.channelCount = NUM_CHANNELS;
     inputParameters.sampleFormat = paFloat32; /* 32 bit floating point output */
     inputParameters.hostApiSpecificStreamInfo = NULL;
@@ -158,8 +158,8 @@ int main( int argc, const char* argv[] )
     if( outputParameters.device == -1 ){
         outputParameters.device = Pa_GetDefaultOutputDevice();
         if (outputParameters.device == paNoDevice) {
-          fprintf(stderr,"Error: No default output device available.\n");
-          goto error;
+            fprintf(stderr,"Error: No default output device available.\n");
+            goto error;
         }
     }else{
         deviceInfo = Pa_GetDeviceInfo(outputParameters.device);
@@ -214,7 +214,7 @@ int main( int argc, const char* argv[] )
 
         err = Pa_OpenStream(
                   &stream,
-                  &inputParameters, 
+                  &inputParameters,
                   NULL, /* no output */
                   sampleRate,
                   framesPerBuffer,
@@ -234,7 +234,7 @@ int main( int argc, const char* argv[] )
 
         err = Pa_OpenStream(
                   &stream,
-                  &inputParameters, 
+                  &inputParameters,
                   &outputParameters,
                   sampleRate,
                   framesPerBuffer,
@@ -258,7 +258,7 @@ int main( int argc, const char* argv[] )
 
     Pa_Terminate();
     printf("# Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_suggested_vs_streaminfo_latency.py
+++ b/test/patest_suggested_vs_streaminfo_latency.py
@@ -88,7 +88,7 @@ compositeTestFramesPerBufferValues.append( 882 )
 
 individualPlotFramesPerBufferValues = [0,64,128,256,512] #output separate plots for these
 
-isFirst = True    
+isFirst = True
 
 for framesPerBuffer in compositeTestFramesPerBufferValues:
     commandString = testExeName + " " + str(inputDeviceIndex) + " " + str(outputDeviceIndex) + " " + str(sampleRate) + " " + str(framesPerBuffer) + ' > ' + dataFileName
@@ -102,13 +102,13 @@ for framesPerBuffer in compositeTestFramesPerBufferValues:
         gcf().text(0.1, 0.0,
            "patest_suggested_vs_streaminfo_latency\n%s\n%s\n%s\n"%(d.inputDevice,d.outputDevice,d.sampleRate))
         pdfFile.savefig()
-        
-        
+
+
     figure(2) # composite plot, includes all compositeTestFramesPerBufferValues
 
     if isFirst:
         plot( d.suggestedLatency, d.suggestedLatency, label="Suggested latency" )
-    
+
     plot( d.suggestedLatency, d.halfDuplexOutputLatency )
     plot( d.suggestedLatency, d.halfDuplexInputLatency )
     plot( d.suggestedLatency, d.fullDuplexOutputLatency )

--- a/test/patest_sync.c
+++ b/test/patest_sync.c
@@ -1,19 +1,19 @@
 /** @file patest_sync.c
-	@ingroup test_src
-	@brief Test time stamping and synchronization of audio and video.
+    @ingroup test_src
+    @brief Test time stamping and synchronization of audio and video.
 
-	A high latency is used so we can hear the difference in time.
-	Random durations are used so we know we are hearing the right beep
-	and not the one before or after.
+    A high latency is used so we can hear the difference in time.
+    Random durations are used so we know we are hearing the right beep
+    and not the one before or after.
 
-	Sequence of events:
-		-# Foreground requests a beep.
-		-# Background randomly schedules a beep.
-		-# Foreground waits for the beep to be heard based on PaUtil_GetTime().
-		-# Foreground outputs video (printf) in sync with audio.
-		-# Repeat.
-	
-	@author Phil Burk  http://www.softsynth.com
+    Sequence of events:
+        -# Foreground requests a beep.
+        -# Background randomly schedules a beep.
+        -# Foreground waits for the beep to be heard based on PaUtil_GetTime().
+        -# Foreground outputs video (printf) in sync with audio.
+        -# Repeat.
+
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -43,13 +43,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -97,8 +97,8 @@ static unsigned long GenerateRandomNumber( void )
 */
 static int patestCallback( const void *inputBuffer, void *outputBuffer,
                            unsigned long framesPerBuffer,
-			   const PaStreamCallbackTimeInfo *timeInfo,
-			   PaStreamCallbackFlags statusFlags, void *userData )
+               const PaStreamCallbackTimeInfo *timeInfo,
+               PaStreamCallbackFlags statusFlags, void *userData )
 {
     /* Cast data passed through stream to our structure. */
     paTestData *data = (paTestData*)userData;
@@ -186,7 +186,7 @@ int main(void)
     /* Initialize library before making any other calls. */
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
-    
+
     outputParameters.device = Pa_GetDefaultOutputDevice();
     if (outputParameters.device == paNoDevice) {
         fprintf(stderr,"Error: No default output device.\n");
@@ -198,16 +198,16 @@ int main(void)
     outputParameters.suggestedLatency = (double)LATENCY_MSEC / 1000;
 
     /* Open an audio I/O stream. */
-     err = Pa_OpenStream(
-              &stream,
-	      NULL,                         /* no input */
-	      &outputParameters,
-              SAMPLE_RATE,
-              FRAMES_PER_BUFFER,            /* frames per buffer */
-              paClipOff,      /* we won't output out of range samples so don't bother clipping them */
-              patestCallback,
-              &DATA );
-   if( err != paNoError ) goto error;
+    err = Pa_OpenStream(
+            &stream,
+            NULL,                         /* no input */
+            &outputParameters,
+            SAMPLE_RATE,
+            FRAMES_PER_BUFFER,            /* frames per buffer */
+            paClipOff,      /* we won't output out of range samples so don't bother clipping them */
+            patestCallback,
+            &DATA );
+    if( err != paNoError ) goto error;
 
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;

--- a/test/patest_sync.c
+++ b/test/patest_sync.c
@@ -97,8 +97,8 @@ static unsigned long GenerateRandomNumber( void )
 */
 static int patestCallback( const void *inputBuffer, void *outputBuffer,
                            unsigned long framesPerBuffer,
-               const PaStreamCallbackTimeInfo *timeInfo,
-               PaStreamCallbackFlags statusFlags, void *userData )
+                           const PaStreamCallbackTimeInfo *timeInfo,
+                           PaStreamCallbackFlags statusFlags, void *userData )
 {
     /* Cast data passed through stream to our structure. */
     paTestData *data = (paTestData*)userData;

--- a/test/patest_timing.c
+++ b/test/patest_timing.c
@@ -1,8 +1,8 @@
 /** @file patest_timing.c
-	@ingroup test_src
-	@brief Play a sine wave for several seconds, and spits out a ton of timing info while it's at it. Based on patest_sine.c
-	@author Bjorn Roche
-	@author Ross Bencina <rossb@audiomulch.com>
+    @ingroup test_src
+    @brief Play a sine wave for several seconds, and spits out a ton of timing info while it's at it. Based on patest_sine.c
+    @author Bjorn Roche
+    @author Ross Bencina <rossb@audiomulch.com>
     @author Phil Burk <philburk@softsynth.com>
 */
 /*
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -90,7 +90,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
             timeInfo->outputBufferDacTime );
 
     printf( "getStreamTime() returns: %g\n", Pa_GetStreamTime(data->stream) - data->start );
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         *out++ = data->sine[data->left_phase];  /* left */
@@ -100,7 +100,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
         data->right_phase += 3; /* higher pitch so we can distinguish left and right. */
         if( data->right_phase >= TABLE_SIZE ) data->right_phase -= TABLE_SIZE;
     }
-    
+
     return paContinue;
 }
 
@@ -114,16 +114,16 @@ int main(void)
     paTestData data;
     int i;
 
-    
+
     printf("PortAudio Test: output sine wave. SR = %d, BufSize = %d\n", SAMPLE_RATE, FRAMES_PER_BUFFER);
-    
+
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
     {
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
     data.left_phase = data.right_phase = 0;
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
@@ -162,7 +162,7 @@ int main(void)
     Pa_Terminate();
     printf("Test finished.\n");
     printf("The tone should have been heard for about 5 seconds and all the timing info above should report that about 5 seconds elapsed (except Adc, which is undefined since there was no input device opened).\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_toomanysines.c
+++ b/test/patest_toomanysines.c
@@ -1,9 +1,9 @@
 /** @file patest_toomanysines.c
-	@ingroup test_src
-	@brief Play more sine waves than we can handle in real time as a stress test.
+    @ingroup test_src
+    @brief Play more sine waves than we can handle in real time as a stress test.
     @todo This may not be needed now that we have "patest_out_overflow.c".
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -120,7 +120,7 @@ int main(void)
 
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
-    
+
     outputParameters.device = Pa_GetDefaultOutputDevice();  /* default output device */
     if (outputParameters.device == paNoDevice) {
         fprintf(stderr,"Error: No default output device.\n");
@@ -139,7 +139,7 @@ int main(void)
               FRAMES_PER_BUFFER,
               paClipOff,    /* we won't output out of range samples so don't bother clipping them */
               patestCallback,
-              &data );    
+              &data );
     if( err != paNoError ) goto error;
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;
@@ -150,44 +150,44 @@ int main(void)
 
         load = Pa_GetStreamCpuLoad( stream );
         printf("numSines = %d, CPU load = %f\n", data.numSines, load );
-		
-		if( load < 0.3 )
-		{
-			data.numSines += 10;
-		}
-		else if( load < 0.4 )
-		{
-			data.numSines += 2;
-		}
-		else
-		{
-			data.numSines += 1;
-		}
-		
+
+        if( load < 0.3 )
+        {
+            data.numSines += 10;
+        }
+        else if( load < 0.4 )
+        {
+            data.numSines += 2;
+        }
+        else
+        {
+            data.numSines += 1;
+        }
+
     }
     while( load < 0.5 );
-    
+
     /* Calculate target stress value then ramp up to that level*/
     numStress = (int) (2.0 * data.numSines * MAX_LOAD );
     if( numStress > MAX_SINES )
-        numStress = MAX_SINES;	
+        numStress = MAX_SINES;
     for( ; data.numSines < numStress; data.numSines+=2 )
     {
         Pa_Sleep( 200 );
         load = Pa_GetStreamCpuLoad( stream );
         printf("STRESSING: numSines = %d, CPU load = %f\n", data.numSines, load );
     }
-    
+
     printf("Suffer for 5 seconds.\n");
     Pa_Sleep( 5000 );
-    
+
     printf("Stop stream.\n");
     err = Pa_StopStream( stream );
     if( err != paNoError ) goto error;
-    
+
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;
-    
+
     Pa_Terminate();
     printf("Test finished.\n");
     return err;

--- a/test/patest_two_rates.c
+++ b/test/patest_two_rates.c
@@ -1,7 +1,7 @@
 /** @file patest_two_rates.c
-	@ingroup test_src
-	@brief Play two streams at different rates to make sure they don't interfere.
-	@author Phil Burk <philburk@softsynth.com>
+    @ingroup test_src
+    @brief Play two streams at different rates to make sure they don't interfere.
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -68,10 +68,10 @@ typedef struct
  ** that could mess up the system like calling malloc() or free().
  */
 static int patestCallback( const void *inputBuffer, void *outputBuffer,
-						  unsigned long framesPerBuffer,
-						  const PaStreamCallbackTimeInfo* timeInfo,
-						  PaStreamCallbackFlags statusFlags,
-						  void *userData )
+                          unsigned long framesPerBuffer,
+                          const PaStreamCallbackTimeInfo* timeInfo,
+                          PaStreamCallbackFlags statusFlags,
+                          void *userData )
 {
     paTestData *data = (paTestData*)userData;
     float *out = (float*)outputBuffer;
@@ -90,7 +90,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
         data->phase += FREQ_INCR;
         if( data->phase >= (2.0 * M_PI) ) data->phase -= (2.0 * M_PI);
     }
-	data->numFrames += 1;
+    data->numFrames += 1;
     return 0;
 }
 
@@ -108,28 +108,28 @@ int main(void)
 
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
-    
+
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* default output device */
     if (outputParameters.device == paNoDevice) {
-		fprintf(stderr,"Error: No default output device.\n");
-		goto error;
+        fprintf(stderr,"Error: No default output device.\n");
+        goto error;
     }
     outputParameters.channelCount = 2;       /* stereo output */
     outputParameters.sampleFormat = paFloat32; /* 32 bit floating point output */
     outputParameters.suggestedLatency = Pa_GetDeviceInfo( outputParameters.device )->defaultLowOutputLatency;
     outputParameters.hostApiSpecificStreamInfo = NULL;
 
-    /* Start first stream. **********************/	
+    /* Start first stream. **********************/
     err = Pa_OpenStream(
-						&stream1,
-						NULL, /* no input */
-						&outputParameters,
-						SAMPLE_RATE_1,
-						FRAMES_PER_BUFFER,
-						paClipOff,      /* we won't output out of range samples so don't bother clipping them */
-						patestCallback,
-						&data1 );
-	if( err != paNoError ) goto error;
+                        &stream1,
+                        NULL, /* no input */
+                        &outputParameters,
+                        SAMPLE_RATE_1,
+                        FRAMES_PER_BUFFER,
+                        paClipOff,      /* we won't output out of range samples so don't bother clipping them */
+                        patestCallback,
+                        &data1 );
+    if( err != paNoError ) goto error;
 
     err = Pa_StartStream( stream1 );
     if( err != paNoError ) goto error;
@@ -138,34 +138,34 @@ int main(void)
 
     /* Start second stream. **********************/
     err = Pa_OpenStream(
-						&stream2,
-						NULL, /* no input */
-						&outputParameters,
-						SAMPLE_RATE_2,
-						FRAMES_PER_BUFFER,
-						paClipOff,      /* we won't output out of range samples so don't bother clipping them */
-						patestCallback,
-						&data2 );
+                        &stream2,
+                        NULL, /* no input */
+                        &outputParameters,
+                        SAMPLE_RATE_2,
+                        FRAMES_PER_BUFFER,
+                        paClipOff,      /* we won't output out of range samples so don't bother clipping them */
+                        patestCallback,
+                        &data2 );
     if( err != paNoError ) goto error;
 
     err = Pa_StartStream( stream2 );
     if( err != paNoError ) goto error;
 
     Pa_Sleep( 3 * 1000 );
-    
+
     err = Pa_StopStream( stream2 );
     if( err != paNoError ) goto error;
 
     Pa_Sleep( 3 * 1000 );
-    
+
     err = Pa_StopStream( stream1 );
     if( err != paNoError ) goto error;
 
     Pa_CloseStream( stream2 );
     Pa_CloseStream( stream1 );
-    
+
     Pa_Terminate();
-	
+
     printf("NumFrames = %d on stream1, %d on stream2.\n", data1.numFrames, data2.numFrames );
     printf("Test finished.\n");
     return err;

--- a/test/patest_underflow.c
+++ b/test/patest_underflow.c
@@ -1,9 +1,9 @@
 /** @file patest_underflow.c
-	@ingroup test_src
-	@brief Simulate an output buffer underflow condition.
-	Tests whether the stream can be stopped when underflowing buffers.
-	@author Ross Bencina <rossb@audiomulch.com>
-	@author Phil Burk <philburk@softsynth.com>
+    @ingroup test_src
+    @brief Simulate an output buffer underflow condition.
+    Tests whether the stream can be stopped when underflowing buffers.
+    @author Ross Bencina <rossb@audiomulch.com>
+    @author Phil Burk <philburk@softsynth.com>
 */
 /*
  * $Id$
@@ -33,13 +33,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -116,7 +116,7 @@ int main(void)
     data.left_phase = data.right_phase = data.sleepTime = 0;
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
-    
+
     outputParameters.device = Pa_GetDefaultOutputDevice(); /* default output device */
     if (outputParameters.device == paNoDevice) {
         fprintf(stderr,"Error: No default output device.\n");

--- a/test/patest_unplug.c
+++ b/test/patest_unplug.c
@@ -1,7 +1,7 @@
 /** @file patest_unplug.c
-	@ingroup test_src
-	@brief Debug a crash involving unplugging a USB device.
-	@author Phil Burk  http://www.softsynth.com
+    @ingroup test_src
+    @brief Debug a crash involving unplugging a USB device.
+    @author Phil Burk  http://www.softsynth.com
 */
 /*
  * $Id$
@@ -131,10 +131,10 @@ int main(int argc, char **args)
     printf("Test unplugging a USB device.\n");
 
     if( argc > 1 ) {
-       inputDevice = outputDevice = atoi( args[1] );
-       printf("Using device number %d.\n\n", inputDevice );
+        inputDevice = outputDevice = atoi( args[1] );
+        printf("Using device number %d.\n\n", inputDevice );
     } else {
-       printf("Using default device.\n\n" );
+        printf("Using default device.\n\n" );
     }
 
     memset(&data, 0, sizeof(data));

--- a/test/patest_wire.c
+++ b/test/patest_wire.c
@@ -1,13 +1,13 @@
 /** @file patest_wire.c
-	@ingroup test_src
-	@brief Pass input directly to output.
+    @ingroup test_src
+    @brief Pass input directly to output.
 
-	Note that some HW devices, for example many ISA audio cards
-	on PCs, do NOT support full duplex! For a PC, you normally need
-	a PCI based audio card such as the SBLive.
+    Note that some HW devices, for example many ISA audio cards
+    on PCs, do NOT support full duplex! For a PC, you normally need
+    a PCI based audio card such as the SBLive.
 
-	@author Phil Burk  http://www.softsynth.com
-    
+    @author Phil Burk  http://www.softsynth.com
+
  While adapting to V19-API, I excluded configs with framesPerCallback=0
  because of an assert in file pa_common/pa_process.c. Pieter, Oct 9, 2003.
 
@@ -40,13 +40,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -138,7 +138,7 @@ static int wireCallback( const void *inputBuffer, void *outputBuffer,
     if( (statusFlags & paOutputOverflow) != 0 ) config->numOutputOverflows += 1;
     if( (statusFlags & paPrimingOutput) != 0 ) config->numPrimingOutputs += 1;
     config->numCallbacks += 1;
-    
+
     inChannel=0, outChannel=0;
     while( !(inDone && outDone) )
     {
@@ -232,7 +232,7 @@ int main(void)
                         }
                         else if( err != paNoError ) goto error;
                     }
-               }
+                }
             }
         }
     }
@@ -260,7 +260,7 @@ static PaError TestConfiguration( WireConfig_t *config )
     PaError err = paNoError;
     PaStream *stream;
     PaStreamParameters inputParameters, outputParameters;
-    
+
     printf("input %sinterleaved!\n", (config->isInputInterleaved ? " " : "NOT ") );
     printf("output %sinterleaved!\n", (config->isOutputInterleaved ? " " : "NOT ") );
     printf("input channels = %d\n", config->numInputChannels );
@@ -304,13 +304,13 @@ static PaError TestConfiguration( WireConfig_t *config )
               wireCallback,
               config );
     if( err != paNoError ) goto error;
-    
+
     err = Pa_StartStream( stream );
     if( err != paNoError ) goto error;
-    
+
     printf("Now recording and playing. - Hit ENTER for next configuration, or 'q' to quit.\n");  fflush(stdout);
     c = getchar();
-    
+
     printf("Closing stream.\n");
     err = Pa_CloseStream( stream );
     if( err != paNoError ) goto error;

--- a/test/patest_wmme_find_best_latency_params.c
+++ b/test/patest_wmme_find_best_latency_params.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -40,7 +40,7 @@
 #include <time.h>
 #include <math.h>
 
-#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */ 
+#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */
 #include <windows.h>    /* required when using pa_win_wmme.h */
 #include <mmsystem.h>   /* required when using pa_win_wmme.h */
 
@@ -107,11 +107,11 @@ static void printWindowsVersionInfo( FILE *fp )
     osVersionInfoEx.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
     GetVersionEx( &osVersionInfoEx );
 
-    
+
     if( osVersionInfoEx.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS ){
         switch( osVersionInfoEx.dwMinorVersion ){
             case 0: osName = "Windows 95"; break;
-            case 10: osName = "Windows 98"; break;  // could also be 98SE (I've seen code discriminate based 
+            case 10: osName = "Windows 98"; break;  // could also be 98SE (I've seen code discriminate based
                                                     // on osInfo.Version.Revision.ToString() == "2222A")
             case 90: osName = "Windows Me"; break;
         }
@@ -137,13 +137,13 @@ static void printWindowsVersionInfo( FILE *fp )
                             }break;
                     }break;
             case 6:switch( osVersionInfoEx.dwMinorVersion ){
-                        case 0: 
+                        case 0:
                             if( osVersionInfoEx.wProductType == VER_NT_WORKSTATION )
                                 osName = "Windows Vista";
                             else
                                 osName = "Windows Server 2008";
                             break;
-                        case 1: 
+                        case 1:
                             if( osVersionInfoEx.wProductType == VER_NT_WORKSTATION )
                                 osName = "Windows 7";
                             else
@@ -171,7 +171,7 @@ static void printWindowsVersionInfo( FILE *fp )
         }
         else if(osVersionInfoEx.wProductType == VER_NT_SERVER)
         {
-            if(osVersionInfoEx.dwMinorVersion == 0) 
+            if(osVersionInfoEx.dwMinorVersion == 0)
             {
                 if((osVersionInfoEx.wSuiteMask & VER_SUITE_DATACENTER) == VER_SUITE_DATACENTER)
                     osProductType = "Datacenter Server"; // Windows 2000 Datacenter Server
@@ -206,8 +206,8 @@ static void printWindowsVersionInfo( FILE *fp )
 
 
     fprintf( fp, "OS name and edition: %s %s\n", osName, osProductType );
-    fprintf( fp, "OS version: %d.%d.%d %S\n", 
-                osVersionInfoEx.dwMajorVersion, osVersionInfoEx.dwMinorVersion, 
+    fprintf( fp, "OS version: %d.%d.%d %S\n",
+                osVersionInfoEx.dwMajorVersion, osVersionInfoEx.dwMinorVersion,
                 osVersionInfoEx.dwBuildNumber, osVersionInfoEx.szCSDVersion );
     fprintf( fp, "Processor architecture: %s\n", processorArchitecture );
     fprintf( fp, "WoW64 process: %s\n", IsWow64() ? "Yes" : "No" );
@@ -230,7 +230,7 @@ static void printTimeAndDate( FILE *fp )
 typedef struct
 {
     float sine[TABLE_SIZE];
-	double phase;
+    double phase;
     double phaseIncrement;
     volatile int fadeIn;
     volatile int fadeOut;
@@ -257,14 +257,14 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         float x = data->sine[(int)data->phase];
         data->phase += data->phaseIncrement;
         if( data->phase >= TABLE_SIZE ){
-			data->phase -= TABLE_SIZE;
-		}
+            data->phase -= TABLE_SIZE;
+        }
 
         x *= data->amp;
         if( data->fadeIn ){
@@ -276,11 +276,11 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
                 data->amp -= .001;
         }
 
-		for( j = 0; j < CHANNEL_COUNT; ++j ){
+        for( j = 0; j < CHANNEL_COUNT; ++j ){
             *out++ = x;
-		}
-	}
-    
+        }
+    }
+
     if( data->amp > 0 )
         return paContinue;
     else
@@ -292,7 +292,7 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
 #define NO      0
 
 
-static int playUntilKeyPress( int deviceIndex, float sampleRate, 
+static int playUntilKeyPress( int deviceIndex, float sampleRate,
                              int framesPerUserBuffer, int framesPerWmmeBuffer, int wmmeBufferCount )
 {
     PaStreamParameters outputParameters;
@@ -308,7 +308,7 @@ static int playUntilKeyPress( int deviceIndex, float sampleRate,
     outputParameters.hostApiSpecificStreamInfo = NULL;
 
     wmmeStreamInfo.size = sizeof(PaWinMmeStreamInfo);
-    wmmeStreamInfo.hostApiType = paMME; 
+    wmmeStreamInfo.hostApiType = paMME;
     wmmeStreamInfo.version = 1;
     wmmeStreamInfo.flags = paWinMmeUseLowLevelLatencyParameters | paWinMmeDontThrottleOverloadedProcessingThread;
     wmmeStreamInfo.framesPerBuffer = framesPerWmmeBuffer;
@@ -379,7 +379,7 @@ static void usage( int wmmeHostApiIndex )
 }
 
 /*
-    ideas: 
+    ideas:
         o- could be testing with 80% CPU load
         o- could test with different channel counts
 */
@@ -409,15 +409,15 @@ int main(int argc, char* argv[])
     if( argc > 5 )
         usage(wmmeHostApiIndex);
 
-	deviceIndex = wmmeHostApiInfo->defaultOutputDevice;
-	if( argc >= 2 ){
+    deviceIndex = wmmeHostApiInfo->defaultOutputDevice;
+    if( argc >= 2 ){
         deviceIndex = -1;
-		if( sscanf( argv[1], "%d", &deviceIndex ) != 1 )
+        if( sscanf( argv[1], "%d", &deviceIndex ) != 1 )
             usage(wmmeHostApiIndex);
         if( deviceIndex < 0 || deviceIndex >= Pa_GetDeviceCount() || Pa_GetDeviceInfo(deviceIndex)->hostApi != wmmeHostApiIndex ){
             usage(wmmeHostApiIndex);
         }
-	}
+    }
 
     printf( "Using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
 
@@ -450,14 +450,14 @@ int main(int argc, char* argv[])
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
 
-	data.phase = 0;
+    data.phase = 0;
 
     resultsFp = fopen( "results.txt", "at" );
     fprintf( resultsFp, "*** WMME smallest working output buffer sizes\n" );
 
     printTimeAndDate( resultsFp );
     printWindowsVersionInfo( resultsFp );
-    
+
     fprintf( resultsFp, "audio device: %s\n", Pa_GetDeviceInfo( deviceIndex )->name );
     fflush( resultsFp );
 
@@ -465,7 +465,7 @@ int main(int argc, char* argv[])
     fprintf( resultsFp, "Buffer count, Smallest working buffer size (frames), Smallest working buffering latency (frames), Smallest working buffering latency (Seconds)\n" );
 
     for( wmmeBufferCount = wmmeMinBufferCount; wmmeBufferCount <= wmmeMaxBufferCount; ++wmmeBufferCount ){
- 
+
         printf( "Test %d of %d\n", (wmmeBufferCount - wmmeMinBufferCount) + 1, (wmmeMaxBufferCount-wmmeMinBufferCount) + 1 );
         printf( "Testing with %d buffers...\n", wmmeBufferCount );
 
@@ -489,7 +489,7 @@ int main(int argc, char* argv[])
             }else{
                 min = mid + 1;
             }
-             
+
         }while( (min <= max) && (testResult == YES || testResult == NO) );
 
         smallestWorkingBufferingLatencyFrames = smallestWorkingBufferSize * (wmmeBufferCount - 1);
@@ -503,10 +503,10 @@ int main(int argc, char* argv[])
 
     fprintf( resultsFp, "###\n" );
     fclose( resultsFp );
-    
+
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_wmme_low_level_latency_params.c
+++ b/test/patest_wmme_low_level_latency_params.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -65,7 +65,7 @@
 typedef struct
 {
     float sine[TABLE_SIZE];
-	double phase;
+    double phase;
 }
 paTestData;
 
@@ -86,20 +86,20 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
     (void) timeInfo; /* Prevent unused variable warnings. */
     (void) statusFlags;
     (void) inputBuffer;
-    
+
     for( i=0; i<framesPerBuffer; i++ )
     {
         float x = data->sine[(int)data->phase];
         data->phase += 20;
         if( data->phase >= TABLE_SIZE ){
-			data->phase -= TABLE_SIZE;
-		}
+            data->phase -= TABLE_SIZE;
+        }
 
-		for( j = 0; j < CHANNEL_COUNT; ++j ){
+        for( j = 0; j < CHANNEL_COUNT; ++j ){
             *out++ = x;
-		}
-	}
-    
+        }
+    }
+
     return paContinue;
 }
 
@@ -119,12 +119,12 @@ int main(int argc, char* argv[])
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
-	deviceIndex = Pa_GetHostApiInfo( Pa_HostApiTypeIdToHostApiIndex( paMME ) )->defaultOutputDevice;
-	if( argc == 2 ){
-		sscanf( argv[1], "%d", &deviceIndex );
-	}
+    deviceIndex = Pa_GetHostApiInfo( Pa_HostApiTypeIdToHostApiIndex( paMME ) )->defaultOutputDevice;
+    if( argc == 2 ){
+        sscanf( argv[1], "%d", &deviceIndex );
+    }
 
-	printf( "using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
+    printf( "using device id %d (%s)\n", deviceIndex, Pa_GetDeviceInfo(deviceIndex)->name );
 
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
         data.sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
 
-	data.phase = 0;
+    data.phase = 0;
 
     outputParameters.device = deviceIndex;
     outputParameters.channelCount = CHANNEL_COUNT;
@@ -141,19 +141,19 @@ int main(int argc, char* argv[])
     outputParameters.hostApiSpecificStreamInfo = NULL;
 
     wmmeStreamInfo.size = sizeof(PaWinMmeStreamInfo);
-    wmmeStreamInfo.hostApiType = paMME; 
+    wmmeStreamInfo.hostApiType = paMME;
     wmmeStreamInfo.version = 1;
     wmmeStreamInfo.flags = paWinMmeUseLowLevelLatencyParameters | paWinMmeDontThrottleOverloadedProcessingThread;
     wmmeStreamInfo.framesPerBuffer = WMME_FRAMES_PER_BUFFER;
     wmmeStreamInfo.bufferCount = WMME_BUFFER_COUNT;
     outputParameters.hostApiSpecificStreamInfo = &wmmeStreamInfo;
-   
 
-	if( Pa_IsFormatSupported( 0, &outputParameters, SAMPLE_RATE ) == paFormatIsSupported  ){
-		printf( "Pa_IsFormatSupported reports device will support %d channels.\n", CHANNEL_COUNT );
-	}else{
-		printf( "Pa_IsFormatSupported reports device will not support %d channels.\n", CHANNEL_COUNT );
-	}
+
+    if( Pa_IsFormatSupported( 0, &outputParameters, SAMPLE_RATE ) == paFormatIsSupported  ){
+        printf( "Pa_IsFormatSupported reports device will support %d channels.\n", CHANNEL_COUNT );
+    }else{
+        printf( "Pa_IsFormatSupported reports device will not support %d channels.\n", CHANNEL_COUNT );
+    }
 
     err = Pa_OpenStream(
               &stream,
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_write_stop.c
+++ b/test/patest_write_stop.c
@@ -1,8 +1,8 @@
 /** @file patest_write_stop.c
-	@brief Play a few seconds of silence followed by a few cycles of a sine wave. Tests to make sure that pa_StopStream() completes playback in blocking I/O
-	@author Bjorn Roche of XO Audio (www.xoaudio.com)
-	@author Ross Bencina
-	@author Phil Burk
+    @brief Play a few seconds of silence followed by a few cycles of a sine wave. Tests to make sure that pa_StopStream() completes playback in blocking I/O
+    @author Bjorn Roche of XO Audio (www.xoaudio.com)
+    @author Ross Bencina
+    @author Phil Burk
 */
 /*
  * $Id$
@@ -32,13 +32,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -74,17 +74,17 @@ int main(void)
     const int   framesBy2  = FRAMES_PER_BUFFER >> 1;
     const float framesBy2f = (float) framesBy2 ;
 
-    
+
     printf( "PortAudio Test: output silence, followed by one buffer of a ramped sine wave. SR = %d, BufSize = %d\n",
             SAMPLE_RATE, FRAMES_PER_BUFFER);
-    
+
     /* initialise sinusoidal wavetable */
     for( i=0; i<TABLE_SIZE; i++ )
     {
         sine[i] = (float) sin( ((double)i/(double)TABLE_SIZE) * M_PI * 2. );
     }
 
-    
+
     err = Pa_Initialize();
     if( err != paNoError ) goto error;
 
@@ -125,15 +125,15 @@ int main(void)
     {
         err = Pa_WriteStream( stream, buffer, FRAMES_PER_BUFFER );
         if( err != paNoError ) goto error;
-    }   
+    }
     /* play a non-silent buffer once */
     for( j=0; j < FRAMES_PER_BUFFER; j++ )
     {
         float ramp = 1;
         if( j < framesBy2 )
-           ramp = j / framesBy2f;
+            ramp = j / framesBy2f;
         else
-           ramp = (FRAMES_PER_BUFFER - j) / framesBy2f ;
+            ramp = (FRAMES_PER_BUFFER - j) / framesBy2f ;
 
         buffer[j][0] = sine[left_phase] * ramp;  /* left */
         buffer[j][1] = sine[right_phase] * ramp;  /* right */
@@ -154,7 +154,7 @@ int main(void)
 
     Pa_Terminate();
     printf("Test finished.\n");
-    
+
     return err;
 error:
     Pa_Terminate();

--- a/test/patest_write_stop_hang_illegal.c
+++ b/test/patest_write_stop_hang_illegal.c
@@ -1,8 +1,8 @@
 /** @file patest_write_stop_threads.c
-	@brief Call Pa_StopStream() from another thread to see if PortAudio hangs.
-	@author Bjorn Roche of XO Audio (www.xoaudio.com)
-	@author Ross Bencina
-	@author Phil Burk
+    @brief Call Pa_StopStream() from another thread to see if PortAudio hangs.
+    @author Bjorn Roche of XO Audio (www.xoaudio.com)
+    @author Ross Bencina
+    @author Phil Burk
 */
 /*
  * $Id$


### PR DESCRIPTION
Convert tabs to 4 spaces. Indent by 4 spaces. Strip trailing whitespace. Ensure EOL at EOF.