### PR TITLE
Add missing PaWasapi_GetDeviceMixFormat cmake DLL export

### DIFF
--- a/cmake_support/template_portaudio.def
+++ b/cmake_support/template_portaudio.def
@@ -51,3 +51,4 @@ PaUtil_SetDebugPrintFunction        @55
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetFramesPerHostBuffer     @60
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetJackDescription         @61
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetJackCount               @62
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetDeviceMixFormat         @63


### PR DESCRIPTION
This omission made it impossible to use `PaWasapi_GetDeviceMixFormat()` from a PortAudio DLL built using CMake.