### PR TITLE
Ignore the Visual Studio CMake settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ portaudio-2.0.pc
 
 # Visual Studio CMake build output folder 
 out/
+
+# Visual Studio CMake settings file
+CMakeSettings.json


### PR DESCRIPTION
When using CMake, this file is written by Visual Studio to hold custom CMake parameters.