### PR TITLE
OSS: include both /dev/dsp and /dev/dsp0

### DIFF
--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -535,13 +535,13 @@ static PaError BuildDeviceList( PaOSSHostApiRepresentation *ossApi )
      * add it to a linked list.
      * A: Set an arbitrary of 100 devices, should probably be a smarter way. */
 
-    for( i = 0; i < 100; i++ )
+    for( i = -1; i < 100; i++ )
     {
        char deviceName[32];
        PaDeviceInfo *deviceInfo;
        int testResult;
 
-       if( i == 0 )
+       if( i == -1 )
           snprintf(deviceName, sizeof (deviceName), "%s", DEVICE_NAME_BASE);
        else
           snprintf(deviceName, sizeof (deviceName), "%s%d", DEVICE_NAME_BASE, i);


### PR DESCRIPTION
On FreeBSD /dev/dsp is the default device but may not be /dev/dsp0.
PortAudio in the FreeBSD ports collection initially had a patch to
replace the default device with /dev/dsp (for example, with three
devices and /dev/dsp1 as the default we'd have /dev/dsp0, /dev/dsp,
/dev/dsp2).  This caused some trouble (the first device is no longer
default) and was later replaced with this change, leaving /dev/dsp
as the first entry, and just adding each /dev/dsp%d that exists.

FreeBSD bugs 208968 and 236118.