### PR TITLE
OSS: correct test for unsupported formats

### DIFF
--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -961,7 +961,7 @@ static PaError GetAvailableFormats( PaOssStreamComponent *component, PaSampleFor
         frmts |= paInt8;
     if( mask & AFMT_S16_NE )
         frmts |= paInt16;
-    else
+    if( frmts == 0 )
         result = paSampleFormatNotSupported;
 
     *availableFormats = frmts;


### PR DESCRIPTION
Previously GetAvailableFormats returned paSampleFormatNotSupported if
AFMT_S16_NE was not supported, regardless of the supported state of any
other formats.  Instead, return paSampleFormatNotSupported if no
supported formats are found.