### PR TITLE
OSS: remove old runtime AFMT_S16_NE endianness compat

### DIFF
--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -927,6 +927,11 @@ static PaError Pa2OssFormat( PaSampleFormat paFormat, int *ossFormat )
         case paInt16:
             *ossFormat = AFMT_S16_NE;
             break;
+#ifdef AFMT_S32_NE
+        case paInt32:
+            *ossFormat = AFMT_S32_NE;
+            break;
+#endif
         default:
             return paInternalError;     /* This shouldn't happen */
     }
@@ -950,6 +955,10 @@ static PaError GetAvailableFormats( PaOssStreamComponent *component, PaSampleFor
         frmts |= paInt8;
     if( mask & AFMT_S16_NE )
         frmts |= paInt16;
+#ifdef AFMT_S32_NE
+    if( mask & AFMT_S32_NE )
+        frmts |= paInt32;
+#endif
     if( frmts == 0 )
         result = paSampleFormatNotSupported;
 

--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -111,18 +111,8 @@ static pthread_t mainThread_;
     } while( 0 );
 
 #ifndef AFMT_S16_NE
-#define AFMT_S16_NE  Get_AFMT_S16_NE()
-/*********************************************************************
- * Some versions of OSS do not define AFMT_S16_NE. So check CPU.
- * PowerPC is Big Endian. X86 is Little Endian.
- */
-static int Get_AFMT_S16_NE( void )
-{
-    long testData = 1;
-    char *ptr = (char *) &testData;
-    int isLittle = ( *ptr == 1 ); /* Does address point to least significant byte? */
-    return isLittle ? AFMT_S16_LE : AFMT_S16_BE;
-}
+/* Implement compile-time endian #defines if this is still true on any OS. */
+#error OSS implementation does not support AFMT_S16_NE.
 #endif
 
 /* PaOSSHostApiRepresentation - host api datastructure specific to this implementation */


### PR DESCRIPTION
We had a runtime endianness test for OSS systems which do not define
AFMT_S16_NE.  It is unclear if any operating system needs this today,
but if one does this should be implemented as a compile-time #define
instead.

Patches are forthcoming for AFMT_S32_NE for FreeBSD and there is no
value in extending this runtime endianness test.