### PR TITLE
build: Add missing src directory.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -146,6 +146,7 @@ SRC_DIRS = \
 	src/hostapi/dsound \
 	src/hostapi/jack \
 	src/hostapi/oss \
+	src/hostapi/skeleton \
 	src/hostapi/wasapi \
 	src/hostapi/wdmks \
 	src/hostapi/wmme \


### PR DESCRIPTION
This fixes out of tree builds when using slibtool (https://dev.midipix.org/cross/slibtool).
```
rdlibtool: error logged in slbt_exec_compile(), line 158: path not found: src/hostapi/skeleton/.libs/.
make: *** [Makefile:227: src/hostapi/skeleton/pa_hostapi_skeleton.lo] Error 2
```
Full log:  [build.log](https://github.com/PortAudio/portaudio/files/5846439/build.log)
