### PR TITLE
build: Fix builds with parallel make.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -220,16 +220,16 @@ clean:
 distclean: clean
 	$(RM) config.log config.status Makefile libtool portaudio-2.0.pc
 
-%.o: %.c $(MAKEFILE) $(PAINC)
+%.o: %.c $(MAKEFILE) $(PAINC) lib-stamp
 	$(CC) -c $(CFLAGS) $< -o $@
 
-%.lo: %.c $(MAKEFILE) $(PAINC)
+%.lo: %.c $(MAKEFILE) $(PAINC) lib-stamp
 	$(LIBTOOL) --mode=compile $(CC) -c $(CFLAGS) $< -o $@
 
-%.lo: %.cpp $(MAKEFILE) $(PAINC)
+%.lo: %.cpp $(MAKEFILE) $(PAINC) lib-stamp
 	$(LIBTOOL) --mode=compile --tag=CXX $(CXX) -c $(CXXFLAGS) $< -o $@
 
-%.o: %.cpp $(MAKEFILE) $(PAINC)
+%.o: %.cpp $(MAKEFILE) $(PAINC) lib-stamp
 	$(CXX) -c $(CXXFLAGS) $< -o $@
 
 %.o: %.asm


### PR DESCRIPTION
When building portaudio with `-j2` or greater, slibtool (https://dev.midipix.org/cross/slibtool) and `ccache(1)` the build fails because `mkdir(1)` is slower than slibtool. This does not seem to happen with GNU libtool which is slower than `mkdir`.
```
rdlibtool: error logged in slbt_exec_compile(), line 158: path not found: src/common/.libs/.
make: *** [Makefile:228: src/common/pa_allocation.lo] Error 2
make: *** Waiting for unfinished jobs....
touch lib-stamp
```
Full log: [build.log](https://github.com/PortAudio/portaudio/files/5847183/build.log)

I fixed this by applying the `lib-stamp` as a dependency wherever it might be needed to be sure this doesn't happen again.