### PR TITLE
Whitespace cleanup in test

### DIFF
--- a/test/patest_dsound_find_best_latency_params.c
+++ b/test/patest_dsound_find_best_latency_params.c
@@ -511,4 +511,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-

--- a/test/patest_dsound_low_level_latency_params.c
+++ b/test/patest_dsound_low_level_latency_params.c
@@ -184,4 +184,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-

--- a/test/patest_dsound_surround.c
+++ b/test/patest_dsound_surround.c
@@ -202,4 +202,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-

--- a/test/patest_mono.c
+++ b/test/patest_mono.c
@@ -153,4 +153,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-

--- a/test/patest_read_record.c
+++ b/test/patest_read_record.c
@@ -241,4 +241,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return -1;
 }
-

--- a/test/patest_wmme_find_best_latency_params.c
+++ b/test/patest_wmme_find_best_latency_params.c
@@ -515,4 +515,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-

--- a/test/patest_wmme_low_level_latency_params.c
+++ b/test/patest_wmme_low_level_latency_params.c
@@ -189,4 +189,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-


### PR DESCRIPTION
Same as #454, in this case there were only doubled EOLs on file ends.