### PR TITLE
Whitespace cleanup in qa

### DIFF
--- a/qa/loopback/src/audio_analyzer.c
+++ b/qa/loopback/src/audio_analyzer.c
@@ -704,4 +704,3 @@ int PaQa_AnalyseRecording( PaQaRecording *recording, PaQaTestTone *testTone, PaQ
 error:
     return -1;
 }
-


### PR DESCRIPTION
Same as #454, in this case only a single EOL was doubled