### PR TITLE
Whitespace cleanup in examples

### DIFF
--- a/examples/paex_read_write_wire.c
+++ b/examples/paex_read_write_wire.c
@@ -202,4 +202,3 @@ error2:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return -1;
 }
-

--- a/examples/paex_record.c
+++ b/examples/paex_record.c
@@ -351,4 +351,3 @@ done:
     }
     return err;
 }
-

--- a/examples/paex_record_file.c
+++ b/examples/paex_record_file.c
@@ -455,4 +455,3 @@ done:
     }
     return err;
 }
-

--- a/examples/paex_wmme_ac3.c
+++ b/examples/paex_wmme_ac3.c
@@ -218,4 +218,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-

--- a/examples/paex_wmme_surround.c
+++ b/examples/paex_wmme_surround.c
@@ -208,4 +208,3 @@ error:
     fprintf( stderr, "Error message: %s\n", Pa_GetErrorText( err ) );
     return err;
 }
-


### PR DESCRIPTION
Same as #454, only a few doubled EOLs here.