### PR TITLE
Whitespace cleanup in bindings

### DIFF
--- a/bindings/cpp/example/devs.cxx
+++ b/bindings/cpp/example/devs.cxx
@@ -8,44 +8,44 @@
 // ---------------------------------------------------------------------------------------
 
 void printSupportedStandardSampleRates(
-		const portaudio::DirectionSpecificStreamParameters &inputParameters, 
-		const portaudio::DirectionSpecificStreamParameters &outputParameters)
+        const portaudio::DirectionSpecificStreamParameters &inputParameters,
+        const portaudio::DirectionSpecificStreamParameters &outputParameters)
 {
-	static double STANDARD_SAMPLE_RATES[] = {
-		8000.0, 9600.0, 11025.0, 12000.0, 16000.0, 22050.0, 24000.0, 32000.0,
-		44100.0, 48000.0, 88200.0, 96000.0, -1 }; // negative terminated list
+    static double STANDARD_SAMPLE_RATES[] = {
+        8000.0, 9600.0, 11025.0, 12000.0, 16000.0, 22050.0, 24000.0, 32000.0,
+        44100.0, 48000.0, 88200.0, 96000.0, -1 }; // negative terminated list
 
-	int printCount = 0;
+    int printCount = 0;
 
-	for (int i = 0; STANDARD_SAMPLE_RATES[i] > 0; ++i)
-	{
-		portaudio::StreamParameters tmp = portaudio::StreamParameters(inputParameters, outputParameters, STANDARD_SAMPLE_RATES[i], 0, paNoFlag);
+    for (int i = 0; STANDARD_SAMPLE_RATES[i] > 0; ++i)
+    {
+        portaudio::StreamParameters tmp = portaudio::StreamParameters(inputParameters, outputParameters, STANDARD_SAMPLE_RATES[i], 0, paNoFlag);
 
-		if (tmp.isSupported())
-		{
-			if (printCount == 0)
-			{
-				std::cout << "    " << STANDARD_SAMPLE_RATES[i]; // 8.2
-				printCount = 1;
-			}
-			else if (printCount == 4)
-			{
-				std::cout << "," << std::endl;
-				std::cout << "    " << STANDARD_SAMPLE_RATES[i]; // 8.2
-				printCount = 1;
-			}
-			else
-			{
-				std::cout << ", " << STANDARD_SAMPLE_RATES[i]; // 8.2
-				++printCount;
-			}
-		}
-	}
+        if (tmp.isSupported())
+        {
+            if (printCount == 0)
+            {
+                std::cout << "    " << STANDARD_SAMPLE_RATES[i]; // 8.2
+                printCount = 1;
+            }
+            else if (printCount == 4)
+            {
+                std::cout << "," << std::endl;
+                std::cout << "    " << STANDARD_SAMPLE_RATES[i]; // 8.2
+                printCount = 1;
+            }
+            else
+            {
+                std::cout << ", " << STANDARD_SAMPLE_RATES[i]; // 8.2
+                ++printCount;
+            }
+        }
+    }
 
-	if (printCount == 0)
-		std::cout << "None" << std::endl;
-	else
-		std::cout << std::endl;
+    if (printCount == 0)
+        std::cout << "None" << std::endl;
+    else
+        std::cout << std::endl;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -53,125 +53,125 @@ void printSupportedStandardSampleRates(
 int main(int, char*[]);
 int main(int, char*[])
 {
-	try
-	{
-		portaudio::AutoSystem autoSys;
+    try
+    {
+        portaudio::AutoSystem autoSys;
 
-		portaudio::System &sys = portaudio::System::instance();
+        portaudio::System &sys = portaudio::System::instance();
 
-		std::cout << "PortAudio version number = " << sys.version() << std::endl;
-		std::cout << "PortAudio version text = '" << sys.versionText() << "'" << std::endl;
+        std::cout << "PortAudio version number = " << sys.version() << std::endl;
+        std::cout << "PortAudio version text = '" << sys.versionText() << "'" << std::endl;
 
-		int numDevices = sys.deviceCount();
-		std::cout << "Number of devices = " << numDevices << std::endl;
+        int numDevices = sys.deviceCount();
+        std::cout << "Number of devices = " << numDevices << std::endl;
 
-		for (portaudio::System::DeviceIterator i = sys.devicesBegin(); i != sys.devicesEnd(); ++i)
-		{
-			std::cout << "--------------------------------------- device #" << (*i).index() << std::endl;
+        for (portaudio::System::DeviceIterator i = sys.devicesBegin(); i != sys.devicesEnd(); ++i)
+        {
+            std::cout << "--------------------------------------- device #" << (*i).index() << std::endl;
 
-			// Mark global and API specific default devices:
-			bool defaultDisplayed = false;
+            // Mark global and API specific default devices:
+            bool defaultDisplayed = false;
 
-			if ((*i).isSystemDefaultInputDevice())
-			{
-				std::cout << "[ Default Input";
-				defaultDisplayed = true;
-			}
-			else if ((*i).isHostApiDefaultInputDevice())
-			{
-				std::cout << "[ Default " << (*i).hostApi().name() << " Input";
-				defaultDisplayed = true;
-			}
+            if ((*i).isSystemDefaultInputDevice())
+            {
+                std::cout << "[ Default Input";
+                defaultDisplayed = true;
+            }
+            else if ((*i).isHostApiDefaultInputDevice())
+            {
+                std::cout << "[ Default " << (*i).hostApi().name() << " Input";
+                defaultDisplayed = true;
+            }
 
-			if ((*i).isSystemDefaultOutputDevice())
-			{
-				std::cout << (defaultDisplayed ? "," : "[");
-				std::cout << " Default Output";
-				defaultDisplayed = true;
-			}
-			else if ((*i).isHostApiDefaultOutputDevice())
-			{
-				std::cout << (defaultDisplayed ? "," : "[");
-				std::cout << " Default " << (*i).hostApi().name() << " Output";
-				defaultDisplayed = true;
-			}
-			
-			if (defaultDisplayed)
-				std::cout << " ]" << std::endl;
+            if ((*i).isSystemDefaultOutputDevice())
+            {
+                std::cout << (defaultDisplayed ? "," : "[");
+                std::cout << " Default Output";
+                defaultDisplayed = true;
+            }
+            else if ((*i).isHostApiDefaultOutputDevice())
+            {
+                std::cout << (defaultDisplayed ? "," : "[");
+                std::cout << " Default " << (*i).hostApi().name() << " Output";
+                defaultDisplayed = true;
+            }
 
-			// Print device info:
-			std::cout << "Name                        = " << (*i).name() << std::endl;
-			std::cout << "Host API                    = " << (*i).hostApi().name() << std::endl;
-			std::cout << "Max inputs = " << (*i).maxInputChannels() << ", Max outputs = " << (*i).maxOutputChannels() << std::endl;
+            if (defaultDisplayed)
+                std::cout << " ]" << std::endl;
 
-			std::cout << "Default low input latency   = " << (*i).defaultLowInputLatency() << std::endl; // 8.3
-			std::cout << "Default low output latency  = " << (*i).defaultLowOutputLatency() << std::endl; // 8.3
-			std::cout << "Default high input latency  = " << (*i).defaultHighInputLatency() << std::endl; // 8.3
-			std::cout << "Default high output latency = " << (*i).defaultHighOutputLatency() << std::endl; // 8.3
+            // Print device info:
+            std::cout << "Name                        = " << (*i).name() << std::endl;
+            std::cout << "Host API                    = " << (*i).hostApi().name() << std::endl;
+            std::cout << "Max inputs = " << (*i).maxInputChannels() << ", Max outputs = " << (*i).maxOutputChannels() << std::endl;
+
+            std::cout << "Default low input latency   = " << (*i).defaultLowInputLatency() << std::endl; // 8.3
+            std::cout << "Default low output latency  = " << (*i).defaultLowOutputLatency() << std::endl; // 8.3
+            std::cout << "Default high input latency  = " << (*i).defaultHighInputLatency() << std::endl; // 8.3
+            std::cout << "Default high output latency = " << (*i).defaultHighOutputLatency() << std::endl; // 8.3
 
 #ifdef WIN32
-			// ASIO specific latency information:
-			if ((*i).hostApi().typeId() == paASIO)
-			{
-				portaudio::AsioDeviceAdapter asioDevice((*i));
+            // ASIO specific latency information:
+            if ((*i).hostApi().typeId() == paASIO)
+            {
+                portaudio::AsioDeviceAdapter asioDevice((*i));
 
-				std::cout << "ASIO minimum buffer size    = " << asioDevice.minBufferSize() << std::endl;
-				std::cout << "ASIO maximum buffer size    = " << asioDevice.maxBufferSize() << std::endl;
-				std::cout << "ASIO preferred buffer size  = " << asioDevice.preferredBufferSize() << std::endl;
+                std::cout << "ASIO minimum buffer size    = " << asioDevice.minBufferSize() << std::endl;
+                std::cout << "ASIO maximum buffer size    = " << asioDevice.maxBufferSize() << std::endl;
+                std::cout << "ASIO preferred buffer size  = " << asioDevice.preferredBufferSize() << std::endl;
 
-				if (asioDevice.granularity() == -1)
-					std::cout << "ASIO buffer granularity     = power of 2" << std::endl;
-				else
-					std::cout << "ASIO buffer granularity     = " << asioDevice.granularity() << std::endl;
-			}
+                if (asioDevice.granularity() == -1)
+                    std::cout << "ASIO buffer granularity     = power of 2" << std::endl;
+                else
+                    std::cout << "ASIO buffer granularity     = " << asioDevice.granularity() << std::endl;
+            }
 #endif // WIN32
 
-			std::cout << "Default sample rate         = " << (*i).defaultSampleRate() << std::endl; // 8.2
+            std::cout << "Default sample rate         = " << (*i).defaultSampleRate() << std::endl; // 8.2
 
-			// Poll for standard sample rates:
-			portaudio::DirectionSpecificStreamParameters inputParameters((*i), (*i).maxInputChannels(), portaudio::INT16, true, 0.0, NULL);
-			portaudio::DirectionSpecificStreamParameters outputParameters((*i), (*i).maxOutputChannels(), portaudio::INT16, true, 0.0, NULL);
+            // Poll for standard sample rates:
+            portaudio::DirectionSpecificStreamParameters inputParameters((*i), (*i).maxInputChannels(), portaudio::INT16, true, 0.0, NULL);
+            portaudio::DirectionSpecificStreamParameters outputParameters((*i), (*i).maxOutputChannels(), portaudio::INT16, true, 0.0, NULL);
 
-			if (inputParameters.numChannels() > 0)
-			{
-				std::cout << "Supported standard sample rates" << std::endl;
-				std::cout << " for half-duplex 16 bit " << inputParameters.numChannels() << " channel input = " << std::endl;
-				printSupportedStandardSampleRates(inputParameters, portaudio::DirectionSpecificStreamParameters::null());
-			}
+            if (inputParameters.numChannels() > 0)
+            {
+                std::cout << "Supported standard sample rates" << std::endl;
+                std::cout << " for half-duplex 16 bit " << inputParameters.numChannels() << " channel input = " << std::endl;
+                printSupportedStandardSampleRates(inputParameters, portaudio::DirectionSpecificStreamParameters::null());
+            }
 
-			if (outputParameters.numChannels() > 0)
-			{
-				std::cout << "Supported standard sample rates" << std::endl;
-				std::cout << " for half-duplex 16 bit " << outputParameters.numChannels() << " channel output = " << std::endl;
-				printSupportedStandardSampleRates(portaudio::DirectionSpecificStreamParameters::null(), outputParameters);
-			}
+            if (outputParameters.numChannels() > 0)
+            {
+                std::cout << "Supported standard sample rates" << std::endl;
+                std::cout << " for half-duplex 16 bit " << outputParameters.numChannels() << " channel output = " << std::endl;
+                printSupportedStandardSampleRates(portaudio::DirectionSpecificStreamParameters::null(), outputParameters);
+            }
 
-			if (inputParameters.numChannels() > 0 && outputParameters.numChannels() > 0)
-			{
-				std::cout << "Supported standard sample rates" << std::endl;
-				std::cout << " for full-duplex 16 bit " << inputParameters.numChannels() << " channel input, " << outputParameters.numChannels() << " channel output = " << std::endl;
-				printSupportedStandardSampleRates(inputParameters, outputParameters);
-			}
-		}
+            if (inputParameters.numChannels() > 0 && outputParameters.numChannels() > 0)
+            {
+                std::cout << "Supported standard sample rates" << std::endl;
+                std::cout << " for full-duplex 16 bit " << inputParameters.numChannels() << " channel input, " << outputParameters.numChannels() << " channel output = " << std::endl;
+                printSupportedStandardSampleRates(inputParameters, outputParameters);
+            }
+        }
 
-		std::cout << "----------------------------------------------" << std::endl;
-	}
-	catch (const portaudio::PaException &e)
-	{
-		std::cout << "A PortAudio error occurred: " << e.paErrorText() << std::endl;
-	}
-	catch (const portaudio::PaCppException &e)
-	{
-		std::cout << "A PortAudioCpp error occurred: " << e.what() << std::endl;
-	}
-	catch (const std::exception &e)
-	{
-		std::cout << "A generic exception occurred: " << e.what() << std::endl;
-	}
-	catch (...)
-	{
-		std::cout << "An unknown exception occurred." << std::endl;
-	}
+        std::cout << "----------------------------------------------" << std::endl;
+    }
+    catch (const portaudio::PaException &e)
+    {
+        std::cout << "A PortAudio error occurred: " << e.paErrorText() << std::endl;
+    }
+    catch (const portaudio::PaCppException &e)
+    {
+        std::cout << "A PortAudioCpp error occurred: " << e.what() << std::endl;
+    }
+    catch (const std::exception &e)
+    {
+        std::cout << "A generic exception occurred: " << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cout << "An unknown exception occurred." << std::endl;
+    }
 
-	return 0;
+    return 0;
 }

--- a/bindings/cpp/example/sine.cxx
+++ b/bindings/cpp/example/sine.cxx
@@ -20,50 +20,50 @@ const int TABLE_SIZE = 200;
 class SineGenerator
 {
 public:
-	SineGenerator(int tableSize) : tableSize_(tableSize), leftPhase_(0), rightPhase_(0)
-	{
-		const double PI = 3.14159265;
-		table_ = new float[tableSize];
-		for (int i = 0; i < tableSize; ++i)
-		{
-			table_[i] = 0.125f * (float)sin(((double)i/(double)tableSize)*PI*2.);
-		}
-	}
+    SineGenerator(int tableSize) : tableSize_(tableSize), leftPhase_(0), rightPhase_(0)
+    {
+        const double PI = 3.14159265;
+        table_ = new float[tableSize];
+        for (int i = 0; i < tableSize; ++i)
+        {
+            table_[i] = 0.125f * (float)sin(((double)i/(double)tableSize)*PI*2.);
+        }
+    }
 
-	~SineGenerator()
-	{
-		delete[] table_;
-	}
+    ~SineGenerator()
+    {
+        delete[] table_;
+    }
 
-	int generate(const void *inputBuffer, void *outputBuffer, unsigned long framesPerBuffer, 
-		const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags)
-	{
-		assert(outputBuffer != NULL);
+    int generate(const void *inputBuffer, void *outputBuffer, unsigned long framesPerBuffer,
+        const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags)
+    {
+        assert(outputBuffer != NULL);
 
-		float **out = static_cast<float **>(outputBuffer);
+        float **out = static_cast<float **>(outputBuffer);
 
-		for (unsigned int i = 0; i < framesPerBuffer; ++i)
-		{
-			out[0][i] = table_[leftPhase_];
-			out[1][i] = table_[rightPhase_];
+        for (unsigned int i = 0; i < framesPerBuffer; ++i)
+        {
+            out[0][i] = table_[leftPhase_];
+            out[1][i] = table_[rightPhase_];
 
-			leftPhase_ += 1;
-			if (leftPhase_ >= tableSize_)
-				leftPhase_ -= tableSize_;
+            leftPhase_ += 1;
+            if (leftPhase_ >= tableSize_)
+                leftPhase_ -= tableSize_;
 
-			rightPhase_ += 3;
-			if (rightPhase_ >= tableSize_)
-				rightPhase_ -= tableSize_;
-		}
+            rightPhase_ += 3;
+            if (rightPhase_ >= tableSize_)
+                rightPhase_ -= tableSize_;
+        }
 
-		return paContinue;
-	}
+        return paContinue;
+    }
 
 private:
-	float *table_;
-	int tableSize_;
-	int leftPhase_;
-	int rightPhase_;
+    float *table_;
+    int tableSize_;
+    int leftPhase_;
+    int rightPhase_;
 };
 
 // ---------------------------------------------------------------------------------------
@@ -72,66 +72,64 @@ private:
 int main(int, char *[]);
 int main(int, char *[])
 {
-	try
-	{
-		// Create a SineGenerator object:
-		SineGenerator sineGenerator(TABLE_SIZE);
+    try
+    {
+        // Create a SineGenerator object:
+        SineGenerator sineGenerator(TABLE_SIZE);
 
-		std::cout << "Setting up PortAudio..." << std::endl;
+        std::cout << "Setting up PortAudio..." << std::endl;
 
-		// Set up the System:
-		portaudio::AutoSystem autoSys;
-		portaudio::System &sys = portaudio::System::instance();
+        // Set up the System:
+        portaudio::AutoSystem autoSys;
+        portaudio::System &sys = portaudio::System::instance();
 
-		// Set up the parameters required to open a (Callback)Stream:
-		portaudio::DirectionSpecificStreamParameters outParams(sys.defaultOutputDevice(), 2, portaudio::FLOAT32, false, sys.defaultOutputDevice().defaultLowOutputLatency(), NULL);
-		portaudio::StreamParameters params(portaudio::DirectionSpecificStreamParameters::null(), outParams, SAMPLE_RATE, FRAMES_PER_BUFFER, paClipOff);
+        // Set up the parameters required to open a (Callback)Stream:
+        portaudio::DirectionSpecificStreamParameters outParams(sys.defaultOutputDevice(), 2, portaudio::FLOAT32, false, sys.defaultOutputDevice().defaultLowOutputLatency(), NULL);
+        portaudio::StreamParameters params(portaudio::DirectionSpecificStreamParameters::null(), outParams, SAMPLE_RATE, FRAMES_PER_BUFFER, paClipOff);
 
-		std::cout << "Opening stereo output stream..." << std::endl;
+        std::cout << "Opening stereo output stream..." << std::endl;
 
-		// Create (and open) a new Stream, using the SineGenerator::generate function as a callback:
-		portaudio::MemFunCallbackStream<SineGenerator> stream(params, sineGenerator, &SineGenerator::generate);
+        // Create (and open) a new Stream, using the SineGenerator::generate function as a callback:
+        portaudio::MemFunCallbackStream<SineGenerator> stream(params, sineGenerator, &SineGenerator::generate);
 
-		std::cout << "Starting playback for " << NUM_SECONDS << " seconds." << std::endl;
+        std::cout << "Starting playback for " << NUM_SECONDS << " seconds." << std::endl;
 
-		// Start the Stream (audio playback starts):
-		stream.start();
+        // Start the Stream (audio playback starts):
+        stream.start();
 
-		// Wait for 5 seconds:
-		sys.sleep(NUM_SECONDS * 1000);
+        // Wait for 5 seconds:
+        sys.sleep(NUM_SECONDS * 1000);
 
-		std::cout << "Closing stream..." <<std::endl;
+        std::cout << "Closing stream..." <<std::endl;
 
-		// Stop the Stream (not strictly needed as termintating the System will also stop all open Streams):
-		stream.stop();
+        // Stop the Stream (not strictly needed as termintating the System will also stop all open Streams):
+        stream.stop();
 
-		// Close the Stream (not strictly needed as terminating the System will also close all open Streams):
-		stream.close();
+        // Close the Stream (not strictly needed as terminating the System will also close all open Streams):
+        stream.close();
 
-		// Terminate the System (not strictly needed as the AutoSystem will also take care of this when it 
-		// goes out of scope):
-		sys.terminate();
+        // Terminate the System (not strictly needed as the AutoSystem will also take care of this when it
+        // goes out of scope):
+        sys.terminate();
 
-		std::cout << "Test finished." << std::endl;
-	}
-	catch (const portaudio::PaException &e)
-	{
-		std::cout << "A PortAudio error occurred: " << e.paErrorText() << std::endl;
-	}
-	catch (const portaudio::PaCppException &e)
-	{
-		std::cout << "A PortAudioCpp error occurred: " << e.what() << std::endl;
-	}
-	catch (const std::exception &e)
-	{
-		std::cout << "A generic exception occurred: " << e.what() << std::endl;
-	}
-	catch (...)
-	{
-		std::cout << "An unknown exception occurred." << std::endl;
-	}
+        std::cout << "Test finished." << std::endl;
+    }
+    catch (const portaudio::PaException &e)
+    {
+        std::cout << "A PortAudio error occurred: " << e.paErrorText() << std::endl;
+    }
+    catch (const portaudio::PaCppException &e)
+    {
+        std::cout << "A PortAudioCpp error occurred: " << e.what() << std::endl;
+    }
+    catch (const std::exception &e)
+    {
+        std::cout << "A generic exception occurred: " << e.what() << std::endl;
+    }
+    catch (...)
+    {
+        std::cout << "An unknown exception occurred." << std::endl;
+    }
 
-	return 0;
+    return 0;
 }
-
-

--- a/bindings/cpp/include/portaudiocpp/AsioDeviceAdapter.hxx
+++ b/bindings/cpp/include/portaudiocpp/AsioDeviceAdapter.hxx
@@ -4,41 +4,41 @@
 namespace portaudio
 {
 
-	// Forward declaration(s):
-	class Device;
+    // Forward declaration(s):
+    class Device;
 
-	// Declaration(s):
-	//////
-	/// @brief Adapts the given Device to an ASIO specific extension.
-	///
-	/// Deleting the AsioDeviceAdapter does not affect the underlying 
-	/// Device.
-	//////
-	class AsioDeviceAdapter
-	{
-	public:
-		AsioDeviceAdapter(Device &device);
+    // Declaration(s):
+    //////
+    /// @brief Adapts the given Device to an ASIO specific extension.
+    ///
+    /// Deleting the AsioDeviceAdapter does not affect the underlying
+    /// Device.
+    //////
+    class AsioDeviceAdapter
+    {
+    public:
+        AsioDeviceAdapter(Device &device);
 
-		Device &device();
+        Device &device();
 
-		long minBufferSize() const;
-		long maxBufferSize() const;
-		long preferredBufferSize() const;
-		long granularity() const;
+        long minBufferSize() const;
+        long maxBufferSize() const;
+        long preferredBufferSize() const;
+        long granularity() const;
 
-		void showControlPanel(void *systemSpecific);
+        void showControlPanel(void *systemSpecific);
 
-		const char *inputChannelName(int channelIndex) const;
-		const char *outputChannelName(int channelIndex) const;
+        const char *inputChannelName(int channelIndex) const;
+        const char *outputChannelName(int channelIndex) const;
 
-	private:
-		Device *device_;
+    private:
+        Device *device_;
 
-		long minBufferSize_;
-		long maxBufferSize_;
-		long preferredBufferSize_;
-		long granularity_;
-	};
+        long minBufferSize_;
+        long maxBufferSize_;
+        long preferredBufferSize_;
+        long granularity_;
+    };
 }
 
 #endif // INCLUDED_PORTAUDIO_ASIODEVICEADAPTER_HXX

--- a/bindings/cpp/include/portaudiocpp/AutoSystem.hxx
+++ b/bindings/cpp/include/portaudiocpp/AutoSystem.hxx
@@ -11,48 +11,48 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief A RAII idiom class to ensure automatic clean-up when an exception is 
-	/// raised.
-	///
-	/// A simple helper class which uses the 'Resource Acquisition is Initialization' 
-	/// idiom (RAII). Use this class to initialize/terminate the System rather than 
-	/// using System directly. AutoSystem must be created on stack and must be valid 
-	/// throughout the time you wish to use PortAudioCpp. Your 'main' function might be 
-	/// a good place for it.
-	///
-	/// To avoid having to type portaudio::System::instance().xyz() all the time, it's usually 
-	/// a good idea to make a reference to the System which can be accessed directly.
-	/// @verbatim
-	/// portaudio::AutoSys autoSys;
-	/// portaudio::System &sys = portaudio::System::instance();
-	/// @endverbatim
-	//////
-	class AutoSystem
-	{
-	public:
-		AutoSystem(bool initialize = true)
-		{
-			if (initialize)
-				System::initialize();
-		}
+    //////
+    /// @brief A RAII idiom class to ensure automatic clean-up when an exception is
+    /// raised.
+    ///
+    /// A simple helper class which uses the 'Resource Acquisition is Initialization'
+    /// idiom (RAII). Use this class to initialize/terminate the System rather than
+    /// using System directly. AutoSystem must be created on stack and must be valid
+    /// throughout the time you wish to use PortAudioCpp. Your 'main' function might be
+    /// a good place for it.
+    ///
+    /// To avoid having to type portaudio::System::instance().xyz() all the time, it's usually
+    /// a good idea to make a reference to the System which can be accessed directly.
+    /// @verbatim
+    /// portaudio::AutoSys autoSys;
+    /// portaudio::System &sys = portaudio::System::instance();
+    /// @endverbatim
+    //////
+    class AutoSystem
+    {
+    public:
+        AutoSystem(bool initialize = true)
+        {
+            if (initialize)
+                System::initialize();
+        }
 
-		~AutoSystem()
-		{
-			if (System::exists())
-				System::terminate();
-		}
+        ~AutoSystem()
+        {
+            if (System::exists())
+                System::terminate();
+        }
 
-		void initialize()
-		{
-			System::initialize();
-		}
+        void initialize()
+        {
+            System::initialize();
+        }
 
-		void terminate()
-		{
-			System::terminate();
-		}
-	};
+        void terminate()
+        {
+            System::terminate();
+        }
+    };
 
 
 } // namespace portaudio

--- a/bindings/cpp/include/portaudiocpp/BlockingStream.hxx
+++ b/bindings/cpp/include/portaudiocpp/BlockingStream.hxx
@@ -12,28 +12,28 @@ namespace portaudio
 
 
 
-	//////
-	/// @brief Stream class for blocking read/write-style input and output.
-	//////
-	class BlockingStream : public Stream
-	{
-	public:
-		BlockingStream();
-		BlockingStream(const StreamParameters &parameters);
-		~BlockingStream();
+    //////
+    /// @brief Stream class for blocking read/write-style input and output.
+    //////
+    class BlockingStream : public Stream
+    {
+    public:
+        BlockingStream();
+        BlockingStream(const StreamParameters &parameters);
+        ~BlockingStream();
 
-		void open(const StreamParameters &parameters);
+        void open(const StreamParameters &parameters);
 
-		void read(void *buffer, unsigned long numFrames);
-		void write(const void *buffer, unsigned long numFrames);
+        void read(void *buffer, unsigned long numFrames);
+        void write(const void *buffer, unsigned long numFrames);
 
-		signed long availableReadSize() const;
-		signed long availableWriteSize() const;
+        signed long availableReadSize() const;
+        signed long availableWriteSize() const;
 
-	private:
-		BlockingStream(const BlockingStream &); // non-copyable
-		BlockingStream &operator=(const BlockingStream &); // non-copyable
-	};
+    private:
+        BlockingStream(const BlockingStream &); // non-copyable
+        BlockingStream &operator=(const BlockingStream &); // non-copyable
+    };
 
 
 
@@ -42,4 +42,3 @@ namespace portaudio
 // ---------------------------------------------------------------------------------------
 
 #endif // INCLUDED_PORTAUDIO_BLOCKINGSTREAM_HXX
-

--- a/bindings/cpp/include/portaudiocpp/CFunCallbackStream.hxx
+++ b/bindings/cpp/include/portaudiocpp/CFunCallbackStream.hxx
@@ -12,7 +12,7 @@
 // Forward declaration(s)
 namespace portaudio
 {
-	class StreamParameters;
+    class StreamParameters;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -20,30 +20,29 @@ namespace portaudio
 // Declaration(s):
 namespace portaudio
 {
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// @brief Callback stream using a free function with C linkage. It's important that the function 
-	/// the passed function pointer points to is declared ``extern "C"''.
-	//////
-	class CFunCallbackStream : public CallbackStream
-	{
-	public:
-		CFunCallbackStream();
-		CFunCallbackStream(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData);
-		~CFunCallbackStream();
-		
-		void open(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData);
+    //////
+    /// @brief Callback stream using a free function with C linkage. It's important that the function
+    /// the passed function pointer points to is declared ``extern "C"''.
+    //////
+    class CFunCallbackStream : public CallbackStream
+    {
+    public:
+        CFunCallbackStream();
+        CFunCallbackStream(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData);
+        ~CFunCallbackStream();
 
-	private:
-		CFunCallbackStream(const CFunCallbackStream &); // non-copyable
-		CFunCallbackStream &operator=(const CFunCallbackStream &); // non-copyable
-	};
+        void open(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData);
 
-	// -----------------------------------------------------------------------------------
+    private:
+        CFunCallbackStream(const CFunCallbackStream &); // non-copyable
+        CFunCallbackStream &operator=(const CFunCallbackStream &); // non-copyable
+    };
+
+    // -----------------------------------------------------------------------------------
 } // portaudio
 
 // ---------------------------------------------------------------------------------------
 
 #endif // INCLUDED_PORTAUDIO_MEMFUNCALLBACKSTREAM_HXX
-

--- a/bindings/cpp/include/portaudiocpp/CallbackInterface.hxx
+++ b/bindings/cpp/include/portaudiocpp/CallbackInterface.hxx
@@ -9,34 +9,34 @@
 
 namespace portaudio
 {
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// @brief Interface for an object that's callable as a PortAudioCpp callback object (ie that implements the 
-	/// paCallbackFun method).
-	//////
-	class CallbackInterface
-	{
-	public:
-		virtual ~CallbackInterface() {}
+    //////
+    /// @brief Interface for an object that's callable as a PortAudioCpp callback object (ie that implements the
+    /// paCallbackFun method).
+    //////
+    class CallbackInterface
+    {
+    public:
+        virtual ~CallbackInterface() {}
 
-		virtual int paCallbackFun(const void *inputBuffer, void *outputBuffer, unsigned long numFrames, 
-			const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags) = 0;
-	};
+        virtual int paCallbackFun(const void *inputBuffer, void *outputBuffer, unsigned long numFrames,
+            const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags) = 0;
+    };
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	namespace impl
-	{
-		extern "C"
-		{
-			int callbackInterfaceToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames, 
-				const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, 
-				void *userData);
-		} // extern "C"
-	}
+    namespace impl
+    {
+        extern "C"
+        {
+            int callbackInterfaceToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames,
+                const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags,
+                void *userData);
+        } // extern "C"
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
 } // namespace portaudio
 

--- a/bindings/cpp/include/portaudiocpp/CallbackStream.hxx
+++ b/bindings/cpp/include/portaudiocpp/CallbackStream.hxx
@@ -14,23 +14,23 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief Base class for all Streams which use a callback-based mechanism.
-	//////
-	class CallbackStream : public Stream
-	{
-	protected:
-		CallbackStream();
-		virtual ~CallbackStream();
+    //////
+    /// @brief Base class for all Streams which use a callback-based mechanism.
+    //////
+    class CallbackStream : public Stream
+    {
+    protected:
+        CallbackStream();
+        virtual ~CallbackStream();
 
-	public:
-		// stream info (time-varying)
-		double cpuLoad() const;
+    public:
+        // stream info (time-varying)
+        double cpuLoad() const;
 
-	private:
-		CallbackStream(const CallbackStream &); // non-copyable
-		CallbackStream &operator=(const CallbackStream &); // non-copyable
-	};
+    private:
+        CallbackStream(const CallbackStream &); // non-copyable
+        CallbackStream &operator=(const CallbackStream &); // non-copyable
+    };
 
 
 } // namespace portaudio

--- a/bindings/cpp/include/portaudiocpp/CppFunCallbackStream.hxx
+++ b/bindings/cpp/include/portaudiocpp/CppFunCallbackStream.hxx
@@ -12,7 +12,7 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class StreamParameters;
+    class StreamParameters;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -22,61 +22,61 @@ namespace portaudio
 {
 
 
-	namespace impl
-	{
-		extern "C"
-		{
-			int cppCallbackToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames, 
-				const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, 
-				void *userData);
-		} // extern "C"
-	}
+    namespace impl
+    {
+        extern "C"
+        {
+            int cppCallbackToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames,
+                const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags,
+                void *userData);
+        } // extern "C"
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// @brief Callback stream using a C++ function (either a free function or a static function) 
-	/// callback.
-	//////
-	class FunCallbackStream : public CallbackStream
-	{
-	public:
-		typedef int (*CallbackFunPtr)(const void *inputBuffer, void *outputBuffer, unsigned long numFrames, 
-			const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, 
-			void *userData);
+    //////
+    /// @brief Callback stream using a C++ function (either a free function or a static function)
+    /// callback.
+    //////
+    class FunCallbackStream : public CallbackStream
+    {
+    public:
+        typedef int (*CallbackFunPtr)(const void *inputBuffer, void *outputBuffer, unsigned long numFrames,
+            const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags,
+            void *userData);
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		//////
-		/// @brief Simple structure containing a function pointer to the C++ callback function and a 
-		/// (void) pointer to the user supplied data.
-		//////
-		struct CppToCCallbackData
-		{
-			CppToCCallbackData();
-			CppToCCallbackData(CallbackFunPtr funPtr, void *userData);
-			void init(CallbackFunPtr funPtr, void *userData);
+        //////
+        /// @brief Simple structure containing a function pointer to the C++ callback function and a
+        /// (void) pointer to the user supplied data.
+        //////
+        struct CppToCCallbackData
+        {
+            CppToCCallbackData();
+            CppToCCallbackData(CallbackFunPtr funPtr, void *userData);
+            void init(CallbackFunPtr funPtr, void *userData);
 
-			CallbackFunPtr funPtr;
-			void *userData;
-		};
+            CallbackFunPtr funPtr;
+            void *userData;
+        };
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		FunCallbackStream();
-		FunCallbackStream(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData);
-		~FunCallbackStream();
+        FunCallbackStream();
+        FunCallbackStream(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData);
+        ~FunCallbackStream();
 
-		void open(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData);
+        void open(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData);
 
-	private:
-		FunCallbackStream(const FunCallbackStream &); // non-copyable
-		FunCallbackStream &operator=(const FunCallbackStream &); // non-copyable
+    private:
+        FunCallbackStream(const FunCallbackStream &); // non-copyable
+        FunCallbackStream &operator=(const FunCallbackStream &); // non-copyable
 
-		CppToCCallbackData adapterData_;
+        CppToCCallbackData adapterData_;
 
-		void open(const StreamParameters &parameters);
-	};
+        void open(const StreamParameters &parameters);
+    };
 
 
 } // portaudio

--- a/bindings/cpp/include/portaudiocpp/Device.hxx
+++ b/bindings/cpp/include/portaudiocpp/Device.hxx
@@ -14,8 +14,8 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class System;
-	class HostApi;
+    class System;
+    class HostApi;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -24,68 +24,67 @@ namespace portaudio
 namespace portaudio
 {
 
-	//////
-	/// @brief Class which represents a PortAudio device in the System.
-	///
-	/// A single physical device in the system may have multiple PortAudio 
-	/// Device representations using different HostApi 's though. A Device 
-	/// can be half-duplex or full-duplex. A half-duplex Device can be used 
-	/// to create a half-duplex Stream. A full-duplex Device can be used to 
-	/// create a full-duplex Stream. If supported by the HostApi, two 
-	/// half-duplex Devices can even be used to create a full-duplex Stream.
-	///
-	/// Note that Device objects are very light-weight and can be passed around 
-	/// by-value.
-	//////
-	class Device
-	{
-	public:
-		// query info: name, max in channels, max out channels, 
-		// default low/high input/output latency, default sample rate
-		PaDeviceIndex index() const;
-		const char *name() const;
-		int maxInputChannels() const;
-		int maxOutputChannels() const;
-		PaTime defaultLowInputLatency() const;
-		PaTime defaultHighInputLatency() const;
-		PaTime defaultLowOutputLatency() const;
-		PaTime defaultHighOutputLatency() const;
-		double defaultSampleRate() const;
+    //////
+    /// @brief Class which represents a PortAudio device in the System.
+    ///
+    /// A single physical device in the system may have multiple PortAudio
+    /// Device representations using different HostApi 's though. A Device
+    /// can be half-duplex or full-duplex. A half-duplex Device can be used
+    /// to create a half-duplex Stream. A full-duplex Device can be used to
+    /// create a full-duplex Stream. If supported by the HostApi, two
+    /// half-duplex Devices can even be used to create a full-duplex Stream.
+    ///
+    /// Note that Device objects are very light-weight and can be passed around
+    /// by-value.
+    //////
+    class Device
+    {
+    public:
+        // query info: name, max in channels, max out channels,
+        // default low/high input/output latency, default sample rate
+        PaDeviceIndex index() const;
+        const char *name() const;
+        int maxInputChannels() const;
+        int maxOutputChannels() const;
+        PaTime defaultLowInputLatency() const;
+        PaTime defaultHighInputLatency() const;
+        PaTime defaultLowOutputLatency() const;
+        PaTime defaultHighOutputLatency() const;
+        double defaultSampleRate() const;
 
-		bool isInputOnlyDevice() const; // extended
-		bool isOutputOnlyDevice() const; // extended
-		bool isFullDuplexDevice() const; // extended
-		bool isSystemDefaultInputDevice() const; // extended
-		bool isSystemDefaultOutputDevice() const; // extended
-		bool isHostApiDefaultInputDevice() const; // extended
-		bool isHostApiDefaultOutputDevice() const; // extended
+        bool isInputOnlyDevice() const; // extended
+        bool isOutputOnlyDevice() const; // extended
+        bool isFullDuplexDevice() const; // extended
+        bool isSystemDefaultInputDevice() const; // extended
+        bool isSystemDefaultOutputDevice() const; // extended
+        bool isHostApiDefaultInputDevice() const; // extended
+        bool isHostApiDefaultOutputDevice() const; // extended
 
-		bool operator==(const Device &rhs) const;
-		bool operator!=(const Device &rhs) const;
+        bool operator==(const Device &rhs) const;
+        bool operator!=(const Device &rhs) const;
 
-		// host api reference
-		HostApi &hostApi();
-		const HostApi &hostApi() const;
+        // host api reference
+        HostApi &hostApi();
+        const HostApi &hostApi() const;
 
-	private:
-		PaDeviceIndex index_;
-		const PaDeviceInfo *info_;
+    private:
+        PaDeviceIndex index_;
+        const PaDeviceInfo *info_;
 
-	private:
-		friend class System;
-		
-		explicit Device(PaDeviceIndex index);
-		~Device();
+    private:
+        friend class System;
 
-		Device(const Device &); // non-copyable
-		Device &operator=(const Device &); // non-copyable
-	};
+        explicit Device(PaDeviceIndex index);
+        ~Device();
 
-	// -----------------------------------------------------------------------------------
+        Device(const Device &); // non-copyable
+        Device &operator=(const Device &); // non-copyable
+    };
+
+    // -----------------------------------------------------------------------------------
 
 } // namespace portaudio
 
 // ---------------------------------------------------------------------------------------
 
 #endif // INCLUDED_PORTAUDIO_DEVICE_HXX
-

--- a/bindings/cpp/include/portaudiocpp/DirectionSpecificStreamParameters.hxx
+++ b/bindings/cpp/include/portaudiocpp/DirectionSpecificStreamParameters.hxx
@@ -15,7 +15,7 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class Device;
+    class Device;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -24,50 +24,50 @@ namespace portaudio
 namespace portaudio
 {
 
-	//////
-	/// @brief All parameters for one direction (either in or out) of a Stream. Together with 
-	/// parameters common to both directions, two DirectionSpecificStreamParameters can make up 
-	/// a StreamParameters object which contains all parameters for a Stream.
-	//////
-	class DirectionSpecificStreamParameters
-	{
-	public:
-		static DirectionSpecificStreamParameters null();
+    //////
+    /// @brief All parameters for one direction (either in or out) of a Stream. Together with
+    /// parameters common to both directions, two DirectionSpecificStreamParameters can make up
+    /// a StreamParameters object which contains all parameters for a Stream.
+    //////
+    class DirectionSpecificStreamParameters
+    {
+    public:
+        static DirectionSpecificStreamParameters null();
 
-		DirectionSpecificStreamParameters();
-		DirectionSpecificStreamParameters(const Device &device, int numChannels, SampleDataFormat format, 
-			bool interleaved, PaTime suggestedLatency, void *hostApiSpecificStreamInfo);
+        DirectionSpecificStreamParameters();
+        DirectionSpecificStreamParameters(const Device &device, int numChannels, SampleDataFormat format,
+            bool interleaved, PaTime suggestedLatency, void *hostApiSpecificStreamInfo);
 
-		// Set up methods:
-		void setDevice(const Device &device);
-		void setNumChannels(int numChannels);
+        // Set up methods:
+        void setDevice(const Device &device);
+        void setNumChannels(int numChannels);
 
-		void setSampleFormat(SampleDataFormat format, bool interleaved = true);
-		void setHostApiSpecificSampleFormat(PaSampleFormat format, bool interleaved = true);
+        void setSampleFormat(SampleDataFormat format, bool interleaved = true);
+        void setHostApiSpecificSampleFormat(PaSampleFormat format, bool interleaved = true);
 
-		void setSuggestedLatency(PaTime latency);
+        void setSuggestedLatency(PaTime latency);
 
-		void setHostApiSpecificStreamInfo(void *streamInfo);
+        void setHostApiSpecificStreamInfo(void *streamInfo);
 
-		// Accessor methods:
-		PaStreamParameters *paStreamParameters();
-		const PaStreamParameters *paStreamParameters() const;
+        // Accessor methods:
+        PaStreamParameters *paStreamParameters();
+        const PaStreamParameters *paStreamParameters() const;
 
-		Device &device() const;
-		int numChannels() const;
+        Device &device() const;
+        int numChannels() const;
 
-		SampleDataFormat sampleFormat() const;
-		bool isSampleFormatInterleaved() const;
-		bool isSampleFormatHostApiSpecific() const;
-		PaSampleFormat hostApiSpecificSampleFormat() const;
+        SampleDataFormat sampleFormat() const;
+        bool isSampleFormatInterleaved() const;
+        bool isSampleFormatHostApiSpecific() const;
+        PaSampleFormat hostApiSpecificSampleFormat() const;
 
-		PaTime suggestedLatency() const;
+        PaTime suggestedLatency() const;
 
-		void *hostApiSpecificStreamInfo() const;
-	
-	private:
-		PaStreamParameters paStreamParameters_;
-	};
+        void *hostApiSpecificStreamInfo() const;
+
+    private:
+        PaStreamParameters paStreamParameters_;
+    };
 
 
 } // namespace portaudio

--- a/bindings/cpp/include/portaudiocpp/Exception.hxx
+++ b/bindings/cpp/include/portaudiocpp/Exception.hxx
@@ -12,92 +12,92 @@
 namespace portaudio
 {
 
-	//////
-	/// @brief Base class for all exceptions PortAudioCpp can throw.
-	///
-	/// Class is derived from std::exception.
-	//////
-	class Exception : public std::exception
-	{
-	public:
-		virtual ~Exception() throw() {}
+    //////
+    /// @brief Base class for all exceptions PortAudioCpp can throw.
+    ///
+    /// Class is derived from std::exception.
+    //////
+    class Exception : public std::exception
+    {
+    public:
+        virtual ~Exception() throw() {}
 
-		virtual const char *what() const throw() = 0;
-	};
-	
-	// -----------------------------------------------------------------------------------
+        virtual const char *what() const throw() = 0;
+    };
 
-	//////
-	/// @brief Wrapper for PortAudio error codes to C++ exceptions.
-	///
-	/// It wraps up PortAudio's error handling mechanism using 
-	/// C++ exceptions and is derived from std::exception for 
-	/// easy exception handling and to ease integration with 
-	/// other code.
-	///
-	/// To know what exceptions each function may throw, look up 
-	/// the errors that can occur in the PortAudio documentation 
-	/// for the equivalent functions.
-	///
-	/// Some functions are likely to throw an exception (such as 
-	/// Stream::open(), etc) and these should always be called in 
-	/// try{} catch{} blocks and the thrown exceptions should be 
-	/// handled properly (ie. the application shouldn't just abort, 
-	/// but merely display a warning dialog to the user or something).
-	/// However nearly all functions in PortAudioCpp are capable 
-	/// of throwing exceptions. When a function like Stream::isStopped() 
-	/// throws an exception, it's such an exceptional state that it's 
-	/// not likely that it can be recovered. PaExceptions such as these 
-	/// can ``safely'' be left to be handled by some outer catch-all-like 
-	/// mechanism for unrecoverable errors.
-	//////
-	class PaException : public Exception
-	{
-	public:
-		explicit PaException(PaError error);
+    // -----------------------------------------------------------------------------------
 
-		const char *what() const throw();
+    //////
+    /// @brief Wrapper for PortAudio error codes to C++ exceptions.
+    ///
+    /// It wraps up PortAudio's error handling mechanism using
+    /// C++ exceptions and is derived from std::exception for
+    /// easy exception handling and to ease integration with
+    /// other code.
+    ///
+    /// To know what exceptions each function may throw, look up
+    /// the errors that can occur in the PortAudio documentation
+    /// for the equivalent functions.
+    ///
+    /// Some functions are likely to throw an exception (such as
+    /// Stream::open(), etc) and these should always be called in
+    /// try{} catch{} blocks and the thrown exceptions should be
+    /// handled properly (ie. the application shouldn't just abort,
+    /// but merely display a warning dialog to the user or something).
+    /// However nearly all functions in PortAudioCpp are capable
+    /// of throwing exceptions. When a function like Stream::isStopped()
+    /// throws an exception, it's such an exceptional state that it's
+    /// not likely that it can be recovered. PaExceptions such as these
+    /// can ``safely'' be left to be handled by some outer catch-all-like
+    /// mechanism for unrecoverable errors.
+    //////
+    class PaException : public Exception
+    {
+    public:
+        explicit PaException(PaError error);
 
-		PaError paError() const;
-		const char *paErrorText() const;
+        const char *what() const throw();
 
-		bool isHostApiError() const; // extended
-		long lastHostApiError() const;
-		const char *lastHostApiErrorText() const;
+        PaError paError() const;
+        const char *paErrorText() const;
 
-		bool operator==(const PaException &rhs) const;
-		bool operator!=(const PaException &rhs) const;
+        bool isHostApiError() const; // extended
+        long lastHostApiError() const;
+        const char *lastHostApiErrorText() const;
 
-	private:
-		PaError error_;
- 	};
+        bool operator==(const PaException &rhs) const;
+        bool operator!=(const PaException &rhs) const;
 
-	// -----------------------------------------------------------------------------------
+    private:
+        PaError error_;
+    };
 
-	//////
-	/// @brief Exceptions specific to PortAudioCpp (ie. exceptions which do not have an 
-	/// equivalent PortAudio error code).
-	//////
-	class PaCppException : public Exception
-	{
-	public:
-		enum ExceptionSpecifier
-		{
-			UNABLE_TO_ADAPT_DEVICE
-		};
+    // -----------------------------------------------------------------------------------
 
-		PaCppException(ExceptionSpecifier specifier);
+    //////
+    /// @brief Exceptions specific to PortAudioCpp (ie. exceptions which do not have an
+    /// equivalent PortAudio error code).
+    //////
+    class PaCppException : public Exception
+    {
+    public:
+        enum ExceptionSpecifier
+        {
+            UNABLE_TO_ADAPT_DEVICE
+        };
 
-		const char *what() const throw();
+        PaCppException(ExceptionSpecifier specifier);
 
-		ExceptionSpecifier specifier() const;
+        const char *what() const throw();
 
-		bool operator==(const PaCppException &rhs) const;
-		bool operator!=(const PaCppException &rhs) const;
+        ExceptionSpecifier specifier() const;
 
-	private:
-		ExceptionSpecifier specifier_;
-	};
+        bool operator==(const PaCppException &rhs) const;
+        bool operator!=(const PaCppException &rhs) const;
+
+    private:
+        ExceptionSpecifier specifier_;
+    };
 
 
 } // namespace portaudio
@@ -105,4 +105,3 @@ namespace portaudio
 // ---------------------------------------------------------------------------------------
 
 #endif // INCLUDED_PORTAUDIO_EXCEPTION_HXX
-

--- a/bindings/cpp/include/portaudiocpp/HostApi.hxx
+++ b/bindings/cpp/include/portaudiocpp/HostApi.hxx
@@ -12,7 +12,7 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class Device;
+    class Device;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -22,50 +22,50 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief HostApi represents a host API (usually type of driver) in the System.
-	///
-	/// A single System can support multiple HostApi's each one typically having 
-	/// a set of Devices using that HostApi (usually driver type). All Devices in 
-	/// the HostApi can be enumerated and the default input/output Device for this 
-	/// HostApi can be retrieved.
-	//////
-	class HostApi
-	{
-	public:
-		typedef System::DeviceIterator DeviceIterator;
+    //////
+    /// @brief HostApi represents a host API (usually type of driver) in the System.
+    ///
+    /// A single System can support multiple HostApi's each one typically having
+    /// a set of Devices using that HostApi (usually driver type). All Devices in
+    /// the HostApi can be enumerated and the default input/output Device for this
+    /// HostApi can be retrieved.
+    //////
+    class HostApi
+    {
+    public:
+        typedef System::DeviceIterator DeviceIterator;
 
-		// query info: id, name, numDevices
-		PaHostApiTypeId typeId() const;
-		PaHostApiIndex index() const;
-		const char *name() const;
-		int deviceCount() const;
+        // query info: id, name, numDevices
+        PaHostApiTypeId typeId() const;
+        PaHostApiIndex index() const;
+        const char *name() const;
+        int deviceCount() const;
 
-		// iterate devices
-		DeviceIterator devicesBegin();
-		DeviceIterator devicesEnd();
+        // iterate devices
+        DeviceIterator devicesBegin();
+        DeviceIterator devicesEnd();
 
-		// default devices
-		Device &defaultInputDevice() const;
-		Device &defaultOutputDevice() const;
+        // default devices
+        Device &defaultInputDevice() const;
+        Device &defaultOutputDevice() const;
 
-		// comparison operators
-		bool operator==(const HostApi &rhs) const;
-		bool operator!=(const HostApi &rhs) const;
+        // comparison operators
+        bool operator==(const HostApi &rhs) const;
+        bool operator!=(const HostApi &rhs) const;
 
-	private:
-		const PaHostApiInfo *info_;
-		Device **devices_;
+    private:
+        const PaHostApiInfo *info_;
+        Device **devices_;
 
-	private:
-		friend class System;
+    private:
+        friend class System;
 
-		explicit HostApi(PaHostApiIndex index);
-		~HostApi();
+        explicit HostApi(PaHostApiIndex index);
+        ~HostApi();
 
-		HostApi(const HostApi &); // non-copyable
-		HostApi &operator=(const HostApi &); // non-copyable
-	};
+        HostApi(const HostApi &); // non-copyable
+        HostApi &operator=(const HostApi &); // non-copyable
+    };
 
 
 }
@@ -73,4 +73,3 @@ namespace portaudio
 // ---------------------------------------------------------------------------------------
 
 #endif // INCLUDED_PORTAUDIO_HOSTAPI_HXX
-

--- a/bindings/cpp/include/portaudiocpp/InterfaceCallbackStream.hxx
+++ b/bindings/cpp/include/portaudiocpp/InterfaceCallbackStream.hxx
@@ -12,8 +12,8 @@
 // Forward declaration(s)
 namespace portaudio
 {
-	class StreamParameters;
-	class CallbackInterface;
+    class StreamParameters;
+    class CallbackInterface;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -23,23 +23,23 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief Callback stream using an instance of an object that's derived from the CallbackInterface 
-	/// interface.
-	//////
-	class InterfaceCallbackStream : public CallbackStream
-	{
-	public:
-		InterfaceCallbackStream();
-		InterfaceCallbackStream(const StreamParameters &parameters, CallbackInterface &instance);
-		~InterfaceCallbackStream();
-		
-		void open(const StreamParameters &parameters, CallbackInterface &instance);
+    //////
+    /// @brief Callback stream using an instance of an object that's derived from the CallbackInterface
+    /// interface.
+    //////
+    class InterfaceCallbackStream : public CallbackStream
+    {
+    public:
+        InterfaceCallbackStream();
+        InterfaceCallbackStream(const StreamParameters &parameters, CallbackInterface &instance);
+        ~InterfaceCallbackStream();
 
-	private:
-		InterfaceCallbackStream(const InterfaceCallbackStream &); // non-copyable
-		InterfaceCallbackStream &operator=(const InterfaceCallbackStream &); // non-copyable
-	};
+        void open(const StreamParameters &parameters, CallbackInterface &instance);
+
+    private:
+        InterfaceCallbackStream(const InterfaceCallbackStream &); // non-copyable
+        InterfaceCallbackStream &operator=(const InterfaceCallbackStream &); // non-copyable
+    };
 
 
 } // portaudio

--- a/bindings/cpp/include/portaudiocpp/MemFunCallbackStream.hxx
+++ b/bindings/cpp/include/portaudiocpp/MemFunCallbackStream.hxx
@@ -17,87 +17,87 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief Callback stream using a class's member function as a callback. Template argument T is the type of the 
-	/// class of which a member function is going to be used.
-	///
-	/// Example usage:
-	/// @verbatim MemFunCallback<MyClass> stream = MemFunCallbackStream(parameters, *this, &MyClass::myCallbackFunction); @endverbatim
-	//////
-	template<typename T>
-	class MemFunCallbackStream : public CallbackStream
-	{
-	public:
-		typedef int (T::*CallbackFunPtr)(const void *, void *, unsigned long, const PaStreamCallbackTimeInfo *, 
-			PaStreamCallbackFlags);
+    //////
+    /// @brief Callback stream using a class's member function as a callback. Template argument T is the type of the
+    /// class of which a member function is going to be used.
+    ///
+    /// Example usage:
+    /// @verbatim MemFunCallback<MyClass> stream = MemFunCallbackStream(parameters, *this, &MyClass::myCallbackFunction); @endverbatim
+    //////
+    template<typename T>
+    class MemFunCallbackStream : public CallbackStream
+    {
+    public:
+        typedef int (T::*CallbackFunPtr)(const void *, void *, unsigned long, const PaStreamCallbackTimeInfo *,
+            PaStreamCallbackFlags);
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		MemFunCallbackStream()
-		{
-		}
+        MemFunCallbackStream()
+        {
+        }
 
-		MemFunCallbackStream(const StreamParameters &parameters, T &instance, CallbackFunPtr memFun) : adapter_(instance, memFun)
-		{
-			open(parameters);
-		}
+        MemFunCallbackStream(const StreamParameters &parameters, T &instance, CallbackFunPtr memFun) : adapter_(instance, memFun)
+        {
+            open(parameters);
+        }
 
-		~MemFunCallbackStream()
-		{
-			close();
-		}
+        ~MemFunCallbackStream()
+        {
+            close();
+        }
 
-		void open(const StreamParameters &parameters, T &instance, CallbackFunPtr memFun)
-		{
-			// XXX:	need to check if already open?
+        void open(const StreamParameters &parameters, T &instance, CallbackFunPtr memFun)
+        {
+            // XXX: need to check if already open?
 
-			adapter_.init(instance, memFun);
-			open(parameters);
-		}
+            adapter_.init(instance, memFun);
+            open(parameters);
+        }
 
-	private:
-		MemFunCallbackStream(const MemFunCallbackStream &); // non-copyable
-		MemFunCallbackStream &operator=(const MemFunCallbackStream &); // non-copyable
+    private:
+        MemFunCallbackStream(const MemFunCallbackStream &); // non-copyable
+        MemFunCallbackStream &operator=(const MemFunCallbackStream &); // non-copyable
 
-		//////
-		/// @brief Inner class which adapts a member function callback to a CallbackInterface compliant 
-		/// class (so it can be adapted using the paCallbackAdapter function).
-		//////
-		class MemFunToCallbackInterfaceAdapter : public CallbackInterface
-		{
-		public:
-			MemFunToCallbackInterfaceAdapter() {}
-			MemFunToCallbackInterfaceAdapter(T &instance, CallbackFunPtr memFun) : instance_(&instance), memFun_(memFun) {}
+        //////
+        /// @brief Inner class which adapts a member function callback to a CallbackInterface compliant
+        /// class (so it can be adapted using the paCallbackAdapter function).
+        //////
+        class MemFunToCallbackInterfaceAdapter : public CallbackInterface
+        {
+        public:
+            MemFunToCallbackInterfaceAdapter() {}
+            MemFunToCallbackInterfaceAdapter(T &instance, CallbackFunPtr memFun) : instance_(&instance), memFun_(memFun) {}
 
-			void init(T &instance, CallbackFunPtr memFun)
-			{
-				instance_ = &instance;
-				memFun_ = memFun;
-			}
+            void init(T &instance, CallbackFunPtr memFun)
+            {
+                instance_ = &instance;
+                memFun_ = memFun;
+            }
 
-			int paCallbackFun(const void *inputBuffer, void *outputBuffer, unsigned long numFrames, 
-				const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags)
-			{
-				return (instance_->*memFun_)(inputBuffer, outputBuffer, numFrames, timeInfo, statusFlags);
-			}
+            int paCallbackFun(const void *inputBuffer, void *outputBuffer, unsigned long numFrames,
+                const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags)
+            {
+                return (instance_->*memFun_)(inputBuffer, outputBuffer, numFrames, timeInfo, statusFlags);
+            }
 
-		private:
-			T *instance_;
-			CallbackFunPtr memFun_;
-		};
+        private:
+            T *instance_;
+            CallbackFunPtr memFun_;
+        };
 
-		MemFunToCallbackInterfaceAdapter adapter_;
+        MemFunToCallbackInterfaceAdapter adapter_;
 
-		void open(const StreamParameters &parameters)
-		{
-			PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(), 
-				parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), &impl::callbackInterfaceToPaCallbackAdapter, 
-				static_cast<void *>(&adapter_));
+        void open(const StreamParameters &parameters)
+        {
+            PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(),
+                parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), &impl::callbackInterfaceToPaCallbackAdapter,
+                static_cast<void *>(&adapter_));
 
-			if (err != paNoError)
-				throw PaException(err);
-		}
-	};
+            if (err != paNoError)
+                throw PaException(err);
+        }
+    };
 
 
 } // portaudio

--- a/bindings/cpp/include/portaudiocpp/PortAudioCpp.hxx
+++ b/bindings/cpp/include/portaudiocpp/PortAudioCpp.hxx
@@ -6,23 +6,23 @@
 //////
 /// @mainpage PortAudioCpp
 ///
-///	<h1>PortAudioCpp - A Native C++ Binding of PortAudio V19</h1>
+/// <h1>PortAudioCpp - A Native C++ Binding of PortAudio V19</h1>
 /// <h2>PortAudio</h2>
 /// <p>
-///   PortAudio is a portable and mature C API for accessing audio hardware. It offers both callback-based and blocking 
-///   style input and output, deals with sample data format conversions, dithering and much more. There are a large number 
-///   of implementations available for various platforms including Windows MME, Windows DirectX, Windows and MacOS (Classic) 
-///   ASIO, MacOS Classic SoundManager, MacOS X CoreAudio, OSS (Linux), Linux ALSA, JACK (MacOS X and Linux) and SGI Irix 
-///   AL. Note that, currently not all of these implementations are equally complete or up-to-date (as PortAudio V19 is 
-///   still in development). Because PortAudio has a C API, it can easily be called from a variety of other programming 
+///   PortAudio is a portable and mature C API for accessing audio hardware. It offers both callback-based and blocking
+///   style input and output, deals with sample data format conversions, dithering and much more. There are a large number
+///   of implementations available for various platforms including Windows MME, Windows DirectX, Windows and MacOS (Classic)
+///   ASIO, MacOS Classic SoundManager, MacOS X CoreAudio, OSS (Linux), Linux ALSA, JACK (MacOS X and Linux) and SGI Irix
+///   AL. Note that, currently not all of these implementations are equally complete or up-to-date (as PortAudio V19 is
+///   still in development). Because PortAudio has a C API, it can easily be called from a variety of other programming
 ///   languages.
 /// </p>
 /// <h2>PortAudioCpp</h2>
 /// <p>
-///   Although, it is possible to use PortAudio's C API from within a C++ program, this is usually a little awkward 
-///   as procedural and object-oriented paradigms need to be mixed. PortAudioCpp aims to resolve this by encapsulating 
-///   PortAudio's C API to form an equivalent object-oriented C++ API. It provides a more natural integration of PortAudio 
-///   into C++ programs as well as a more structured interface. PortAudio's concepts were preserved as much as possible and 
+///   Although, it is possible to use PortAudio's C API from within a C++ program, this is usually a little awkward
+///   as procedural and object-oriented paradigms need to be mixed. PortAudioCpp aims to resolve this by encapsulating
+///   PortAudio's C API to form an equivalent object-oriented C++ API. It provides a more natural integration of PortAudio
+///   into C++ programs as well as a more structured interface. PortAudio's concepts were preserved as much as possible and
 ///   no additional features were added except for some `convenience methods'.
 /// </p>
 /// <p>
@@ -30,15 +30,15 @@
 ///   <ul>
 ///     <li>Structured object model.</li>
 ///     <li>C++ exception handling instead of C-style error return codes.</li>
-///     <li>Handling of callbacks using free functions (C and C++), static functions, member functions or instances of classes 
+///     <li>Handling of callbacks using free functions (C and C++), static functions, member functions or instances of classes
 ///     derived from a given interface.</li>
 ///     <li>STL compliant iterators to host APIs and devices.</li>
 ///     <li>Some additional convenience functions to more easily set up and use PortAudio.</li>
 ///   </ul>
 /// </p>
 /// <p>
-///   PortAudioCpp requires a recent version of the PortAudio V19 source code. This can be obtained from CVS or as a snapshot 
-///   from the website. The examples also require the ASIO 2 SDK which can be obtained from the Steinberg website. Alternatively, the 
+///   PortAudioCpp requires a recent version of the PortAudio V19 source code. This can be obtained from CVS or as a snapshot
+///   from the website. The examples also require the ASIO 2 SDK which can be obtained from the Steinberg website. Alternatively, the
 ///   examples can easily be modified to compile without needing ASIO.
 /// </p>
 /// <p>
@@ -50,12 +50,12 @@
 ///   Other platforms should be easily supported as PortAudioCpp is platform-independent and (reasonably) C++ standard compliant.
 /// </p>
 /// <p>
-///   This documentation mainly provides information specific to PortAudioCpp. For a more complete explanation of all of the 
+///   This documentation mainly provides information specific to PortAudioCpp. For a more complete explanation of all of the
 ///   concepts used, please consult the PortAudio documentation.
 /// </p>
 /// <p>
-///   PortAudioCpp was developed by Merlijn Blaauw with many great suggestions and help from Ross Bencina. Ludwig Schwardt provided 
-///   GNU/Linux build files and checked G++ compatibility. PortAudioCpp may be used under the same licensing, conditions and 
+///   PortAudioCpp was developed by Merlijn Blaauw with many great suggestions and help from Ross Bencina. Ludwig Schwardt provided
+///   GNU/Linux build files and checked G++ compatibility. PortAudioCpp may be used under the same licensing, conditions and
 ///   warranty as PortAudio. See <a href="http://www.portaudio.com/license.html">the PortAudio license</a> for more details.
 /// </p>
 /// <h2>Links</h2>
@@ -69,8 +69,8 @@
 //////
 /// @namespace portaudio
 ///
-/// To avoid name collision, everything in PortAudioCpp is in the portaudio 
-/// namespace. If this name is too long it's usually pretty safe to use an 
+/// To avoid name collision, everything in PortAudioCpp is in the portaudio
+/// namespace. If this name is too long it's usually pretty safe to use an
 /// alias like ``namespace pa = portaudio;''.
 //////
 

--- a/bindings/cpp/include/portaudiocpp/SampleDataFormat.hxx
+++ b/bindings/cpp/include/portaudiocpp/SampleDataFormat.hxx
@@ -11,21 +11,21 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief PortAudio sample data formats.
-	///
-	/// Small helper enum to wrap the PortAudio defines.
-	//////
-	enum SampleDataFormat
-	{
-		INVALID_FORMAT	= 0,
-		FLOAT32			= paFloat32,
-		INT32			= paInt32,
-		INT24			= paInt24,
-		INT16			= paInt16,
-		INT8			= paInt8,
-		UINT8			= paUInt8
-	};
+    //////
+    /// @brief PortAudio sample data formats.
+    ///
+    /// Small helper enum to wrap the PortAudio defines.
+    //////
+    enum SampleDataFormat
+    {
+        INVALID_FORMAT  = 0,
+        FLOAT32         = paFloat32,
+        INT32           = paInt32,
+        INT24           = paInt24,
+        INT16           = paInt16,
+        INT8            = paInt8,
+        UINT8           = paUInt8
+    };
 
 
 } // namespace portaudio

--- a/bindings/cpp/include/portaudiocpp/Stream.hxx
+++ b/bindings/cpp/include/portaudiocpp/Stream.hxx
@@ -8,7 +8,7 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class StreamParameters;
+    class StreamParameters;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -18,65 +18,64 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief A Stream represents an active or inactive input and/or output data 
-	/// stream in the System.
-	/// 
-	/// Concrete Stream classes should ensure themselves being in a closed state at 
-	/// destruction (i.e. by calling their own close() method in their deconstructor). 
-	/// Following good C++ programming practices, care must be taken to ensure no 
-	/// exceptions are thrown by the deconstructor of these classes. As a consequence, 
-	/// clients need to explicitly call close() to ensure the stream closed successfully.
-	///
-	/// The Stream object can be used to manipulate the Stream's state. Also, time-constant 
-	/// and time-varying information about the Stream can be retrieved.
-	//////
-	class Stream
-	{
-	public:
-		// Opening/closing:
-		virtual ~Stream();
+    //////
+    /// @brief A Stream represents an active or inactive input and/or output data
+    /// stream in the System.
+    ///
+    /// Concrete Stream classes should ensure themselves being in a closed state at
+    /// destruction (i.e. by calling their own close() method in their deconstructor).
+    /// Following good C++ programming practices, care must be taken to ensure no
+    /// exceptions are thrown by the deconstructor of these classes. As a consequence,
+    /// clients need to explicitly call close() to ensure the stream closed successfully.
+    ///
+    /// The Stream object can be used to manipulate the Stream's state. Also, time-constant
+    /// and time-varying information about the Stream can be retrieved.
+    //////
+    class Stream
+    {
+    public:
+        // Opening/closing:
+        virtual ~Stream();
 
-		virtual void close();
-		bool isOpen() const;
+        virtual void close();
+        bool isOpen() const;
 
-		// Additional set up:
-		void setStreamFinishedCallback(PaStreamFinishedCallback *callback);
+        // Additional set up:
+        void setStreamFinishedCallback(PaStreamFinishedCallback *callback);
 
-		// State management:
-		void start();
-		void stop();
-		void abort();
+        // State management:
+        void start();
+        void stop();
+        void abort();
 
-		bool isStopped() const;
-		bool isActive() const;
+        bool isStopped() const;
+        bool isActive() const;
 
-		// Stream info (time-constant, but might become time-variant soon):
-		PaTime inputLatency() const;
-		PaTime outputLatency() const;
-		double sampleRate() const;
+        // Stream info (time-constant, but might become time-variant soon):
+        PaTime inputLatency() const;
+        PaTime outputLatency() const;
+        double sampleRate() const;
 
-		// Stream info (time-varying):
-		PaTime time() const;
+        // Stream info (time-varying):
+        PaTime time() const;
 
-		// Accessors for PortAudio PaStream, useful for interfacing 
-		// with PortAudio add-ons (such as PortMixer) for instance:
-		const PaStream *paStream() const;
-		PaStream *paStream();
+        // Accessors for PortAudio PaStream, useful for interfacing
+        // with PortAudio add-ons (such as PortMixer) for instance:
+        const PaStream *paStream() const;
+        PaStream *paStream();
 
-	protected:
-		Stream(); // abstract class
+    protected:
+        Stream(); // abstract class
 
-		PaStream *stream_;
+        PaStream *stream_;
 
-	private:
-		Stream(const Stream &); // non-copyable
-		Stream &operator=(const Stream &); // non-copyable
-	};
+    private:
+        Stream(const Stream &); // non-copyable
+        Stream &operator=(const Stream &); // non-copyable
+    };
 
 
 } // namespace portaudio
 
 
 #endif // INCLUDED_PORTAUDIO_STREAM_HXX
-

--- a/bindings/cpp/include/portaudiocpp/StreamParameters.hxx
+++ b/bindings/cpp/include/portaudiocpp/StreamParameters.hxx
@@ -13,61 +13,61 @@
 namespace portaudio
 {
 
-	//////
-	/// @brief The entire set of parameters needed to configure and open 
-	/// a Stream.
-	///
-	/// It contains parameters of input, output and shared parameters. 
-	/// Using the isSupported() method, the StreamParameters can be 
-	/// checked if opening a Stream using this StreamParameters would 
-	/// succeed or not. Accessors are provided to higher-level parameters 
-	/// aswell as the lower-level parameters which are mainly intended for 
-	/// internal use.
-	//////
-	class StreamParameters
-	{
-	public:
-		StreamParameters();
-		StreamParameters(const DirectionSpecificStreamParameters &inputParameters, 
-			const DirectionSpecificStreamParameters &outputParameters, double sampleRate, 
-			unsigned long framesPerBuffer, PaStreamFlags flags);
+    //////
+    /// @brief The entire set of parameters needed to configure and open
+    /// a Stream.
+    ///
+    /// It contains parameters of input, output and shared parameters.
+    /// Using the isSupported() method, the StreamParameters can be
+    /// checked if opening a Stream using this StreamParameters would
+    /// succeed or not. Accessors are provided to higher-level parameters
+    /// aswell as the lower-level parameters which are mainly intended for
+    /// internal use.
+    //////
+    class StreamParameters
+    {
+    public:
+        StreamParameters();
+        StreamParameters(const DirectionSpecificStreamParameters &inputParameters,
+            const DirectionSpecificStreamParameters &outputParameters, double sampleRate,
+            unsigned long framesPerBuffer, PaStreamFlags flags);
 
-		// Set up for direction-specific:
-		void setInputParameters(const DirectionSpecificStreamParameters &parameters);
-		void setOutputParameters(const DirectionSpecificStreamParameters &parameters);
+        // Set up for direction-specific:
+        void setInputParameters(const DirectionSpecificStreamParameters &parameters);
+        void setOutputParameters(const DirectionSpecificStreamParameters &parameters);
 
-		// Set up for common parameters:
-		void setSampleRate(double sampleRate);
-		void setFramesPerBuffer(unsigned long framesPerBuffer);
-		void setFlag(PaStreamFlags flag);
-		void unsetFlag(PaStreamFlags flag);
-		void clearFlags();
+        // Set up for common parameters:
+        void setSampleRate(double sampleRate);
+        void setFramesPerBuffer(unsigned long framesPerBuffer);
+        void setFlag(PaStreamFlags flag);
+        void unsetFlag(PaStreamFlags flag);
+        void clearFlags();
 
-		// Validation:
-		bool isSupported() const;
+        // Validation:
+        bool isSupported() const;
 
-		// Accessors (direction-specific):
-		DirectionSpecificStreamParameters &inputParameters();
-		const DirectionSpecificStreamParameters &inputParameters() const;
-		DirectionSpecificStreamParameters &outputParameters();
-		const DirectionSpecificStreamParameters &outputParameters() const;
+        // Accessors (direction-specific):
+        DirectionSpecificStreamParameters &inputParameters();
+        const DirectionSpecificStreamParameters &inputParameters() const;
+        DirectionSpecificStreamParameters &outputParameters();
+        const DirectionSpecificStreamParameters &outputParameters() const;
 
-		// Accessors (common):
-		double sampleRate() const;
-		unsigned long framesPerBuffer() const;
-		PaStreamFlags flags() const;
-		bool isFlagSet(PaStreamFlags flag) const;
+        // Accessors (common):
+        double sampleRate() const;
+        unsigned long framesPerBuffer() const;
+        PaStreamFlags flags() const;
+        bool isFlagSet(PaStreamFlags flag) const;
 
-	private:
-		// Half-duplex specific parameters:
-		DirectionSpecificStreamParameters inputParameters_;
-		DirectionSpecificStreamParameters outputParameters_;
+    private:
+        // Half-duplex specific parameters:
+        DirectionSpecificStreamParameters inputParameters_;
+        DirectionSpecificStreamParameters outputParameters_;
 
-		// Common parameters:
-		double sampleRate_;
-		unsigned long framesPerBuffer_;
-		PaStreamFlags flags_;
-	};
+        // Common parameters:
+        double sampleRate_;
+        unsigned long framesPerBuffer_;
+        PaStreamFlags flags_;
+    };
 
 
 } // namespace portaudio

--- a/bindings/cpp/include/portaudiocpp/System.hxx
+++ b/bindings/cpp/include/portaudiocpp/System.hxx
@@ -10,9 +10,9 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class Device;
-	class Stream;
-	class HostApi;
+    class Device;
+    class Stream;
+    class HostApi;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -22,86 +22,85 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief System singleton which represents the PortAudio system.
-	///
-	/// The System is used to initialize/terminate PortAudio and provide 
-	/// a single access point to the PortAudio System (instance()).
-	/// It can be used to iterate through all HostApi 's in the System as 
-	/// well as all devices in the System. It also provides some utility 
-	/// functionality of PortAudio.
-	///
-	/// Terminating the System will also abort and close the open streams. 
-	/// The Stream objects will need to be deallocated by the client though 
-	/// (it's usually a good idea to have them cleaned up automatically).
-	//////
-	class System
-	{
-	public:
-		class HostApiIterator; // forward declaration
-		class DeviceIterator; // forward declaration
+    //////
+    /// @brief System singleton which represents the PortAudio system.
+    ///
+    /// The System is used to initialize/terminate PortAudio and provide
+    /// a single access point to the PortAudio System (instance()).
+    /// It can be used to iterate through all HostApi 's in the System as
+    /// well as all devices in the System. It also provides some utility
+    /// functionality of PortAudio.
+    ///
+    /// Terminating the System will also abort and close the open streams.
+    /// The Stream objects will need to be deallocated by the client though
+    /// (it's usually a good idea to have them cleaned up automatically).
+    //////
+    class System
+    {
+    public:
+        class HostApiIterator; // forward declaration
+        class DeviceIterator; // forward declaration
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		static int version();
-		static const char *versionText();
+        static int version();
+        static const char *versionText();
 
-		static void initialize();
-		static void terminate();
+        static void initialize();
+        static void terminate();
 
-		static System &instance();
-		static bool exists();
+        static System &instance();
+        static bool exists();
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		// host apis:
-		HostApiIterator hostApisBegin();
-		HostApiIterator hostApisEnd();
+        // host apis:
+        HostApiIterator hostApisBegin();
+        HostApiIterator hostApisEnd();
 
-		HostApi &defaultHostApi();
+        HostApi &defaultHostApi();
 
-		HostApi &hostApiByTypeId(PaHostApiTypeId type);
-		HostApi &hostApiByIndex(PaHostApiIndex index);
+        HostApi &hostApiByTypeId(PaHostApiTypeId type);
+        HostApi &hostApiByIndex(PaHostApiIndex index);
 
-		int hostApiCount();
+        int hostApiCount();
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		// devices:
-		DeviceIterator devicesBegin();
-		DeviceIterator devicesEnd();
+        // devices:
+        DeviceIterator devicesBegin();
+        DeviceIterator devicesEnd();
 
-		Device &defaultInputDevice();
-		Device &defaultOutputDevice();
+        Device &defaultInputDevice();
+        Device &defaultOutputDevice();
 
-		Device &deviceByIndex(PaDeviceIndex index);
+        Device &deviceByIndex(PaDeviceIndex index);
 
-		int deviceCount();
+        int deviceCount();
 
-		static Device &nullDevice();
+        static Device &nullDevice();
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		// misc:
-		void sleep(long msec);
-		int sizeOfSample(PaSampleFormat format);
+        // misc:
+        void sleep(long msec);
+        int sizeOfSample(PaSampleFormat format);
 
-	private:
-		System();
-		~System();
+    private:
+        System();
+        ~System();
 
-		static System *instance_;
-		static int initCount_;
+        static System *instance_;
+        static int initCount_;
 
-		static HostApi **hostApis_;
-		static Device **devices_;
+        static HostApi **hostApis_;
+        static Device **devices_;
 
-		static Device *nullDevice_;
-	};
+        static Device *nullDevice_;
+    };
 
 
 } // namespace portaudio
 
 
 #endif // INCLUDED_PORTAUDIO_SYSTEM_HXX
-

--- a/bindings/cpp/include/portaudiocpp/SystemDeviceIterator.hxx
+++ b/bindings/cpp/include/portaudiocpp/SystemDeviceIterator.hxx
@@ -13,8 +13,8 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class Device;
-	class HostApi;
+    class Device;
+    class HostApi;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -23,39 +23,39 @@ namespace portaudio
 namespace portaudio
 {
 
-	
-	//////
-	/// @brief Iterator class for iterating through all Devices in a System.
-	///
-	/// Devices will be iterated by iterating all Devices in each 
-	/// HostApi in the System. Compliant with the STL bidirectional 
-	/// iterator concept.
-	//////
-	class System::DeviceIterator
-	{
-	public:
-		typedef std::bidirectional_iterator_tag iterator_category;
-		typedef Device value_type;
-		typedef ptrdiff_t difference_type;
-		typedef Device * pointer;
-		typedef Device & reference;
 
-		Device &operator*() const;
-		Device *operator->() const;
+    //////
+    /// @brief Iterator class for iterating through all Devices in a System.
+    ///
+    /// Devices will be iterated by iterating all Devices in each
+    /// HostApi in the System. Compliant with the STL bidirectional
+    /// iterator concept.
+    //////
+    class System::DeviceIterator
+    {
+    public:
+        typedef std::bidirectional_iterator_tag iterator_category;
+        typedef Device value_type;
+        typedef ptrdiff_t difference_type;
+        typedef Device * pointer;
+        typedef Device & reference;
 
-		DeviceIterator &operator++();
-		DeviceIterator operator++(int);
-		DeviceIterator &operator--();
-		DeviceIterator operator--(int);
+        Device &operator*() const;
+        Device *operator->() const;
 
-		bool operator==(const DeviceIterator &rhs) const;
-		bool operator!=(const DeviceIterator &rhs) const;
+        DeviceIterator &operator++();
+        DeviceIterator operator++(int);
+        DeviceIterator &operator--();
+        DeviceIterator operator--(int);
 
-	private:
-		friend class System;
-		friend class HostApi;
-		Device **ptr_;
-	};
+        bool operator==(const DeviceIterator &rhs) const;
+        bool operator!=(const DeviceIterator &rhs) const;
+
+    private:
+        friend class System;
+        friend class HostApi;
+        Device **ptr_;
+    };
 
 
 } // namespace portaudio
@@ -63,4 +63,3 @@ namespace portaudio
 // ---------------------------------------------------------------------------------------
 
 #endif // INCLUDED_PORTAUDIO_SYSTEMDEVICEITERATOR_HXX
-

--- a/bindings/cpp/include/portaudiocpp/SystemHostApiIterator.hxx
+++ b/bindings/cpp/include/portaudiocpp/SystemHostApiIterator.hxx
@@ -13,7 +13,7 @@
 // Forward declaration(s):
 namespace portaudio
 {
-	class HostApi;
+    class HostApi;
 }
 
 // ---------------------------------------------------------------------------------------
@@ -23,35 +23,35 @@ namespace portaudio
 {
 
 
-	//////
-	/// @brief Iterator class for iterating through all HostApis in a System.
-	///
-	/// Compliant with the STL bidirectional iterator concept.
-	//////
-	class System::HostApiIterator
-	{
-	public:
-		typedef std::bidirectional_iterator_tag iterator_category;
-		typedef Device value_type;
-		typedef ptrdiff_t difference_type;
-		typedef HostApi * pointer;
-		typedef HostApi & reference;
+    //////
+    /// @brief Iterator class for iterating through all HostApis in a System.
+    ///
+    /// Compliant with the STL bidirectional iterator concept.
+    //////
+    class System::HostApiIterator
+    {
+    public:
+        typedef std::bidirectional_iterator_tag iterator_category;
+        typedef Device value_type;
+        typedef ptrdiff_t difference_type;
+        typedef HostApi * pointer;
+        typedef HostApi & reference;
 
-		HostApi &operator*() const;
-		HostApi *operator->() const;
+        HostApi &operator*() const;
+        HostApi *operator->() const;
 
-		HostApiIterator &operator++();
-		HostApiIterator operator++(int);
-		HostApiIterator &operator--();
-		HostApiIterator operator--(int);
+        HostApiIterator &operator++();
+        HostApiIterator operator++(int);
+        HostApiIterator &operator--();
+        HostApiIterator operator--(int);
 
-		bool operator==(const HostApiIterator &rhs) const;
-		bool operator!=(const HostApiIterator &rhs) const;
+        bool operator==(const HostApiIterator &rhs) const;
+        bool operator!=(const HostApiIterator &rhs) const;
 
-	private:
-		friend class System;
-		HostApi **ptr_;
-	};
+    private:
+        friend class System;
+        HostApi **ptr_;
+    };
 
 
 } // namespace portaudio

--- a/bindings/cpp/source/portaudiocpp/AsioDeviceAdapter.cxx
+++ b/bindings/cpp/source/portaudiocpp/AsioDeviceAdapter.cxx
@@ -9,75 +9,73 @@
 
 namespace portaudio
 {
-	AsioDeviceAdapter::AsioDeviceAdapter(Device &device)
-	{
-		if (device.hostApi().typeId() != paASIO)
-			throw PaCppException(PaCppException::UNABLE_TO_ADAPT_DEVICE);
+    AsioDeviceAdapter::AsioDeviceAdapter(Device &device)
+    {
+        if (device.hostApi().typeId() != paASIO)
+            throw PaCppException(PaCppException::UNABLE_TO_ADAPT_DEVICE);
 
-		device_ = &device;
+        device_ = &device;
 
-		PaError err = PaAsio_GetAvailableLatencyValues(device_->index(), &minBufferSize_, &maxBufferSize_, 
-			&preferredBufferSize_, &granularity_);
+        PaError err = PaAsio_GetAvailableLatencyValues(device_->index(), &minBufferSize_, &maxBufferSize_,
+            &preferredBufferSize_, &granularity_);
 
-		if (err != paNoError)
-			throw PaException(err);
+        if (err != paNoError)
+            throw PaException(err);
 
-	}
+    }
 
-	Device &AsioDeviceAdapter::device()
-	{
-		return *device_;
-	}
+    Device &AsioDeviceAdapter::device()
+    {
+        return *device_;
+    }
 
-	long AsioDeviceAdapter::minBufferSize() const
-	{
-		return minBufferSize_;
-	}
+    long AsioDeviceAdapter::minBufferSize() const
+    {
+        return minBufferSize_;
+    }
 
-	long AsioDeviceAdapter::maxBufferSize() const
-	{
-		return maxBufferSize_;
-	}
+    long AsioDeviceAdapter::maxBufferSize() const
+    {
+        return maxBufferSize_;
+    }
 
-	long AsioDeviceAdapter::preferredBufferSize() const
-	{
-		return preferredBufferSize_;
-	}
+    long AsioDeviceAdapter::preferredBufferSize() const
+    {
+        return preferredBufferSize_;
+    }
 
-	long AsioDeviceAdapter::granularity() const
-	{
-		return granularity_;
-	}
+    long AsioDeviceAdapter::granularity() const
+    {
+        return granularity_;
+    }
 
-	void AsioDeviceAdapter::showControlPanel(void *systemSpecific)
-	{
-		PaError err = PaAsio_ShowControlPanel(device_->index(), systemSpecific);
+    void AsioDeviceAdapter::showControlPanel(void *systemSpecific)
+    {
+        PaError err = PaAsio_ShowControlPanel(device_->index(), systemSpecific);
 
-		if (err != paNoError)
-			throw PaException(err);
-	}
+        if (err != paNoError)
+            throw PaException(err);
+    }
 
-	const char *AsioDeviceAdapter::inputChannelName(int channelIndex) const
-	{
-		const char *channelName;
-		PaError err = PaAsio_GetInputChannelName(device_->index(), channelIndex, &channelName);
+    const char *AsioDeviceAdapter::inputChannelName(int channelIndex) const
+    {
+        const char *channelName;
+        PaError err = PaAsio_GetInputChannelName(device_->index(), channelIndex, &channelName);
 
-		if (err != paNoError)
-			throw PaException(err);
+        if (err != paNoError)
+            throw PaException(err);
 
-		return channelName;
-	}
+        return channelName;
+    }
 
-	const char *AsioDeviceAdapter::outputChannelName(int channelIndex) const
-	{
-		const char *channelName;
-		PaError err = PaAsio_GetOutputChannelName(device_->index(), channelIndex, &channelName);
+    const char *AsioDeviceAdapter::outputChannelName(int channelIndex) const
+    {
+        const char *channelName;
+        PaError err = PaAsio_GetOutputChannelName(device_->index(), channelIndex, &channelName);
 
-		if (err != paNoError)
-			throw PaException(err);
+        if (err != paNoError)
+            throw PaException(err);
 
-		return channelName;
-	}
+        return channelName;
+    }
 }
-
-

--- a/bindings/cpp/source/portaudiocpp/BlockingStream.cxx
+++ b/bindings/cpp/source/portaudiocpp/BlockingStream.cxx
@@ -8,93 +8,90 @@
 namespace portaudio
 {
 
-	// --------------------------------------------------------------------------------------
+    // --------------------------------------------------------------------------------------
 
-	BlockingStream::BlockingStream()
-	{
-	}
+    BlockingStream::BlockingStream()
+    {
+    }
 
-	BlockingStream::BlockingStream(const StreamParameters &parameters)
-	{
-		open(parameters);
-	}
+    BlockingStream::BlockingStream(const StreamParameters &parameters)
+    {
+        open(parameters);
+    }
 
-	BlockingStream::~BlockingStream()
-	{
-		try
-		{
-			close();
-		}
-		catch (...)
-		{
-			// ignore all errors
-		}
-	}
+    BlockingStream::~BlockingStream()
+    {
+        try
+        {
+            close();
+        }
+        catch (...)
+        {
+            // ignore all errors
+        }
+    }
 
-	// --------------------------------------------------------------------------------------
+    // --------------------------------------------------------------------------------------
 
-	void BlockingStream::open(const StreamParameters &parameters)
-	{
-		PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(), 
-			parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), NULL, NULL);
+    void BlockingStream::open(const StreamParameters &parameters)
+    {
+        PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(),
+            parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), NULL, NULL);
 
-		if (err != paNoError)
-		{
-			throw PaException(err);
-		}
-	}
+        if (err != paNoError)
+        {
+            throw PaException(err);
+        }
+    }
 
-	// --------------------------------------------------------------------------------------
+    // --------------------------------------------------------------------------------------
 
-	void BlockingStream::read(void *buffer, unsigned long numFrames)
-	{
-		PaError err = Pa_ReadStream(stream_, buffer, numFrames);
+    void BlockingStream::read(void *buffer, unsigned long numFrames)
+    {
+        PaError err = Pa_ReadStream(stream_, buffer, numFrames);
 
-		if (err != paNoError)
-		{
-			throw PaException(err);
-		}
-	}
+        if (err != paNoError)
+        {
+            throw PaException(err);
+        }
+    }
 
-	void BlockingStream::write(const void *buffer, unsigned long numFrames)
-	{
-		PaError err = Pa_WriteStream(stream_, buffer, numFrames);
+    void BlockingStream::write(const void *buffer, unsigned long numFrames)
+    {
+        PaError err = Pa_WriteStream(stream_, buffer, numFrames);
 
-		if (err != paNoError)
-		{
-			throw PaException(err);
-		}
-	}
+        if (err != paNoError)
+        {
+            throw PaException(err);
+        }
+    }
 
-	// --------------------------------------------------------------------------------------
+    // --------------------------------------------------------------------------------------
 
-	signed long BlockingStream::availableReadSize() const
-	{
-		signed long avail = Pa_GetStreamReadAvailable(stream_);
+    signed long BlockingStream::availableReadSize() const
+    {
+        signed long avail = Pa_GetStreamReadAvailable(stream_);
 
-		if (avail < 0)
-		{
-			throw PaException(avail);
-		}
+        if (avail < 0)
+        {
+            throw PaException(avail);
+        }
 
-		return avail;
-	}
+        return avail;
+    }
 
-	signed long BlockingStream::availableWriteSize() const
-	{
-		signed long avail = Pa_GetStreamWriteAvailable(stream_);
+    signed long BlockingStream::availableWriteSize() const
+    {
+        signed long avail = Pa_GetStreamWriteAvailable(stream_);
 
-		if (avail < 0)
-		{
-			throw PaException(avail);
-		}
+        if (avail < 0)
+        {
+            throw PaException(avail);
+        }
 
-		return avail;
-	}
+        return avail;
+    }
 
-	// --------------------------------------------------------------------------------------
+    // --------------------------------------------------------------------------------------
 
 } // portaudio
-
-
-

--- a/bindings/cpp/source/portaudiocpp/CFunCallbackStream.cxx
+++ b/bindings/cpp/source/portaudiocpp/CFunCallbackStream.cxx
@@ -5,37 +5,37 @@
 
 namespace portaudio
 {
-	CFunCallbackStream::CFunCallbackStream()
-	{
-	}
+    CFunCallbackStream::CFunCallbackStream()
+    {
+    }
 
-	CFunCallbackStream::CFunCallbackStream(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData)
-	{
-		open(parameters, funPtr, userData);
-	}
+    CFunCallbackStream::CFunCallbackStream(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData)
+    {
+        open(parameters, funPtr, userData);
+    }
 
-	CFunCallbackStream::~CFunCallbackStream()
-	{
-		try
-		{
-			close();
-		}
-		catch (...)
-		{
-			// ignore all errors
-		}
-	}
+    CFunCallbackStream::~CFunCallbackStream()
+    {
+        try
+        {
+            close();
+        }
+        catch (...)
+        {
+            // ignore all errors
+        }
+    }
 
-	// ---------------------------------------------------------------------------------==
+    // ---------------------------------------------------------------------------------==
 
-	void CFunCallbackStream::open(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData)
-	{
-		PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(), 
-			parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), funPtr, userData);
+    void CFunCallbackStream::open(const StreamParameters &parameters, PaStreamCallback *funPtr, void *userData)
+    {
+        PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(),
+            parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), funPtr, userData);
 
-		if (err != paNoError)
-		{
-			throw PaException(err);
-		}
-	}
+        if (err != paNoError)
+        {
+            throw PaException(err);
+        }
+    }
 }

--- a/bindings/cpp/source/portaudiocpp/CallbackInterface.cxx
+++ b/bindings/cpp/source/portaudiocpp/CallbackInterface.cxx
@@ -3,23 +3,21 @@
 namespace portaudio
 {
 
-	namespace impl
-	{
+    namespace impl
+    {
 
-		//////
-		/// Adapts any CallbackInterface object to a C-callable function (ie this function). A 
-		/// pointer to the object should be passed as ``userData'' when setting up the callback.
-		//////
-		int callbackInterfaceToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames, 
-			const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, void *userData)
-		{
-			CallbackInterface *cb = static_cast<CallbackInterface *>(userData);
-			return cb->paCallbackFun(inputBuffer, outputBuffer, numFrames, timeInfo, statusFlags);
-		}
+        //////
+        /// Adapts any CallbackInterface object to a C-callable function (ie this function). A
+        /// pointer to the object should be passed as ``userData'' when setting up the callback.
+        //////
+        int callbackInterfaceToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames,
+            const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, void *userData)
+        {
+            CallbackInterface *cb = static_cast<CallbackInterface *>(userData);
+            return cb->paCallbackFun(inputBuffer, outputBuffer, numFrames, timeInfo, statusFlags);
+        }
 
 
-	} // namespace impl
+    } // namespace impl
 
 } // namespace portaudio
-
-

--- a/bindings/cpp/source/portaudiocpp/CallbackStream.cxx
+++ b/bindings/cpp/source/portaudiocpp/CallbackStream.cxx
@@ -2,19 +2,19 @@
 
 namespace portaudio
 {
-	CallbackStream::CallbackStream()
-	{
-	}
+    CallbackStream::CallbackStream()
+    {
+    }
 
-	CallbackStream::~CallbackStream()
-	{
-	}
+    CallbackStream::~CallbackStream()
+    {
+    }
 
-	// -----------------------------------------------------------------------------------
-	
-	double CallbackStream::cpuLoad() const
-	{
-		return Pa_GetStreamCpuLoad(stream_);
-	}
+    // -----------------------------------------------------------------------------------
+
+    double CallbackStream::cpuLoad() const
+    {
+        return Pa_GetStreamCpuLoad(stream_);
+    }
 
 } // namespace portaudio

--- a/bindings/cpp/source/portaudiocpp/CppFunCallbackStream.cxx
+++ b/bindings/cpp/source/portaudiocpp/CppFunCallbackStream.cxx
@@ -5,77 +5,77 @@
 
 namespace portaudio
 {
-	namespace impl
-	{
-		//////
-		/// Adapts any a C++ callback to a C-callable function (ie this function). A 
-		/// pointer to a struct with the C++ function pointer and the actual user data should be 
-		/// passed as the ``userData'' parameter when setting up the callback.
-		//////
-		int cppCallbackToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames, 
-			const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, void *userData)
-		{
-			FunCallbackStream::CppToCCallbackData *data = static_cast<FunCallbackStream::CppToCCallbackData *>(userData);
-			return data->funPtr(inputBuffer, outputBuffer, numFrames, timeInfo, statusFlags, data->userData);
-		}
-	}
+    namespace impl
+    {
+        //////
+        /// Adapts any a C++ callback to a C-callable function (ie this function). A
+        /// pointer to a struct with the C++ function pointer and the actual user data should be
+        /// passed as the ``userData'' parameter when setting up the callback.
+        //////
+        int cppCallbackToPaCallbackAdapter(const void *inputBuffer, void *outputBuffer, unsigned long numFrames,
+            const PaStreamCallbackTimeInfo *timeInfo, PaStreamCallbackFlags statusFlags, void *userData)
+        {
+            FunCallbackStream::CppToCCallbackData *data = static_cast<FunCallbackStream::CppToCCallbackData *>(userData);
+            return data->funPtr(inputBuffer, outputBuffer, numFrames, timeInfo, statusFlags, data->userData);
+        }
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	FunCallbackStream::CppToCCallbackData::CppToCCallbackData()
-	{
-	}
+    FunCallbackStream::CppToCCallbackData::CppToCCallbackData()
+    {
+    }
 
-	FunCallbackStream::CppToCCallbackData::CppToCCallbackData(CallbackFunPtr funPtr, void *userData) : funPtr(funPtr), userData(userData)
-	{
-	}
+    FunCallbackStream::CppToCCallbackData::CppToCCallbackData(CallbackFunPtr funPtr, void *userData) : funPtr(funPtr), userData(userData)
+    {
+    }
 
-	void FunCallbackStream::CppToCCallbackData::init(CallbackFunPtr funPtr, void *userData)
-	{
-		this->funPtr = funPtr;
-		this->userData = userData;
-	}
+    void FunCallbackStream::CppToCCallbackData::init(CallbackFunPtr funPtr, void *userData)
+    {
+        this->funPtr = funPtr;
+        this->userData = userData;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	FunCallbackStream::FunCallbackStream()
-	{
-	}
+    FunCallbackStream::FunCallbackStream()
+    {
+    }
 
-	FunCallbackStream::FunCallbackStream(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData) : adapterData_(funPtr, userData)
-	{
-		open(parameters);
-	}
+    FunCallbackStream::FunCallbackStream(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData) : adapterData_(funPtr, userData)
+    {
+        open(parameters);
+    }
 
-	FunCallbackStream::~FunCallbackStream()
-	{
-		try
-		{
-			close();
-		}
-		catch (...)
-		{
-			// ignore all errors
-		}
-	}
+    FunCallbackStream::~FunCallbackStream()
+    {
+        try
+        {
+            close();
+        }
+        catch (...)
+        {
+            // ignore all errors
+        }
+    }
 
-	void FunCallbackStream::open(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData)
-	{
-		adapterData_.init(funPtr, userData);
-		open(parameters);
-	}
+    void FunCallbackStream::open(const StreamParameters &parameters, CallbackFunPtr funPtr, void *userData)
+    {
+        adapterData_.init(funPtr, userData);
+        open(parameters);
+    }
 
-	void FunCallbackStream::open(const StreamParameters &parameters)
-	{
-		PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(), 
-			parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), &impl::cppCallbackToPaCallbackAdapter, 
-			static_cast<void *>(&adapterData_));
+    void FunCallbackStream::open(const StreamParameters &parameters)
+    {
+        PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(),
+            parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), &impl::cppCallbackToPaCallbackAdapter,
+            static_cast<void *>(&adapterData_));
 
-		if (err != paNoError)
-		{
-			throw PaException(err);
-		}
-	}
+        if (err != paNoError)
+        {
+            throw PaException(err);
+        }
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 }

--- a/bindings/cpp/source/portaudiocpp/Device.cxx
+++ b/bindings/cpp/source/portaudiocpp/Device.cxx
@@ -9,160 +9,158 @@
 namespace portaudio
 {
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		Device::Device(PaDeviceIndex index) : index_(index)
-		{
-			if (index == paNoDevice)
-				info_ = NULL;
-			else
-				info_ = Pa_GetDeviceInfo(index);
-		}
+        Device::Device(PaDeviceIndex index) : index_(index)
+        {
+            if (index == paNoDevice)
+                info_ = NULL;
+            else
+                info_ = Pa_GetDeviceInfo(index);
+        }
 
-		Device::~Device()
-		{
-		}
+        Device::~Device()
+        {
+        }
 
-		PaDeviceIndex Device::index() const
-		{
-			return index_;
-		}
+        PaDeviceIndex Device::index() const
+        {
+            return index_;
+        }
 
-		const char *Device::name() const
-		{
-			if (info_ == NULL)
-				return "";
+        const char *Device::name() const
+        {
+            if (info_ == NULL)
+                return "";
 
-			return info_->name;
-		}
+            return info_->name;
+        }
 
-		int Device::maxInputChannels() const
-		{
-			if (info_ == NULL)
-				return 0;
+        int Device::maxInputChannels() const
+        {
+            if (info_ == NULL)
+                return 0;
 
-			return info_->maxInputChannels;
-		}
+            return info_->maxInputChannels;
+        }
 
-		int Device::maxOutputChannels() const
-		{
-			if (info_ == NULL)
-				return 0;
+        int Device::maxOutputChannels() const
+        {
+            if (info_ == NULL)
+                return 0;
 
-			return info_->maxOutputChannels;
-		}
+            return info_->maxOutputChannels;
+        }
 
-		PaTime Device::defaultLowInputLatency() const
-		{
-			if (info_ == NULL)
-				return static_cast<PaTime>(0.0);
+        PaTime Device::defaultLowInputLatency() const
+        {
+            if (info_ == NULL)
+                return static_cast<PaTime>(0.0);
 
-			return info_->defaultLowInputLatency;
-		}
+            return info_->defaultLowInputLatency;
+        }
 
-		PaTime Device::defaultHighInputLatency() const
-		{
-			if (info_ == NULL)
-				return static_cast<PaTime>(0.0);
+        PaTime Device::defaultHighInputLatency() const
+        {
+            if (info_ == NULL)
+                return static_cast<PaTime>(0.0);
 
-			return info_->defaultHighInputLatency;
-		}
+            return info_->defaultHighInputLatency;
+        }
 
-		PaTime Device::defaultLowOutputLatency() const
-		{
-			if (info_ == NULL)
-				return static_cast<PaTime>(0.0);
+        PaTime Device::defaultLowOutputLatency() const
+        {
+            if (info_ == NULL)
+                return static_cast<PaTime>(0.0);
 
-			return info_->defaultLowOutputLatency;
-		}
+            return info_->defaultLowOutputLatency;
+        }
 
-		PaTime Device::defaultHighOutputLatency() const
-		{
-			if (info_ == NULL)
-				return static_cast<PaTime>(0.0);
+        PaTime Device::defaultHighOutputLatency() const
+        {
+            if (info_ == NULL)
+                return static_cast<PaTime>(0.0);
 
-			return info_->defaultHighOutputLatency;
-		}
+            return info_->defaultHighOutputLatency;
+        }
 
-		double Device::defaultSampleRate() const
-		{
-			if (info_ == NULL)
-				return 0.0;
+        double Device::defaultSampleRate() const
+        {
+            if (info_ == NULL)
+                return 0.0;
 
-			return info_->defaultSampleRate;
-		}
+            return info_->defaultSampleRate;
+        }
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		bool Device::isInputOnlyDevice() const
-		{
-			return (maxOutputChannels() == 0);
-		}
+        bool Device::isInputOnlyDevice() const
+        {
+            return (maxOutputChannels() == 0);
+        }
 
-		bool Device::isOutputOnlyDevice() const
-		{
-			return (maxInputChannels() == 0);
-		}
+        bool Device::isOutputOnlyDevice() const
+        {
+            return (maxInputChannels() == 0);
+        }
 
-		bool Device::isFullDuplexDevice() const
-		{
-			return (maxInputChannels() > 0 && maxOutputChannels() > 0);
-		}
+        bool Device::isFullDuplexDevice() const
+        {
+            return (maxInputChannels() > 0 && maxOutputChannels() > 0);
+        }
 
-		bool Device::isSystemDefaultInputDevice() const
-		{
-			return (System::instance().defaultInputDevice() == *this);
-		}
+        bool Device::isSystemDefaultInputDevice() const
+        {
+            return (System::instance().defaultInputDevice() == *this);
+        }
 
-		bool Device::isSystemDefaultOutputDevice() const
-		{
-			return (System::instance().defaultOutputDevice() == *this);
-		}
+        bool Device::isSystemDefaultOutputDevice() const
+        {
+            return (System::instance().defaultOutputDevice() == *this);
+        }
 
-		bool Device::isHostApiDefaultInputDevice() const
-		{
-			return (hostApi().defaultInputDevice() == *this);
-		}
+        bool Device::isHostApiDefaultInputDevice() const
+        {
+            return (hostApi().defaultInputDevice() == *this);
+        }
 
-		bool Device::isHostApiDefaultOutputDevice() const
-		{
-			return (hostApi().defaultOutputDevice() == *this);
-		}
+        bool Device::isHostApiDefaultOutputDevice() const
+        {
+            return (hostApi().defaultOutputDevice() == *this);
+        }
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		bool Device::operator==(const Device &rhs) const
-		{
-			return (index_ == rhs.index_);
-		}
+        bool Device::operator==(const Device &rhs) const
+        {
+            return (index_ == rhs.index_);
+        }
 
-		bool Device::operator!=(const Device &rhs) const
-		{
-			return !(*this == rhs);
-		}
+        bool Device::operator!=(const Device &rhs) const
+        {
+            return !(*this == rhs);
+        }
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
-		HostApi &Device::hostApi()
-		{
-			// NOTE: will cause an exception when called for the null device
-			if (info_ == NULL)
-				throw PaException(paInternalError);
+        HostApi &Device::hostApi()
+        {
+            // NOTE: will cause an exception when called for the null device
+            if (info_ == NULL)
+                throw PaException(paInternalError);
 
-			return System::instance().hostApiByIndex(info_->hostApi);
-		}
+            return System::instance().hostApiByIndex(info_->hostApi);
+        }
 
-		const HostApi &Device::hostApi() const
-		{
-			// NOTE; will cause an exception when called for the null device
-			if (info_ == NULL)
-				throw PaException(paInternalError);
+        const HostApi &Device::hostApi() const
+        {
+            // NOTE; will cause an exception when called for the null device
+            if (info_ == NULL)
+                throw PaException(paInternalError);
 
-			return System::instance().hostApiByIndex(info_->hostApi);
-		}
+            return System::instance().hostApiByIndex(info_->hostApi);
+        }
 
-		// -------------------------------------------------------------------------------
+        // -------------------------------------------------------------------------------
 
 } // namespace portaudio
-
-

--- a/bindings/cpp/source/portaudiocpp/DirectionSpecificStreamParameters.cxx
+++ b/bindings/cpp/source/portaudiocpp/DirectionSpecificStreamParameters.cxx
@@ -5,159 +5,159 @@
 namespace portaudio
 {
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Returns a `nil' DirectionSpecificStreamParameters object. This can be used to 
-	/// specify that one direction of a Stream is not required (i.e. when creating 
-	/// a half-duplex Stream). All fields of the null DirectionSpecificStreamParameters 
-	/// object are invalid except for the device and the number of channel, which are set 
-	/// to paNoDevice and 0 respectively.
-	//////
-	DirectionSpecificStreamParameters DirectionSpecificStreamParameters::null()
-	{
-		DirectionSpecificStreamParameters tmp;
-		tmp.paStreamParameters_.device = paNoDevice;
-		tmp.paStreamParameters_.channelCount = 0;
-		return tmp;
-	}
+    //////
+    /// Returns a `nil' DirectionSpecificStreamParameters object. This can be used to
+    /// specify that one direction of a Stream is not required (i.e. when creating
+    /// a half-duplex Stream). All fields of the null DirectionSpecificStreamParameters
+    /// object are invalid except for the device and the number of channel, which are set
+    /// to paNoDevice and 0 respectively.
+    //////
+    DirectionSpecificStreamParameters DirectionSpecificStreamParameters::null()
+    {
+        DirectionSpecificStreamParameters tmp;
+        tmp.paStreamParameters_.device = paNoDevice;
+        tmp.paStreamParameters_.channelCount = 0;
+        return tmp;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Default constructor -- all parameters will be uninitialized.
-	//////
-	DirectionSpecificStreamParameters::DirectionSpecificStreamParameters()
-	{
-	}
+    //////
+    /// Default constructor -- all parameters will be uninitialized.
+    //////
+    DirectionSpecificStreamParameters::DirectionSpecificStreamParameters()
+    {
+    }
 
-	//////
-	/// Constructor which sets all required fields.
-	//////
-	DirectionSpecificStreamParameters::DirectionSpecificStreamParameters(const Device &device, int numChannels, 
-		SampleDataFormat format, bool interleaved, PaTime suggestedLatency, void *hostApiSpecificStreamInfo)
-	{
-		setDevice(device);
-		setNumChannels(numChannels);
-		setSampleFormat(format, interleaved);
-		setSuggestedLatency(suggestedLatency);
-		setHostApiSpecificStreamInfo(hostApiSpecificStreamInfo);
-	}
+    //////
+    /// Constructor which sets all required fields.
+    //////
+    DirectionSpecificStreamParameters::DirectionSpecificStreamParameters(const Device &device, int numChannels,
+        SampleDataFormat format, bool interleaved, PaTime suggestedLatency, void *hostApiSpecificStreamInfo)
+    {
+        setDevice(device);
+        setNumChannels(numChannels);
+        setSampleFormat(format, interleaved);
+        setSuggestedLatency(suggestedLatency);
+        setHostApiSpecificStreamInfo(hostApiSpecificStreamInfo);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	void DirectionSpecificStreamParameters::setDevice(const Device &device)
-	{
-		paStreamParameters_.device = device.index();
-	}
+    void DirectionSpecificStreamParameters::setDevice(const Device &device)
+    {
+        paStreamParameters_.device = device.index();
+    }
 
-	void DirectionSpecificStreamParameters::setNumChannels(int numChannels)
-	{
-		paStreamParameters_.channelCount = numChannels;
-	}
+    void DirectionSpecificStreamParameters::setNumChannels(int numChannels)
+    {
+        paStreamParameters_.channelCount = numChannels;
+    }
 
-	void DirectionSpecificStreamParameters::setSampleFormat(SampleDataFormat format, bool interleaved)
-	{
-		paStreamParameters_.sampleFormat = static_cast<PaSampleFormat>(format);
+    void DirectionSpecificStreamParameters::setSampleFormat(SampleDataFormat format, bool interleaved)
+    {
+        paStreamParameters_.sampleFormat = static_cast<PaSampleFormat>(format);
 
-		if (!interleaved)
-			paStreamParameters_.sampleFormat |= paNonInterleaved;
-	}
+        if (!interleaved)
+            paStreamParameters_.sampleFormat |= paNonInterleaved;
+    }
 
-	void DirectionSpecificStreamParameters::setHostApiSpecificSampleFormat(PaSampleFormat format, bool interleaved)
-	{
-		paStreamParameters_.sampleFormat = format;
+    void DirectionSpecificStreamParameters::setHostApiSpecificSampleFormat(PaSampleFormat format, bool interleaved)
+    {
+        paStreamParameters_.sampleFormat = format;
 
-		paStreamParameters_.sampleFormat |= paCustomFormat;
+        paStreamParameters_.sampleFormat |= paCustomFormat;
 
-		if (!interleaved)
-			paStreamParameters_.sampleFormat |= paNonInterleaved;
-	}
+        if (!interleaved)
+            paStreamParameters_.sampleFormat |= paNonInterleaved;
+    }
 
-	void DirectionSpecificStreamParameters::setSuggestedLatency(PaTime latency)
-	{
-		paStreamParameters_.suggestedLatency = latency;
-	}
+    void DirectionSpecificStreamParameters::setSuggestedLatency(PaTime latency)
+    {
+        paStreamParameters_.suggestedLatency = latency;
+    }
 
-	void DirectionSpecificStreamParameters::setHostApiSpecificStreamInfo(void *streamInfo)
-	{
-		paStreamParameters_.hostApiSpecificStreamInfo = streamInfo;
-	}
+    void DirectionSpecificStreamParameters::setHostApiSpecificStreamInfo(void *streamInfo)
+    {
+        paStreamParameters_.hostApiSpecificStreamInfo = streamInfo;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	PaStreamParameters *DirectionSpecificStreamParameters::paStreamParameters()
-	{
-		if (paStreamParameters_.channelCount > 0 && paStreamParameters_.device != paNoDevice)
-			return &paStreamParameters_;
-		else
-			return NULL;
-	}
+    PaStreamParameters *DirectionSpecificStreamParameters::paStreamParameters()
+    {
+        if (paStreamParameters_.channelCount > 0 && paStreamParameters_.device != paNoDevice)
+            return &paStreamParameters_;
+        else
+            return NULL;
+    }
 
-	const PaStreamParameters *DirectionSpecificStreamParameters::paStreamParameters() const
-	{
-		if (paStreamParameters_.channelCount > 0 && paStreamParameters_.device != paNoDevice)
-			return &paStreamParameters_;
-		else
-			return NULL;
-	}
+    const PaStreamParameters *DirectionSpecificStreamParameters::paStreamParameters() const
+    {
+        if (paStreamParameters_.channelCount > 0 && paStreamParameters_.device != paNoDevice)
+            return &paStreamParameters_;
+        else
+            return NULL;
+    }
 
-	Device &DirectionSpecificStreamParameters::device() const
-	{
-		return System::instance().deviceByIndex(paStreamParameters_.device);
-	}
+    Device &DirectionSpecificStreamParameters::device() const
+    {
+        return System::instance().deviceByIndex(paStreamParameters_.device);
+    }
 
-	int DirectionSpecificStreamParameters::numChannels() const
-	{
-		return paStreamParameters_.channelCount;
-	}
+    int DirectionSpecificStreamParameters::numChannels() const
+    {
+        return paStreamParameters_.channelCount;
+    }
 
-	//////
-	/// Returns the (non host api-specific) sample format, without including 
-	/// the paNonInterleaved flag. If the sample format is host api-spefific, 
-	/// INVALID_FORMAT (0) will be returned.
-	//////
-	SampleDataFormat DirectionSpecificStreamParameters::sampleFormat() const
-	{
-		if (isSampleFormatHostApiSpecific())
-			return INVALID_FORMAT;
-		else
-			return static_cast<SampleDataFormat>(paStreamParameters_.sampleFormat & ~paNonInterleaved);
-	}
+    //////
+    /// Returns the (non host api-specific) sample format, without including
+    /// the paNonInterleaved flag. If the sample format is host api-spefific,
+    /// INVALID_FORMAT (0) will be returned.
+    //////
+    SampleDataFormat DirectionSpecificStreamParameters::sampleFormat() const
+    {
+        if (isSampleFormatHostApiSpecific())
+            return INVALID_FORMAT;
+        else
+            return static_cast<SampleDataFormat>(paStreamParameters_.sampleFormat & ~paNonInterleaved);
+    }
 
-	bool DirectionSpecificStreamParameters::isSampleFormatInterleaved() const
-	{
-		return ((paStreamParameters_.sampleFormat & paNonInterleaved) == 0);
-	}
+    bool DirectionSpecificStreamParameters::isSampleFormatInterleaved() const
+    {
+        return ((paStreamParameters_.sampleFormat & paNonInterleaved) == 0);
+    }
 
-	bool DirectionSpecificStreamParameters::isSampleFormatHostApiSpecific() const
-	{
-		return ((paStreamParameters_.sampleFormat & paCustomFormat) == 0);
-	}
+    bool DirectionSpecificStreamParameters::isSampleFormatHostApiSpecific() const
+    {
+        return ((paStreamParameters_.sampleFormat & paCustomFormat) == 0);
+    }
 
-	//////
-	/// Returns the host api-specific sample format, without including any 
-	/// paCustomFormat or paNonInterleaved flags. Will return 0 if the sample format is 
-	/// not host api-specific.
-	//////
-	PaSampleFormat DirectionSpecificStreamParameters::hostApiSpecificSampleFormat() const
-	{
-		if (isSampleFormatHostApiSpecific())
-			return paStreamParameters_.sampleFormat & ~paCustomFormat & ~paNonInterleaved;
-		else
-			return 0;
-	}
+    //////
+    /// Returns the host api-specific sample format, without including any
+    /// paCustomFormat or paNonInterleaved flags. Will return 0 if the sample format is
+    /// not host api-specific.
+    //////
+    PaSampleFormat DirectionSpecificStreamParameters::hostApiSpecificSampleFormat() const
+    {
+        if (isSampleFormatHostApiSpecific())
+            return paStreamParameters_.sampleFormat & ~paCustomFormat & ~paNonInterleaved;
+        else
+            return 0;
+    }
 
-	PaTime DirectionSpecificStreamParameters::suggestedLatency() const
-	{
-		return paStreamParameters_.suggestedLatency;
-	}
+    PaTime DirectionSpecificStreamParameters::suggestedLatency() const
+    {
+        return paStreamParameters_.suggestedLatency;
+    }
 
-	void *DirectionSpecificStreamParameters::hostApiSpecificStreamInfo() const
-	{
-		return paStreamParameters_.hostApiSpecificStreamInfo;
-	}
+    void *DirectionSpecificStreamParameters::hostApiSpecificStreamInfo() const
+    {
+        return paStreamParameters_.hostApiSpecificStreamInfo;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
 } // namespace portaudio

--- a/bindings/cpp/source/portaudiocpp/Exception.cxx
+++ b/bindings/cpp/source/portaudiocpp/Exception.cxx
@@ -2,122 +2,120 @@
 
 namespace portaudio
 {
-	// -----------------------------------------------------------------------------------
-	// PaException:
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
+    // PaException:
+    // -----------------------------------------------------------------------------------
 
-	//////
-	///  Wraps a PortAudio error into a PortAudioCpp PaException.
-	//////
-	PaException::PaException(PaError error) : error_(error)
-	{
-	}
+    //////
+    ///  Wraps a PortAudio error into a PortAudioCpp PaException.
+    //////
+    PaException::PaException(PaError error) : error_(error)
+    {
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Alias for paErrorText(), to have std::exception compliance.
-	//////
-	const char *PaException::what() const throw()
-	{
-		return paErrorText();
-	}
+    //////
+    /// Alias for paErrorText(), to have std::exception compliance.
+    //////
+    const char *PaException::what() const throw()
+    {
+        return paErrorText();
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Returns the PortAudio error code (PaError).
-	//////
-	PaError PaException::paError() const
-	{
-		return error_;
-	}
+    //////
+    /// Returns the PortAudio error code (PaError).
+    //////
+    PaError PaException::paError() const
+    {
+        return error_;
+    }
 
-	//////
-	/// Returns the error as a (zero-terminated) text string.
-	//////
-	const char *PaException::paErrorText() const
-	{
-		return Pa_GetErrorText(error_);
-	}
+    //////
+    /// Returns the error as a (zero-terminated) text string.
+    //////
+    const char *PaException::paErrorText() const
+    {
+        return Pa_GetErrorText(error_);
+    }
 
-	//////
-	/// Returns true is the error is a HostApi error.
-	//////
-	bool PaException::isHostApiError() const
-	{
-		return (error_ == paUnanticipatedHostError);
-	}
+    //////
+    /// Returns true is the error is a HostApi error.
+    //////
+    bool PaException::isHostApiError() const
+    {
+        return (error_ == paUnanticipatedHostError);
+    }
 
-	//////
-	/// Returns the last HostApi error (which is the current one if 
-	/// isHostApiError() returns true) as an error code.
-	//////
-	long PaException::lastHostApiError() const
-	{
-		return Pa_GetLastHostErrorInfo()->errorCode;
-	}
+    //////
+    /// Returns the last HostApi error (which is the current one if
+    /// isHostApiError() returns true) as an error code.
+    //////
+    long PaException::lastHostApiError() const
+    {
+        return Pa_GetLastHostErrorInfo()->errorCode;
+    }
 
-	//////
-	/// Returns the last HostApi error (which is the current one if 
-	/// isHostApiError() returns true) as a (zero-terminated) text 
-	/// string, if it's available.
-	//////
-	const char *PaException::lastHostApiErrorText() const
-	{
-		return Pa_GetLastHostErrorInfo()->errorText;
-	}
+    //////
+    /// Returns the last HostApi error (which is the current one if
+    /// isHostApiError() returns true) as a (zero-terminated) text
+    /// string, if it's available.
+    //////
+    const char *PaException::lastHostApiErrorText() const
+    {
+        return Pa_GetLastHostErrorInfo()->errorText;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	bool PaException::operator==(const PaException &rhs) const
-	{
-		return (error_ == rhs.error_);
-	}
+    bool PaException::operator==(const PaException &rhs) const
+    {
+        return (error_ == rhs.error_);
+    }
 
-	bool PaException::operator!=(const PaException &rhs) const
-	{
-		return !(*this == rhs);
-	}
+    bool PaException::operator!=(const PaException &rhs) const
+    {
+        return !(*this == rhs);
+    }
 
-	// -----------------------------------------------------------------------------------
-	// PaCppException:
-	// -----------------------------------------------------------------------------------
-	
-	PaCppException::PaCppException(ExceptionSpecifier specifier) : specifier_(specifier)
-	{
-	}
+    // -----------------------------------------------------------------------------------
+    // PaCppException:
+    // -----------------------------------------------------------------------------------
 
-	const char *PaCppException::what() const throw()
-	{
-		switch (specifier_)
-		{
-			case UNABLE_TO_ADAPT_DEVICE:
-			{
-				return "Unable to adapt the given device to the specified host api specific device extension";
-			}
-		}
+    PaCppException::PaCppException(ExceptionSpecifier specifier) : specifier_(specifier)
+    {
+    }
 
-		return "Unknown exception";
-	}
+    const char *PaCppException::what() const throw()
+    {
+        switch (specifier_)
+        {
+            case UNABLE_TO_ADAPT_DEVICE:
+            {
+                return "Unable to adapt the given device to the specified host api specific device extension";
+            }
+        }
 
-	PaCppException::ExceptionSpecifier PaCppException::specifier() const
-	{
-		return specifier_;
-	}
+        return "Unknown exception";
+    }
 
-	bool PaCppException::operator==(const PaCppException &rhs) const
-	{
-		return (specifier_ == rhs.specifier_);
-	}
+    PaCppException::ExceptionSpecifier PaCppException::specifier() const
+    {
+        return specifier_;
+    }
 
-	bool PaCppException::operator!=(const PaCppException &rhs) const
-	{
-		return !(*this == rhs);
-	}
+    bool PaCppException::operator==(const PaCppException &rhs) const
+    {
+        return (specifier_ == rhs.specifier_);
+    }
 
-	// -----------------------------------------------------------------------------------
+    bool PaCppException::operator!=(const PaCppException &rhs) const
+    {
+        return !(*this == rhs);
+    }
+
+    // -----------------------------------------------------------------------------------
 
 } // namespace portaudio
-
-

--- a/bindings/cpp/source/portaudiocpp/HostApi.cxx
+++ b/bindings/cpp/source/portaudiocpp/HostApi.cxx
@@ -8,114 +8,114 @@
 namespace portaudio
 {
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	HostApi::HostApi(PaHostApiIndex index) : devices_(NULL)
-	{
-		try
-		{
-			info_ = Pa_GetHostApiInfo(index);
+    HostApi::HostApi(PaHostApiIndex index) : devices_(NULL)
+    {
+        try
+        {
+            info_ = Pa_GetHostApiInfo(index);
 
-			// Create and populate devices array:
-			int numDevices = deviceCount();
+            // Create and populate devices array:
+            int numDevices = deviceCount();
 
-			devices_ = new Device*[numDevices];
+            devices_ = new Device*[numDevices];
 
-			for (int i = 0; i < numDevices; ++i)
-			{
-				PaDeviceIndex deviceIndex = Pa_HostApiDeviceIndexToDeviceIndex(index, i);
+            for (int i = 0; i < numDevices; ++i)
+            {
+                PaDeviceIndex deviceIndex = Pa_HostApiDeviceIndexToDeviceIndex(index, i);
 
-				if (deviceIndex < 0)
-				{
-					throw PaException(deviceIndex);
-				}
+                if (deviceIndex < 0)
+                {
+                    throw PaException(deviceIndex);
+                }
 
-				devices_[i] = &System::instance().deviceByIndex(deviceIndex);
-			}
-		}
-		catch (const std::exception &e)
-		{
-			// Delete any (partially) constructed objects (deconstructor isn't called):
-			delete[] devices_; // devices_ is either NULL or valid
+                devices_[i] = &System::instance().deviceByIndex(deviceIndex);
+            }
+        }
+        catch (const std::exception &e)
+        {
+            // Delete any (partially) constructed objects (deconstructor isn't called):
+            delete[] devices_; // devices_ is either NULL or valid
 
-			// Re-throw exception:
-			throw e;
-		}
-	}
+            // Re-throw exception:
+            throw e;
+        }
+    }
 
-	HostApi::~HostApi()
-	{
-		// Destroy devices array:
-		delete[] devices_;
-	}
+    HostApi::~HostApi()
+    {
+        // Destroy devices array:
+        delete[] devices_;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	PaHostApiTypeId HostApi::typeId() const
-	{
-		return info_->type;
-	}
+    PaHostApiTypeId HostApi::typeId() const
+    {
+        return info_->type;
+    }
 
-	PaHostApiIndex HostApi::index() const
-	{
-		PaHostApiIndex index = Pa_HostApiTypeIdToHostApiIndex(typeId());
+    PaHostApiIndex HostApi::index() const
+    {
+        PaHostApiIndex index = Pa_HostApiTypeIdToHostApiIndex(typeId());
 
-		if (index < 0)
-			throw PaException(index);
+        if (index < 0)
+            throw PaException(index);
 
-		return index;
-	}
+        return index;
+    }
 
-	const char *HostApi::name() const
-	{
-		return info_->name;
-	}
+    const char *HostApi::name() const
+    {
+        return info_->name;
+    }
 
-	int HostApi::deviceCount() const
-	{
-		return info_->deviceCount;
-	}
+    int HostApi::deviceCount() const
+    {
+        return info_->deviceCount;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	HostApi::DeviceIterator HostApi::devicesBegin()
-	{
-		DeviceIterator tmp;
-		tmp.ptr_ = &devices_[0]; // begin (first element)
-		return tmp;
-	}
+    HostApi::DeviceIterator HostApi::devicesBegin()
+    {
+        DeviceIterator tmp;
+        tmp.ptr_ = &devices_[0]; // begin (first element)
+        return tmp;
+    }
 
-	HostApi::DeviceIterator HostApi::devicesEnd()
-	{
-		DeviceIterator tmp;
-		tmp.ptr_ = &devices_[deviceCount()]; // end (one past last element)
-		return tmp;
-	}
+    HostApi::DeviceIterator HostApi::devicesEnd()
+    {
+        DeviceIterator tmp;
+        tmp.ptr_ = &devices_[deviceCount()]; // end (one past last element)
+        return tmp;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	Device &HostApi::defaultInputDevice() const
-	{
-		return System::instance().deviceByIndex(info_->defaultInputDevice);
-	}
+    Device &HostApi::defaultInputDevice() const
+    {
+        return System::instance().deviceByIndex(info_->defaultInputDevice);
+    }
 
-	Device &HostApi::defaultOutputDevice() const
-	{
-		return System::instance().deviceByIndex(info_->defaultOutputDevice);
-	}
+    Device &HostApi::defaultOutputDevice() const
+    {
+        return System::instance().deviceByIndex(info_->defaultOutputDevice);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	bool HostApi::operator==(const HostApi &rhs) const
-	{
-		return (typeId() == rhs.typeId());
-	}
+    bool HostApi::operator==(const HostApi &rhs) const
+    {
+        return (typeId() == rhs.typeId());
+    }
 
-	bool HostApi::operator!=(const HostApi &rhs) const
-	{
-		return !(*this == rhs);
-	}
+    bool HostApi::operator!=(const HostApi &rhs) const
+    {
+        return !(*this == rhs);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
 } // namespace portaudio

--- a/bindings/cpp/source/portaudiocpp/InterfaceCallbackStream.cxx
+++ b/bindings/cpp/source/portaudiocpp/InterfaceCallbackStream.cxx
@@ -7,39 +7,39 @@
 namespace portaudio
 {
 
-	// ---------------------------------------------------------------------------------==
+    // ---------------------------------------------------------------------------------==
 
-	InterfaceCallbackStream::InterfaceCallbackStream()
-	{
-	}
+    InterfaceCallbackStream::InterfaceCallbackStream()
+    {
+    }
 
-	InterfaceCallbackStream::InterfaceCallbackStream(const StreamParameters &parameters, CallbackInterface &instance)
-	{
-		open(parameters, instance);
-	}
+    InterfaceCallbackStream::InterfaceCallbackStream(const StreamParameters &parameters, CallbackInterface &instance)
+    {
+        open(parameters, instance);
+    }
 
-	InterfaceCallbackStream::~InterfaceCallbackStream()
-	{
-		try
-		{
-			close();
-		}
-		catch (...)
-		{
-			// ignore all errors
-		}
-	}
+    InterfaceCallbackStream::~InterfaceCallbackStream()
+    {
+        try
+        {
+            close();
+        }
+        catch (...)
+        {
+            // ignore all errors
+        }
+    }
 
-	// ---------------------------------------------------------------------------------==
+    // ---------------------------------------------------------------------------------==
 
-	void InterfaceCallbackStream::open(const StreamParameters &parameters, CallbackInterface &instance)
-	{
-		PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(), 
-			parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), &impl::callbackInterfaceToPaCallbackAdapter, static_cast<void *>(&instance));
+    void InterfaceCallbackStream::open(const StreamParameters &parameters, CallbackInterface &instance)
+    {
+        PaError err = Pa_OpenStream(&stream_, parameters.inputParameters().paStreamParameters(), parameters.outputParameters().paStreamParameters(),
+            parameters.sampleRate(), parameters.framesPerBuffer(), parameters.flags(), &impl::callbackInterfaceToPaCallbackAdapter, static_cast<void *>(&instance));
 
-		if (err != paNoError)
-		{
-			throw PaException(err);
-		}
-	}
+        if (err != paNoError)
+        {
+            throw PaException(err);
+        }
+    }
 }

--- a/bindings/cpp/source/portaudiocpp/MemFunCallbackStream.cxx
+++ b/bindings/cpp/source/portaudiocpp/MemFunCallbackStream.cxx
@@ -1,4 +1,3 @@
 #include "portaudiocpp/MemFunCallbackStream.hxx"
 
 // (... template class ...)
-

--- a/bindings/cpp/source/portaudiocpp/Stream.cxx
+++ b/bindings/cpp/source/portaudiocpp/Stream.cxx
@@ -8,188 +8,188 @@
 namespace portaudio
 {
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	Stream::Stream() : stream_(NULL)
-	{
-	}
+    Stream::Stream() : stream_(NULL)
+    {
+    }
 
-	Stream::~Stream()
-	{
-		// (can't call close here, 
-		// the derived class should atleast call 
-		// close() in it's deconstructor)
-	}
+    Stream::~Stream()
+    {
+        // (can't call close here,
+        // the derived class should atleast call
+        // close() in it's deconstructor)
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Closes the Stream if it's open, else does nothing.
-	//////
-	void Stream::close()
-	{
-		if (isOpen() && System::exists())
-		{
-			PaError err = Pa_CloseStream(stream_);
-			stream_ = NULL;
+    //////
+    /// Closes the Stream if it's open, else does nothing.
+    //////
+    void Stream::close()
+    {
+        if (isOpen() && System::exists())
+        {
+            PaError err = Pa_CloseStream(stream_);
+            stream_ = NULL;
 
-			if (err != paNoError)
-				throw PaException(err);
-		}
-	}
+            if (err != paNoError)
+                throw PaException(err);
+        }
+    }
 
-	//////
-	/// Returns true if the Stream is open.
-	//////
-	bool Stream::isOpen() const
-	{
-		return (stream_ != NULL);
-	}
+    //////
+    /// Returns true if the Stream is open.
+    //////
+    bool Stream::isOpen() const
+    {
+        return (stream_ != NULL);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	void Stream::setStreamFinishedCallback(PaStreamFinishedCallback *callback)
-	{
-		PaError err = Pa_SetStreamFinishedCallback(stream_, callback);
+    void Stream::setStreamFinishedCallback(PaStreamFinishedCallback *callback)
+    {
+        PaError err = Pa_SetStreamFinishedCallback(stream_, callback);
 
-		if (err != paNoError)
-			throw PaException(err);
-	}
+        if (err != paNoError)
+            throw PaException(err);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	void Stream::start()
-	{
-		PaError err = Pa_StartStream(stream_);
+    void Stream::start()
+    {
+        PaError err = Pa_StartStream(stream_);
 
-		if (err != paNoError)
-			throw PaException(err);
-	}
+        if (err != paNoError)
+            throw PaException(err);
+    }
 
-	void Stream::stop()
-	{
-		PaError err = Pa_StopStream(stream_);
+    void Stream::stop()
+    {
+        PaError err = Pa_StopStream(stream_);
 
-		if (err != paNoError)
-			throw PaException(err);
-	}
+        if (err != paNoError)
+            throw PaException(err);
+    }
 
-	void Stream::abort()
-	{
-		PaError err = Pa_AbortStream(stream_);
+    void Stream::abort()
+    {
+        PaError err = Pa_AbortStream(stream_);
 
-		if (err != paNoError)
-			throw PaException(err);
-	}
+        if (err != paNoError)
+            throw PaException(err);
+    }
 
-	bool Stream::isStopped() const
-	{
-		PaError ret = Pa_IsStreamStopped(stream_);
+    bool Stream::isStopped() const
+    {
+        PaError ret = Pa_IsStreamStopped(stream_);
 
-		if (ret < 0)
-			throw PaException(ret);
+        if (ret < 0)
+            throw PaException(ret);
 
-		return (ret == 1);
-	}
+        return (ret == 1);
+    }
 
-	bool Stream::isActive() const
-	{
-		PaError ret = Pa_IsStreamActive(stream_);
+    bool Stream::isActive() const
+    {
+        PaError ret = Pa_IsStreamActive(stream_);
 
-		if (ret < 0)
-			throw PaException(ret);
+        if (ret < 0)
+            throw PaException(ret);
 
-		return (ret == 1);
-	}
+        return (ret == 1);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Returns the best known input latency for the Stream. This value may differ from the 
-	/// suggested input latency set in the StreamParameters. Includes all sources of 
-	/// latency known to PortAudio such as internal buffering, and Host API reported latency. 
-	/// Doesn't include any estimates of unknown latency.
-	//////
-	PaTime Stream::inputLatency() const
-	{
-		const PaStreamInfo *info = Pa_GetStreamInfo(stream_);
-		if (info == NULL)
-		{
-			throw PaException(paInternalError);
-			return PaTime(0.0);
-		}
+    //////
+    /// Returns the best known input latency for the Stream. This value may differ from the
+    /// suggested input latency set in the StreamParameters. Includes all sources of
+    /// latency known to PortAudio such as internal buffering, and Host API reported latency.
+    /// Doesn't include any estimates of unknown latency.
+    //////
+    PaTime Stream::inputLatency() const
+    {
+        const PaStreamInfo *info = Pa_GetStreamInfo(stream_);
+        if (info == NULL)
+        {
+            throw PaException(paInternalError);
+            return PaTime(0.0);
+        }
 
-		return info->inputLatency;
-	}
+        return info->inputLatency;
+    }
 
-	//////
-	/// Returns the best known output latency for the Stream. This value may differ from the 
-	/// suggested output latency set in the StreamParameters. Includes all sources of 
-	/// latency known to PortAudio such as internal buffering, and Host API reported latency. 
-	/// Doesn't include any estimates of unknown latency.
-	//////
-	PaTime Stream::outputLatency() const
-	{
-		const PaStreamInfo *info = Pa_GetStreamInfo(stream_);
-		if (info == NULL)
-		{
-			throw PaException(paInternalError);
-			return PaTime(0.0);
-		}
+    //////
+    /// Returns the best known output latency for the Stream. This value may differ from the
+    /// suggested output latency set in the StreamParameters. Includes all sources of
+    /// latency known to PortAudio such as internal buffering, and Host API reported latency.
+    /// Doesn't include any estimates of unknown latency.
+    //////
+    PaTime Stream::outputLatency() const
+    {
+        const PaStreamInfo *info = Pa_GetStreamInfo(stream_);
+        if (info == NULL)
+        {
+            throw PaException(paInternalError);
+            return PaTime(0.0);
+        }
 
-		return info->outputLatency;
-	}
+        return info->outputLatency;
+    }
 
-	//////
-	/// Returns the sample rate of the Stream. Usually this will be the 
-	/// best known estimate of the used sample rate. For instance when opening a 
-	/// Stream setting 44100.0 Hz in the StreamParameters, the actual sample 
-	/// rate might be something like 44103.2 Hz (due to imperfections in the 
-	/// sound card hardware).
-	//////
-	double Stream::sampleRate() const
-	{
-		const PaStreamInfo *info = Pa_GetStreamInfo(stream_);
-		if (info == NULL)
-		{
-			throw PaException(paInternalError);
-			return 0.0;
-		}
+    //////
+    /// Returns the sample rate of the Stream. Usually this will be the
+    /// best known estimate of the used sample rate. For instance when opening a
+    /// Stream setting 44100.0 Hz in the StreamParameters, the actual sample
+    /// rate might be something like 44103.2 Hz (due to imperfections in the
+    /// sound card hardware).
+    //////
+    double Stream::sampleRate() const
+    {
+        const PaStreamInfo *info = Pa_GetStreamInfo(stream_);
+        if (info == NULL)
+        {
+            throw PaException(paInternalError);
+            return 0.0;
+        }
 
-		return info->sampleRate;
-	}
+        return info->sampleRate;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	PaTime Stream::time() const
-	{
-		return Pa_GetStreamTime(stream_);
-	}
+    PaTime Stream::time() const
+    {
+        return Pa_GetStreamTime(stream_);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Accessor (const) for PortAudio PaStream pointer, useful for interfacing with 
-	/// PortAudio add-ons such as PortMixer for instance. Normally accessing this 
-	/// pointer should not be needed as PortAudioCpp aims to provide all of PortAudio's 
-	/// functionality.
-	//////
-	const PaStream *Stream::paStream() const
-	{
-		return stream_;
-	}
+    //////
+    /// Accessor (const) for PortAudio PaStream pointer, useful for interfacing with
+    /// PortAudio add-ons such as PortMixer for instance. Normally accessing this
+    /// pointer should not be needed as PortAudioCpp aims to provide all of PortAudio's
+    /// functionality.
+    //////
+    const PaStream *Stream::paStream() const
+    {
+        return stream_;
+    }
 
-	//////
-	/// Accessor (non-const) for PortAudio PaStream pointer, useful for interfacing with 
-	/// PortAudio add-ons such as PortMixer for instance. Normally accessing this 
-	/// pointer should not be needed as PortAudioCpp aims to provide all of PortAudio's 
-	/// functionality.
-	//////
-	PaStream *Stream::paStream()
-	{
-		return stream_;
-	}
+    //////
+    /// Accessor (non-const) for PortAudio PaStream pointer, useful for interfacing with
+    /// PortAudio add-ons such as PortMixer for instance. Normally accessing this
+    /// pointer should not be needed as PortAudioCpp aims to provide all of PortAudio's
+    /// functionality.
+    //////
+    PaStream *Stream::paStream()
+    {
+        return stream_;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
 } // namespace portaudio

--- a/bindings/cpp/source/portaudiocpp/StreamParameters.cxx
+++ b/bindings/cpp/source/portaudiocpp/StreamParameters.cxx
@@ -6,160 +6,155 @@
 
 namespace portaudio
 {
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Default constructor; does nothing.
-	//////
-	StreamParameters::StreamParameters()
-	{
-	}
+    //////
+    /// Default constructor; does nothing.
+    //////
+    StreamParameters::StreamParameters()
+    {
+    }
 
-	//////
-	/// Sets up the all parameters needed to open either a half-duplex or full-duplex Stream.
-	///
-	/// @param inputParameters The parameters for the input direction of the to-be opened 
-	/// Stream or DirectionSpecificStreamParameters::null() for an output-only Stream.
-	/// @param outputParameters The parameters for the output direction of the to-be opened
-	/// Stream or DirectionSpecificStreamParameters::null() for an input-only Stream.
-	/// @param sampleRate The to-be opened Stream's sample rate in Hz.
-	/// @param framesPerBuffer The number of frames per buffer for a CallbackStream, or 
-	/// the preferred buffer granularity for a BlockingStream.
-	/// @param flags The flags for the to-be opened Stream; default paNoFlag.
-	//////
-	StreamParameters::StreamParameters(const DirectionSpecificStreamParameters &inputParameters, 
-		const DirectionSpecificStreamParameters &outputParameters, double sampleRate, unsigned long framesPerBuffer, 
-		PaStreamFlags flags) : inputParameters_(inputParameters), outputParameters_(outputParameters), 
-		sampleRate_(sampleRate), framesPerBuffer_(framesPerBuffer), flags_(flags)
-	{
-	}
+    //////
+    /// Sets up the all parameters needed to open either a half-duplex or full-duplex Stream.
+    ///
+    /// @param inputParameters The parameters for the input direction of the to-be opened
+    /// Stream or DirectionSpecificStreamParameters::null() for an output-only Stream.
+    /// @param outputParameters The parameters for the output direction of the to-be opened
+    /// Stream or DirectionSpecificStreamParameters::null() for an input-only Stream.
+    /// @param sampleRate The to-be opened Stream's sample rate in Hz.
+    /// @param framesPerBuffer The number of frames per buffer for a CallbackStream, or
+    /// the preferred buffer granularity for a BlockingStream.
+    /// @param flags The flags for the to-be opened Stream; default paNoFlag.
+    //////
+    StreamParameters::StreamParameters(const DirectionSpecificStreamParameters &inputParameters,
+        const DirectionSpecificStreamParameters &outputParameters, double sampleRate, unsigned long framesPerBuffer,
+        PaStreamFlags flags) : inputParameters_(inputParameters), outputParameters_(outputParameters),
+        sampleRate_(sampleRate), framesPerBuffer_(framesPerBuffer), flags_(flags)
+    {
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	//////
-	/// Sets the requested sample rate. If this sample rate isn't supported by the hardware, the 
-	/// Stream will fail to open. The real-life sample rate used might differ slightly due to 
-	/// imperfections in the sound card hardware; use Stream::sampleRate() to retrieve the 
-	/// best known estimate for this value.
-	//////
-	void StreamParameters::setSampleRate(double sampleRate)
-	{
-		sampleRate_ = sampleRate;
-	}
+    //////
+    /// Sets the requested sample rate. If this sample rate isn't supported by the hardware, the
+    /// Stream will fail to open. The real-life sample rate used might differ slightly due to
+    /// imperfections in the sound card hardware; use Stream::sampleRate() to retrieve the
+    /// best known estimate for this value.
+    //////
+    void StreamParameters::setSampleRate(double sampleRate)
+    {
+        sampleRate_ = sampleRate;
+    }
 
-	//////
-	/// Either the number of frames per buffer for a CallbackStream, or 
-	/// the preferred buffer granularity for a BlockingStream. See PortAudio 
-	/// documentation.
-	//////
-	void StreamParameters::setFramesPerBuffer(unsigned long framesPerBuffer)
-	{
-		framesPerBuffer_ = framesPerBuffer;
-	}
+    //////
+    /// Either the number of frames per buffer for a CallbackStream, or
+    /// the preferred buffer granularity for a BlockingStream. See PortAudio
+    /// documentation.
+    //////
+    void StreamParameters::setFramesPerBuffer(unsigned long framesPerBuffer)
+    {
+        framesPerBuffer_ = framesPerBuffer;
+    }
 
-	//////
-	/// Sets the specified flag or does nothing when the flag is already set. Doesn't 
-	/// `unset' any previously existing flags (use clearFlags() for that).
-	//////
-	void StreamParameters::setFlag(PaStreamFlags flag)
-	{
-		flags_ |= flag;
-	}
+    //////
+    /// Sets the specified flag or does nothing when the flag is already set. Doesn't
+    /// `unset' any previously existing flags (use clearFlags() for that).
+    //////
+    void StreamParameters::setFlag(PaStreamFlags flag)
+    {
+        flags_ |= flag;
+    }
 
-	//////
-	/// Unsets the specified flag or does nothing if the flag isn't set. Doesn't affect 
-	/// any other flags.
-	//////
-	void StreamParameters::unsetFlag(PaStreamFlags flag)
-	{
-		flags_ &= ~flag;
-	}
+    //////
+    /// Unsets the specified flag or does nothing if the flag isn't set. Doesn't affect
+    /// any other flags.
+    //////
+    void StreamParameters::unsetFlag(PaStreamFlags flag)
+    {
+        flags_ &= ~flag;
+    }
 
-	//////
-	/// Clears or `unsets' all set flags.
-	//////
-	void StreamParameters::clearFlags()
-	{
-		flags_ = paNoFlag;
-	}
+    //////
+    /// Clears or `unsets' all set flags.
+    //////
+    void StreamParameters::clearFlags()
+    {
+        flags_ = paNoFlag;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	void StreamParameters::setInputParameters(const DirectionSpecificStreamParameters &parameters)
-	{
-		inputParameters_ = parameters;
-	}
+    void StreamParameters::setInputParameters(const DirectionSpecificStreamParameters &parameters)
+    {
+        inputParameters_ = parameters;
+    }
 
-	void StreamParameters::setOutputParameters(const DirectionSpecificStreamParameters &parameters)
-	{
-		outputParameters_ = parameters;
-	}
+    void StreamParameters::setOutputParameters(const DirectionSpecificStreamParameters &parameters)
+    {
+        outputParameters_ = parameters;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	bool StreamParameters::isSupported() const
-	{
-		return (Pa_IsFormatSupported(inputParameters_.paStreamParameters(), 
-			outputParameters_.paStreamParameters(), sampleRate_) == paFormatIsSupported);
-	}
+    bool StreamParameters::isSupported() const
+    {
+        return (Pa_IsFormatSupported(inputParameters_.paStreamParameters(),
+            outputParameters_.paStreamParameters(), sampleRate_) == paFormatIsSupported);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	double StreamParameters::sampleRate() const
-	{
-		return sampleRate_;
-	}
+    double StreamParameters::sampleRate() const
+    {
+        return sampleRate_;
+    }
 
-	unsigned long StreamParameters::framesPerBuffer() const
-	{
-		return framesPerBuffer_;
-	}
+    unsigned long StreamParameters::framesPerBuffer() const
+    {
+        return framesPerBuffer_;
+    }
 
-	//////
-	/// Returns all currently set flags as a binary combined 
-	/// integer value (PaStreamFlags). Use isFlagSet() to 
-	/// avoid dealing with the bitmasks.
-	//////
-	PaStreamFlags StreamParameters::flags() const
-	{
-		return flags_;
-	}
+    //////
+    /// Returns all currently set flags as a binary combined
+    /// integer value (PaStreamFlags). Use isFlagSet() to
+    /// avoid dealing with the bitmasks.
+    //////
+    PaStreamFlags StreamParameters::flags() const
+    {
+        return flags_;
+    }
 
-	//////
-	/// Returns true if the specified flag is currently set 
-	/// or false if it isn't.
-	//////
-	bool StreamParameters::isFlagSet(PaStreamFlags flag) const
-	{
-		return ((flags_ & flag) != 0);
-	}
+    //////
+    /// Returns true if the specified flag is currently set
+    /// or false if it isn't.
+    //////
+    bool StreamParameters::isFlagSet(PaStreamFlags flag) const
+    {
+        return ((flags_ & flag) != 0);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	DirectionSpecificStreamParameters &StreamParameters::inputParameters()
-	{
-		return inputParameters_;
-	}
+    DirectionSpecificStreamParameters &StreamParameters::inputParameters()
+    {
+        return inputParameters_;
+    }
 
-	const DirectionSpecificStreamParameters &StreamParameters::inputParameters() const
-	{
-		return inputParameters_;
-	}
+    const DirectionSpecificStreamParameters &StreamParameters::inputParameters() const
+    {
+        return inputParameters_;
+    }
 
-	DirectionSpecificStreamParameters &StreamParameters::outputParameters()
-	{
-		return outputParameters_;
-	}
+    DirectionSpecificStreamParameters &StreamParameters::outputParameters()
+    {
+        return outputParameters_;
+    }
 
-	const DirectionSpecificStreamParameters &StreamParameters::outputParameters() const
-	{
-		return outputParameters_;
-	}
+    const DirectionSpecificStreamParameters &StreamParameters::outputParameters() const
+    {
+        return outputParameters_;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 } // namespace portaudio
-
-
-
-
-

--- a/bindings/cpp/source/portaudiocpp/System.cxx
+++ b/bindings/cpp/source/portaudiocpp/System.cxx
@@ -12,297 +12,296 @@
 
 namespace portaudio
 {
-	// -----------------------------------------------------------------------------------
-
-	// Static members:
-	System *System::instance_ = NULL;
-	int System::initCount_ = 0;
-	HostApi **System::hostApis_ = NULL;
-	Device **System::devices_ = NULL;
-	Device *System::nullDevice_ = NULL;
-
-	// -----------------------------------------------------------------------------------
-
-	int System::version()
-	{
-		return Pa_GetVersion();
-	}
-
-	const char *System::versionText()
-	{
-		return Pa_GetVersionText();
-	}
-
-	void System::initialize()
-	{
-		++initCount_;
-
-		if (initCount_ == 1)
-		{
-			// Create singleton:
-			assert(instance_ == NULL);
-			instance_ = new System();
-
-			// Initialize the PortAudio system:
-			{
-				PaError err = Pa_Initialize();
-
-				if (err != paNoError)
-					throw PaException(err);
-			}
-
-			// Create and populate device array:
-			{
-				int numDevices = instance().deviceCount();
-
-				devices_ = new Device*[numDevices];
-
-				for (int i = 0; i < numDevices; ++i)
-					devices_[i] = new Device(i);
-			}
-
-			// Create and populate host api array:
-			{
-				int numHostApis = instance().hostApiCount();
-
-				hostApis_ = new HostApi*[numHostApis];
-
-				for (int i = 0; i < numHostApis; ++i)
-					hostApis_[i] = new HostApi(i);
-			}
-			
-			// Create null device:
-			nullDevice_ = new Device(paNoDevice);
-		}
-	}
-
-	void System::terminate()
-	{
-		PaError err = paNoError;
-
-		if (initCount_ == 1)
-		{
-			// Destroy null device:
-			delete nullDevice_;
-
-			// Destroy host api array:
-			{
-				if (hostApis_ != NULL)
-				{
-					int numHostApis = instance().hostApiCount();
-
-					for (int i = 0; i < numHostApis; ++i)
-						delete hostApis_[i];
-
-					delete[] hostApis_;
-					hostApis_ = NULL;
-				}
-			}
-
-			// Destroy device array:
-			{
-				if (devices_ != NULL)
-				{
-					int numDevices = instance().deviceCount();
-
-					for (int i = 0; i < numDevices; ++i)
-						delete devices_[i];
-
-					delete[] devices_;
-					devices_ = NULL;
-				}
-			}
+    // -----------------------------------------------------------------------------------
+
+    // Static members:
+    System *System::instance_ = NULL;
+    int System::initCount_ = 0;
+    HostApi **System::hostApis_ = NULL;
+    Device **System::devices_ = NULL;
+    Device *System::nullDevice_ = NULL;
+
+    // -----------------------------------------------------------------------------------
+
+    int System::version()
+    {
+        return Pa_GetVersion();
+    }
+
+    const char *System::versionText()
+    {
+        return Pa_GetVersionText();
+    }
+
+    void System::initialize()
+    {
+        ++initCount_;
+
+        if (initCount_ == 1)
+        {
+            // Create singleton:
+            assert(instance_ == NULL);
+            instance_ = new System();
+
+            // Initialize the PortAudio system:
+            {
+                PaError err = Pa_Initialize();
+
+                if (err != paNoError)
+                    throw PaException(err);
+            }
+
+            // Create and populate device array:
+            {
+                int numDevices = instance().deviceCount();
+
+                devices_ = new Device*[numDevices];
+
+                for (int i = 0; i < numDevices; ++i)
+                    devices_[i] = new Device(i);
+            }
+
+            // Create and populate host api array:
+            {
+                int numHostApis = instance().hostApiCount();
+
+                hostApis_ = new HostApi*[numHostApis];
+
+                for (int i = 0; i < numHostApis; ++i)
+                    hostApis_[i] = new HostApi(i);
+            }
+
+            // Create null device:
+            nullDevice_ = new Device(paNoDevice);
+        }
+    }
+
+    void System::terminate()
+    {
+        PaError err = paNoError;
+
+        if (initCount_ == 1)
+        {
+            // Destroy null device:
+            delete nullDevice_;
+
+            // Destroy host api array:
+            {
+                if (hostApis_ != NULL)
+                {
+                    int numHostApis = instance().hostApiCount();
+
+                    for (int i = 0; i < numHostApis; ++i)
+                        delete hostApis_[i];
+
+                    delete[] hostApis_;
+                    hostApis_ = NULL;
+                }
+            }
 
-			// Terminate the PortAudio system:
-			assert(instance_ != NULL);
-			err = Pa_Terminate();
+            // Destroy device array:
+            {
+                if (devices_ != NULL)
+                {
+                    int numDevices = instance().deviceCount();
 
-			// Destroy singleton:
-			delete instance_;
-			instance_ = NULL;
-		}
+                    for (int i = 0; i < numDevices; ++i)
+                        delete devices_[i];
 
-		if (initCount_ > 0)
-			--initCount_;
+                    delete[] devices_;
+                    devices_ = NULL;
+                }
+            }
 
-		if (err != paNoError)
-			throw PaException(err);
-	}
+            // Terminate the PortAudio system:
+            assert(instance_ != NULL);
+            err = Pa_Terminate();
 
+            // Destroy singleton:
+            delete instance_;
+            instance_ = NULL;
+        }
 
-	System &System::instance()
-	{
-		assert(exists());
+        if (initCount_ > 0)
+            --initCount_;
 
-		return *instance_;
-	}
+        if (err != paNoError)
+            throw PaException(err);
+    }
 
-	bool System::exists()
-	{
-		return (instance_ != NULL);
-	}
-
-	// -----------------------------------------------------------------------------------
-
-	System::HostApiIterator System::hostApisBegin()
-	{
-		System::HostApiIterator tmp;
-		tmp.ptr_ = &hostApis_[0]; // begin (first element)
-		return tmp;
-	}
-
-	System::HostApiIterator System::hostApisEnd()
-	{
-		int count = hostApiCount();
-
-		System::HostApiIterator tmp;
-		tmp.ptr_ = &hostApis_[count]; // end (one past last element)
-		return tmp;
-	}
-
-	HostApi &System::defaultHostApi()
-	{
-		PaHostApiIndex defaultHostApi = Pa_GetDefaultHostApi();
-
-		if (defaultHostApi < 0)
-			throw PaException(defaultHostApi);
-
-		return *hostApis_[defaultHostApi];
-	}
-
-	HostApi &System::hostApiByTypeId(PaHostApiTypeId type)
-	{
-		PaHostApiIndex index = Pa_HostApiTypeIdToHostApiIndex(type);
-
-		if (index < 0)
-			throw PaException(index);
-
-		return *hostApis_[index];
-	}
-
-	HostApi &System::hostApiByIndex(PaHostApiIndex index)
-	{
-		if (index < 0 || index >= hostApiCount())
-			throw PaException(paInternalError);
-
-		return *hostApis_[index];
-	}
-
-	int System::hostApiCount()
-	{
-		PaHostApiIndex count = Pa_GetHostApiCount();
-
-		if (count < 0)
-			throw PaException(count);
-
-		return count;
-	}
-
-	// -----------------------------------------------------------------------------------
-
-	System::DeviceIterator System::devicesBegin()
-	{
-		DeviceIterator tmp;
-		tmp.ptr_ = &devices_[0];
-
-		return tmp;
-	}
-
-	System::DeviceIterator System::devicesEnd()
-	{
-		int count = deviceCount();
-
-		DeviceIterator tmp;
-		tmp.ptr_ = &devices_[count];
-
-		return tmp;
-	}
-
-	//////
-	/// Returns the System's default input Device, or the null Device if none 
-	/// was available.
-	//////
-	Device &System::defaultInputDevice()
-	{
-		PaDeviceIndex index = Pa_GetDefaultInputDevice();
-		return deviceByIndex(index);
-	}
-
-	//////
-	/// Returns the System's default output Device, or the null Device if none 
-	/// was available.
-	//////
-	Device &System::defaultOutputDevice()
-	{
-		PaDeviceIndex index = Pa_GetDefaultOutputDevice();
-		return deviceByIndex(index);
-	}
-
-	//////
-	/// Returns the Device for the given index.
-	/// Will throw a paInternalError equivalent PaException if the given index 
-	/// is out of range.
-	//////
-	Device &System::deviceByIndex(PaDeviceIndex index)
-	{
-		if (index < -1 || index >= deviceCount())
-		{
-			throw PaException(paInternalError);
-		}
-
-		if (index == -1)
-			return System::instance().nullDevice();
-
-		return *devices_[index];
-	}
-
-	int System::deviceCount()
-	{
-		PaDeviceIndex count = Pa_GetDeviceCount();
-
-		if (count < 0)
-			throw PaException(count);
-
-		return count;
-	}
-
-	Device &System::nullDevice()
-	{
-		return *nullDevice_;
-	}
-
-	// -----------------------------------------------------------------------------------
-
-	void System::sleep(long msec)
-	{
-		Pa_Sleep(msec);
-	}
-
-	int System::sizeOfSample(PaSampleFormat format)
-	{
-		PaError err = Pa_GetSampleSize(format);
-		if (err < 0)
-		{
-			throw PaException(err);
-			return 0;
-		}
-
-		return err;
-	}
-
-	// -----------------------------------------------------------------------------------
-
-	System::System()
-	{
-		// (left blank intentionally)
-	}
-
-	System::~System()
-	{
-		// (left blank intentionally)
-	}
-
-	// -----------------------------------------------------------------------------------
+
+    System &System::instance()
+    {
+        assert(exists());
+
+        return *instance_;
+    }
+
+    bool System::exists()
+    {
+        return (instance_ != NULL);
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    System::HostApiIterator System::hostApisBegin()
+    {
+        System::HostApiIterator tmp;
+        tmp.ptr_ = &hostApis_[0]; // begin (first element)
+        return tmp;
+    }
+
+    System::HostApiIterator System::hostApisEnd()
+    {
+        int count = hostApiCount();
+
+        System::HostApiIterator tmp;
+        tmp.ptr_ = &hostApis_[count]; // end (one past last element)
+        return tmp;
+    }
+
+    HostApi &System::defaultHostApi()
+    {
+        PaHostApiIndex defaultHostApi = Pa_GetDefaultHostApi();
+
+        if (defaultHostApi < 0)
+            throw PaException(defaultHostApi);
+
+        return *hostApis_[defaultHostApi];
+    }
+
+    HostApi &System::hostApiByTypeId(PaHostApiTypeId type)
+    {
+        PaHostApiIndex index = Pa_HostApiTypeIdToHostApiIndex(type);
+
+        if (index < 0)
+            throw PaException(index);
+
+        return *hostApis_[index];
+    }
+
+    HostApi &System::hostApiByIndex(PaHostApiIndex index)
+    {
+        if (index < 0 || index >= hostApiCount())
+            throw PaException(paInternalError);
+
+        return *hostApis_[index];
+    }
+
+    int System::hostApiCount()
+    {
+        PaHostApiIndex count = Pa_GetHostApiCount();
+
+        if (count < 0)
+            throw PaException(count);
+
+        return count;
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    System::DeviceIterator System::devicesBegin()
+    {
+        DeviceIterator tmp;
+        tmp.ptr_ = &devices_[0];
+
+        return tmp;
+    }
+
+    System::DeviceIterator System::devicesEnd()
+    {
+        int count = deviceCount();
+
+        DeviceIterator tmp;
+        tmp.ptr_ = &devices_[count];
+
+        return tmp;
+    }
+
+    //////
+    /// Returns the System's default input Device, or the null Device if none
+    /// was available.
+    //////
+    Device &System::defaultInputDevice()
+    {
+        PaDeviceIndex index = Pa_GetDefaultInputDevice();
+        return deviceByIndex(index);
+    }
+
+    //////
+    /// Returns the System's default output Device, or the null Device if none
+    /// was available.
+    //////
+    Device &System::defaultOutputDevice()
+    {
+        PaDeviceIndex index = Pa_GetDefaultOutputDevice();
+        return deviceByIndex(index);
+    }
+
+    //////
+    /// Returns the Device for the given index.
+    /// Will throw a paInternalError equivalent PaException if the given index
+    /// is out of range.
+    //////
+    Device &System::deviceByIndex(PaDeviceIndex index)
+    {
+        if (index < -1 || index >= deviceCount())
+        {
+            throw PaException(paInternalError);
+        }
+
+        if (index == -1)
+            return System::instance().nullDevice();
+
+        return *devices_[index];
+    }
+
+    int System::deviceCount()
+    {
+        PaDeviceIndex count = Pa_GetDeviceCount();
+
+        if (count < 0)
+            throw PaException(count);
+
+        return count;
+    }
+
+    Device &System::nullDevice()
+    {
+        return *nullDevice_;
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    void System::sleep(long msec)
+    {
+        Pa_Sleep(msec);
+    }
+
+    int System::sizeOfSample(PaSampleFormat format)
+    {
+        PaError err = Pa_GetSampleSize(format);
+        if (err < 0)
+        {
+            throw PaException(err);
+            return 0;
+        }
+
+        return err;
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    System::System()
+    {
+        // (left blank intentionally)
+    }
+
+    System::~System()
+    {
+        // (left blank intentionally)
+    }
+
+    // -----------------------------------------------------------------------------------
 
 } // namespace portaudio
-

--- a/bindings/cpp/source/portaudiocpp/SystemDeviceIterator.cxx
+++ b/bindings/cpp/source/portaudiocpp/SystemDeviceIterator.cxx
@@ -2,59 +2,57 @@
 
 namespace portaudio
 {
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	Device &System::DeviceIterator::operator*() const
-	{
-		return **ptr_;
-	}
+    Device &System::DeviceIterator::operator*() const
+    {
+        return **ptr_;
+    }
 
-	Device *System::DeviceIterator::operator->() const
-	{
-		return &**this;
-	}
+    Device *System::DeviceIterator::operator->() const
+    {
+        return &**this;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	System::DeviceIterator &System::DeviceIterator::operator++()
-	{
-		++ptr_;
-		return *this;
-	}
+    System::DeviceIterator &System::DeviceIterator::operator++()
+    {
+        ++ptr_;
+        return *this;
+    }
 
-	System::DeviceIterator System::DeviceIterator::operator++(int)
-	{
-		System::DeviceIterator prev = *this;
-		++*this;
-		return prev;
-	}
+    System::DeviceIterator System::DeviceIterator::operator++(int)
+    {
+        System::DeviceIterator prev = *this;
+        ++*this;
+        return prev;
+    }
 
-	System::DeviceIterator &System::DeviceIterator::operator--()
-	{
-		--ptr_;
-		return *this;
-	}
+    System::DeviceIterator &System::DeviceIterator::operator--()
+    {
+        --ptr_;
+        return *this;
+    }
 
-	System::DeviceIterator System::DeviceIterator::operator--(int)
-	{
-		System::DeviceIterator prev = *this;
-		--*this;
-		return prev;
-	}
+    System::DeviceIterator System::DeviceIterator::operator--(int)
+    {
+        System::DeviceIterator prev = *this;
+        --*this;
+        return prev;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	bool System::DeviceIterator::operator==(const System::DeviceIterator &rhs) const
-	{
-		return (ptr_ == rhs.ptr_);
-	}
+    bool System::DeviceIterator::operator==(const System::DeviceIterator &rhs) const
+    {
+        return (ptr_ == rhs.ptr_);
+    }
 
-	bool System::DeviceIterator::operator!=(const System::DeviceIterator &rhs) const
-	{
-		return !(*this == rhs);
-	}
+    bool System::DeviceIterator::operator!=(const System::DeviceIterator &rhs) const
+    {
+        return !(*this == rhs);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 } // namespace portaudio
-
-

--- a/bindings/cpp/source/portaudiocpp/SystemHostApiIterator.cxx
+++ b/bindings/cpp/source/portaudiocpp/SystemHostApiIterator.cxx
@@ -2,58 +2,57 @@
 
 namespace portaudio
 {
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	HostApi &System::HostApiIterator::operator*() const
-	{
-		return **ptr_;
-	}
+    HostApi &System::HostApiIterator::operator*() const
+    {
+        return **ptr_;
+    }
 
-	HostApi *System::HostApiIterator::operator->() const
-	{
-		return &**this;
-	}
+    HostApi *System::HostApiIterator::operator->() const
+    {
+        return &**this;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	System::HostApiIterator &System::HostApiIterator::operator++()
-	{
-		++ptr_;
-		return *this;
-	}
+    System::HostApiIterator &System::HostApiIterator::operator++()
+    {
+        ++ptr_;
+        return *this;
+    }
 
-	System::HostApiIterator System::HostApiIterator::operator++(int)
-	{
-		System::HostApiIterator prev = *this;
-		++*this;
-		return prev;
-	}
+    System::HostApiIterator System::HostApiIterator::operator++(int)
+    {
+        System::HostApiIterator prev = *this;
+        ++*this;
+        return prev;
+    }
 
-	System::HostApiIterator &System::HostApiIterator::operator--()
-	{
-		--ptr_;
-		return *this;
-	}
+    System::HostApiIterator &System::HostApiIterator::operator--()
+    {
+        --ptr_;
+        return *this;
+    }
 
-	System::HostApiIterator System::HostApiIterator::operator--(int)
-	{
-		System::HostApiIterator prev = *this;
-		--*this;
-		return prev;
-	}
+    System::HostApiIterator System::HostApiIterator::operator--(int)
+    {
+        System::HostApiIterator prev = *this;
+        --*this;
+        return prev;
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 
-	bool System::HostApiIterator::operator==(const System::HostApiIterator &rhs) const
-	{
-		return (ptr_ == rhs.ptr_);
-	}
+    bool System::HostApiIterator::operator==(const System::HostApiIterator &rhs) const
+    {
+        return (ptr_ == rhs.ptr_);
+    }
 
-	bool System::HostApiIterator::operator!=(const System::HostApiIterator &rhs) const
-	{
-		return !(*this == rhs);
-	}
+    bool System::HostApiIterator::operator!=(const System::HostApiIterator &rhs) const
+    {
+        return !(*this == rhs);
+    }
 
-	// -----------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------
 } // namespace portaudio
-

--- a/bindings/java/c/src/com_portaudio_BlockingStream.c
+++ b/bindings/java/c/src/com_portaudio_BlockingStream.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -55,9 +55,9 @@
 JNIEXPORT jint JNICALL Java_com_portaudio_BlockingStream_getReadAvailable
   (JNIEnv *env, jobject blockingStream)
 {
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( stream == NULL ) return 0;
-	return Pa_GetStreamReadAvailable( stream );
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( stream == NULL ) return 0;
+    return Pa_GetStreamReadAvailable( stream );
 }
 
 /*
@@ -68,9 +68,9 @@ JNIEXPORT jint JNICALL Java_com_portaudio_BlockingStream_getReadAvailable
 JNIEXPORT jint JNICALL Java_com_portaudio_BlockingStream_getWriteAvailable
   (JNIEnv *env, jobject blockingStream)
 {
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( stream == NULL ) return 0;
-	return Pa_GetStreamWriteAvailable( stream );
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( stream == NULL ) return 0;
+    return Pa_GetStreamWriteAvailable( stream );
 }
 
 
@@ -82,33 +82,33 @@ JNIEXPORT jint JNICALL Java_com_portaudio_BlockingStream_getWriteAvailable
 JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_writeFloats
   (JNIEnv *env, jobject blockingStream, jfloatArray buffer, jint numFrames)
 {
-	jfloat *carr;
-	jint err;
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( buffer == NULL )
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+    jfloat *carr;
+    jint err;
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( buffer == NULL )
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "null stream buffer");
-		return FALSE;
-	}
-	carr = (*env)->GetFloatArrayElements(env, buffer, NULL);
-	if (carr == NULL)
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+        return FALSE;
+    }
+    carr = (*env)->GetFloatArrayElements(env, buffer, NULL);
+    if (carr == NULL)
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "invalid stream buffer");
-		return FALSE;
-	}
-	err = Pa_WriteStream( stream, carr, numFrames );
-	(*env)->ReleaseFloatArrayElements(env, buffer, carr, 0);
-	if( err == paOutputUnderflowed )
-	{
-		return TRUE;
-	}
-	else
-	{
-		jpa_CheckError( env, err );
-		return FALSE;
-	}
+        return FALSE;
+    }
+    err = Pa_WriteStream( stream, carr, numFrames );
+    (*env)->ReleaseFloatArrayElements(env, buffer, carr, 0);
+    if( err == paOutputUnderflowed )
+    {
+        return TRUE;
+    }
+    else
+    {
+        jpa_CheckError( env, err );
+        return FALSE;
+    }
 }
 
 /*
@@ -119,33 +119,33 @@ JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_writeFloats
 JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_readFloats
   (JNIEnv *env, jobject blockingStream, jfloatArray buffer, jint numFrames)
 {
-	jfloat *carr;
-	jint err;
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( buffer == NULL )
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+    jfloat *carr;
+    jint err;
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( buffer == NULL )
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "null stream buffer");
-		return FALSE;
-	}
-	carr = (*env)->GetFloatArrayElements(env, buffer, NULL);
-	if (carr == NULL)
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+        return FALSE;
+    }
+    carr = (*env)->GetFloatArrayElements(env, buffer, NULL);
+    if (carr == NULL)
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "invalid stream buffer");
-		return FALSE;
-	}
-	err = Pa_ReadStream( stream, carr, numFrames );
-	(*env)->ReleaseFloatArrayElements(env, buffer, carr, 0);
-	if( err == paInputOverflowed )
-	{
-		return TRUE;
-	}
-	else
-	{
-		jpa_CheckError( env, err );
-		return FALSE;
-	}
+        return FALSE;
+    }
+    err = Pa_ReadStream( stream, carr, numFrames );
+    (*env)->ReleaseFloatArrayElements(env, buffer, carr, 0);
+    if( err == paInputOverflowed )
+    {
+        return TRUE;
+    }
+    else
+    {
+        jpa_CheckError( env, err );
+        return FALSE;
+    }
 }
 
 /*
@@ -156,33 +156,33 @@ JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_readFloats
 JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_writeShorts
   (JNIEnv *env, jobject blockingStream, jfloatArray buffer, jint numFrames)
 {
-	jshort *carr;
-	jint err;
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( buffer == NULL )
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+    jshort *carr;
+    jint err;
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( buffer == NULL )
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "null stream buffer");
-		return FALSE;
-	}
-	carr = (*env)->GetShortArrayElements(env, buffer, NULL);
-	if (carr == NULL)
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+        return FALSE;
+    }
+    carr = (*env)->GetShortArrayElements(env, buffer, NULL);
+    if (carr == NULL)
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "invalid stream buffer");
-		return FALSE;
-	}
-	err = Pa_WriteStream( stream, carr, numFrames );
-	(*env)->ReleaseShortArrayElements(env, buffer, carr, 0);
-	if( err == paOutputUnderflowed )
-	{
-		return TRUE;
-	}
-	else
-	{
-		jpa_CheckError( env, err );
-		return FALSE;
-	}
+        return FALSE;
+    }
+    err = Pa_WriteStream( stream, carr, numFrames );
+    (*env)->ReleaseShortArrayElements(env, buffer, carr, 0);
+    if( err == paOutputUnderflowed )
+    {
+        return TRUE;
+    }
+    else
+    {
+        jpa_CheckError( env, err );
+        return FALSE;
+    }
 }
 
 /*
@@ -193,33 +193,33 @@ JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_writeShorts
 JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_readShorts
   (JNIEnv *env, jobject blockingStream, jfloatArray buffer, jint numFrames)
 {
-	jshort *carr;
-	jint err;
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( buffer == NULL )
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+    jshort *carr;
+    jint err;
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( buffer == NULL )
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "null stream buffer");
-		return FALSE;
-	}
-	carr = (*env)->GetShortArrayElements(env, buffer, NULL);
-	if (carr == NULL)
-	{
-		(*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
+        return FALSE;
+    }
+    carr = (*env)->GetShortArrayElements(env, buffer, NULL);
+    if (carr == NULL)
+    {
+        (*env)->ThrowNew( env, (*env)->FindClass(env,"java/lang/RuntimeException"),
                   "invalid stream buffer");
-		return FALSE;
-	}
-	err = Pa_ReadStream( stream, carr, numFrames );
-	(*env)->ReleaseShortArrayElements(env, buffer, carr, 0);
-	if( err == paInputOverflowed )
-	{
-		return TRUE;
-	}
-	else
-	{
-		jpa_CheckError( env, err );
-		return FALSE;
-	}
+        return FALSE;
+    }
+    err = Pa_ReadStream( stream, carr, numFrames );
+    (*env)->ReleaseShortArrayElements(env, buffer, carr, 0);
+    if( err == paInputOverflowed )
+    {
+        return TRUE;
+    }
+    else
+    {
+        jpa_CheckError( env, err );
+        return FALSE;
+    }
 }
 
 /*
@@ -230,9 +230,9 @@ JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_readShorts
 JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_start
   (JNIEnv *env, jobject blockingStream )
 {
-	PaStream *stream = jpa_GetStreamPointer( env, blockingStream );
-	int err = Pa_StartStream( stream );
-	jpa_CheckError( env, err );
+    PaStream *stream = jpa_GetStreamPointer( env, blockingStream );
+    int err = Pa_StartStream( stream );
+    jpa_CheckError( env, err );
 }
 
 /*
@@ -243,9 +243,9 @@ JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_start
 JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_stop
   (JNIEnv *env, jobject blockingStream )
 {
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	int err = Pa_StopStream( stream );
-	jpa_CheckError( env, err );
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    int err = Pa_StopStream( stream );
+    jpa_CheckError( env, err );
 }
 /*
  * Class:     com_portaudio_BlockingStream
@@ -255,9 +255,9 @@ JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_stop
 JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_abort
   (JNIEnv *env, jobject blockingStream )
 {
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	int err = Pa_AbortStream( stream );
-	jpa_CheckError( env, err );
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    int err = Pa_AbortStream( stream );
+    jpa_CheckError( env, err );
 }
 
 /*
@@ -268,15 +268,15 @@ JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_abort
 JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_close
   (JNIEnv *env, jobject blockingStream )
 {
-	jclass cls;
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( stream != NULL )
-	{
-		int err = Pa_CloseStream( stream );
-		jpa_CheckError( env, err );
-		cls = (*env)->GetObjectClass(env, blockingStream);
-		jpa_SetLongField( env, cls, blockingStream, "nativeStream", (jlong) 0 );
-	}
+    jclass cls;
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( stream != NULL )
+    {
+        int err = Pa_CloseStream( stream );
+        jpa_CheckError( env, err );
+        cls = (*env)->GetObjectClass(env, blockingStream);
+        jpa_SetLongField( env, cls, blockingStream, "nativeStream", (jlong) 0 );
+    }
 }
 
 /*
@@ -287,11 +287,11 @@ JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_close
 JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_isStopped
   (JNIEnv *env, jobject blockingStream )
 {
-	int err;
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( stream == NULL ) return 1;
-	err = Pa_IsStreamStopped( stream );
-	return (jpa_CheckError( env, err ) > 0);
+    int err;
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( stream == NULL ) return 1;
+    err = Pa_IsStreamStopped( stream );
+    return (jpa_CheckError( env, err ) > 0);
 }
 /*
  * Class:     com_portaudio_BlockingStream
@@ -301,11 +301,11 @@ JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_isStopped
 JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_isActive
   (JNIEnv *env, jobject blockingStream )
 {
-	int err;
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( stream == NULL ) return 0;
-	err = Pa_IsStreamActive( stream );
-	return (jpa_CheckError( env, err ) > 0);
+    int err;
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( stream == NULL ) return 0;
+    err = Pa_IsStreamActive( stream );
+    return (jpa_CheckError( env, err ) > 0);
 }
 
 
@@ -317,9 +317,9 @@ JNIEXPORT jboolean JNICALL Java_com_portaudio_BlockingStream_isActive
 JNIEXPORT jdouble JNICALL Java_com_portaudio_BlockingStream_getTime
   (JNIEnv *env, jobject blockingStream )
 {
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	if( stream == NULL ) return 0.0;
-	return Pa_GetStreamTime( stream );
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    if( stream == NULL ) return 0.0;
+    return Pa_GetStreamTime( stream );
 }
 
 
@@ -331,22 +331,21 @@ JNIEXPORT jdouble JNICALL Java_com_portaudio_BlockingStream_getTime
 JNIEXPORT void JNICALL Java_com_portaudio_BlockingStream_getInfo
   (JNIEnv *env, jobject blockingStream, jobject streamInfo)
 {
-	
-	PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
-	const PaStreamInfo *info = Pa_GetStreamInfo( stream );
-	if( streamInfo == NULL )
-	{
-		jpa_ThrowError( env, "Invalid stream." );
-	}
-	else
-	{
-		/* Get a reference to obj's class */
-		jclass cls = (*env)->GetObjectClass(env, streamInfo);
- 
-		jpa_SetIntField( env, cls, streamInfo, "structVersion", info->structVersion );
-		jpa_SetDoubleField( env, cls, streamInfo, "inputLatency", info->inputLatency );
-		jpa_SetDoubleField( env, cls, streamInfo, "outputLatency", info->outputLatency );
-		jpa_SetDoubleField( env, cls, streamInfo, "sampleRate", info->sampleRate );
-	}
-}
 
+    PaStream *stream =jpa_GetStreamPointer( env, blockingStream );
+    const PaStreamInfo *info = Pa_GetStreamInfo( stream );
+    if( streamInfo == NULL )
+    {
+        jpa_ThrowError( env, "Invalid stream." );
+    }
+    else
+    {
+        /* Get a reference to obj's class */
+        jclass cls = (*env)->GetObjectClass(env, streamInfo);
+
+        jpa_SetIntField( env, cls, streamInfo, "structVersion", info->structVersion );
+        jpa_SetDoubleField( env, cls, streamInfo, "inputLatency", info->inputLatency );
+        jpa_SetDoubleField( env, cls, streamInfo, "outputLatency", info->outputLatency );
+        jpa_SetDoubleField( env, cls, streamInfo, "sampleRate", info->sampleRate );
+    }
+}

--- a/bindings/java/c/src/com_portaudio_PortAudio.c
+++ b/bindings/java/c/src/com_portaudio_PortAudio.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -48,7 +48,7 @@
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getVersion
   (JNIEnv *env, jclass clazz)
 {
-	return Pa_GetVersion();
+    return Pa_GetVersion();
 }
 
 /*
@@ -59,7 +59,7 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getVersion
 JNIEXPORT jstring JNICALL Java_com_portaudio_PortAudio_getVersionText
   (JNIEnv *env, jclass clazz)
 {
-	return (*env)->NewStringUTF(env, Pa_GetVersionText() );
+    return (*env)->NewStringUTF(env, Pa_GetVersionText() );
 }
 
 /*
@@ -70,8 +70,8 @@ JNIEXPORT jstring JNICALL Java_com_portaudio_PortAudio_getVersionText
 JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_initialize
   (JNIEnv *env, jclass clazz)
 {
-	PaError err = Pa_Initialize();
-	jpa_CheckError( env, err );
+    PaError err = Pa_Initialize();
+    jpa_CheckError( env, err );
 }
 
 /*
@@ -82,8 +82,8 @@ JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_initialize
 JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_terminate
   (JNIEnv *env, jclass clazz)
 {
-	PaError err = Pa_Terminate();
-	jpa_CheckError( env, err );
+    PaError err = Pa_Terminate();
+    jpa_CheckError( env, err );
 }
 
 /*
@@ -94,8 +94,8 @@ JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_terminate
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDeviceCount
   (JNIEnv *env, jclass clazz)
 {
-	jint count = Pa_GetDeviceCount();
-	return jpa_CheckError( env, count );
+    jint count = Pa_GetDeviceCount();
+    return jpa_CheckError( env, count );
 }
 
 /*
@@ -106,27 +106,27 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDeviceCount
 JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_getDeviceInfo
   (JNIEnv *env, jclass clazz, jint index, jobject deviceInfo)
 {
-	const PaDeviceInfo *info;
-	     /* Get a reference to obj's class */
-	jclass cls = (*env)->GetObjectClass(env, deviceInfo);
- 
-	info = Pa_GetDeviceInfo( index );
-	if( info == NULL )
-	{
-		jpa_ThrowError( env, "Pa_GetDeviceInfo returned NULL." );
-	}
-	else
-	{
-		jpa_SetStringField( env, cls, deviceInfo, "name", info->name );
-		jpa_SetIntField( env, cls, deviceInfo, "maxInputChannels", info->maxInputChannels );
-		jpa_SetIntField( env, cls, deviceInfo, "maxOutputChannels", info->maxOutputChannels );
-		jpa_SetIntField( env, cls, deviceInfo, "hostApi", info->hostApi );
-		jpa_SetDoubleField( env, cls, deviceInfo, "defaultSampleRate", info->defaultSampleRate );
-		jpa_SetDoubleField( env, cls, deviceInfo, "defaultLowInputLatency", info->defaultLowInputLatency );
-		jpa_SetDoubleField( env, cls, deviceInfo, "defaultLowInputLatency", info->defaultHighInputLatency );
-		jpa_SetDoubleField( env, cls, deviceInfo, "defaultLowOutputLatency", info->defaultLowOutputLatency );
-		jpa_SetDoubleField( env, cls, deviceInfo, "defaultHighOutputLatency", info->defaultHighOutputLatency );
-	}
+    const PaDeviceInfo *info;
+         /* Get a reference to obj's class */
+    jclass cls = (*env)->GetObjectClass(env, deviceInfo);
+
+    info = Pa_GetDeviceInfo( index );
+    if( info == NULL )
+    {
+        jpa_ThrowError( env, "Pa_GetDeviceInfo returned NULL." );
+    }
+    else
+    {
+        jpa_SetStringField( env, cls, deviceInfo, "name", info->name );
+        jpa_SetIntField( env, cls, deviceInfo, "maxInputChannels", info->maxInputChannels );
+        jpa_SetIntField( env, cls, deviceInfo, "maxOutputChannels", info->maxOutputChannels );
+        jpa_SetIntField( env, cls, deviceInfo, "hostApi", info->hostApi );
+        jpa_SetDoubleField( env, cls, deviceInfo, "defaultSampleRate", info->defaultSampleRate );
+        jpa_SetDoubleField( env, cls, deviceInfo, "defaultLowInputLatency", info->defaultLowInputLatency );
+        jpa_SetDoubleField( env, cls, deviceInfo, "defaultLowInputLatency", info->defaultHighInputLatency );
+        jpa_SetDoubleField( env, cls, deviceInfo, "defaultLowOutputLatency", info->defaultLowOutputLatency );
+        jpa_SetDoubleField( env, cls, deviceInfo, "defaultHighOutputLatency", info->defaultHighOutputLatency );
+    }
 }
 
 /*
@@ -137,8 +137,8 @@ JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_getDeviceInfo
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getHostApiCount
   (JNIEnv *env, jclass clazz)
 {
-	jint count = Pa_GetHostApiCount();
-	return jpa_CheckError( env, count );
+    jint count = Pa_GetHostApiCount();
+    return jpa_CheckError( env, count );
 }
 
 
@@ -150,7 +150,7 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getHostApiCount
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_hostApiTypeIdToHostApiIndex
   (JNIEnv *env, jclass clazz, jint hostApiType)
 {
-	return Pa_HostApiTypeIdToHostApiIndex( (PaHostApiTypeId) hostApiType );
+    return Pa_HostApiTypeIdToHostApiIndex( (PaHostApiTypeId) hostApiType );
 }
 
 /*
@@ -161,7 +161,7 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_hostApiTypeIdToHostApiIndex
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_hostApiDeviceIndexToDeviceIndex
   (JNIEnv *env, jclass clazz, jint hostApiIndex, jint apiDeviceIndex)
 {
-	return Pa_HostApiDeviceIndexToDeviceIndex( hostApiIndex, apiDeviceIndex );
+    return Pa_HostApiDeviceIndexToDeviceIndex( hostApiIndex, apiDeviceIndex );
 }
 
 
@@ -173,24 +173,24 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_hostApiDeviceIndexToDeviceIn
 JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_getHostApiInfo
   (JNIEnv *env, jclass clazz, jint index, jobject hostApiInfo)
 {
-	const PaHostApiInfo *info;
-	     /* Get a reference to obj's class */
-	jclass cls = (*env)->GetObjectClass(env, hostApiInfo);
- 
-	info = Pa_GetHostApiInfo( index );
-	if( info == NULL )
-	{
-		jpa_ThrowError( env, "Pa_GetHostApiInfo returned NULL." );
-	}
-	else
-	{
-		jpa_SetIntField( env, cls, hostApiInfo, "version", info->structVersion );
-		jpa_SetIntField( env, cls, hostApiInfo, "type", info->type );
-		jpa_SetStringField( env, cls, hostApiInfo, "name", info->name );
-		jpa_SetIntField( env, cls, hostApiInfo, "deviceCount", info->deviceCount );
-		jpa_SetIntField( env, cls, hostApiInfo, "defaultInputDevice", info->defaultInputDevice );
-		jpa_SetIntField( env, cls, hostApiInfo, "defaultOutputDevice", info->defaultOutputDevice );
-	}
+    const PaHostApiInfo *info;
+         /* Get a reference to obj's class */
+    jclass cls = (*env)->GetObjectClass(env, hostApiInfo);
+
+    info = Pa_GetHostApiInfo( index );
+    if( info == NULL )
+    {
+        jpa_ThrowError( env, "Pa_GetHostApiInfo returned NULL." );
+    }
+    else
+    {
+        jpa_SetIntField( env, cls, hostApiInfo, "version", info->structVersion );
+        jpa_SetIntField( env, cls, hostApiInfo, "type", info->type );
+        jpa_SetStringField( env, cls, hostApiInfo, "name", info->name );
+        jpa_SetIntField( env, cls, hostApiInfo, "deviceCount", info->deviceCount );
+        jpa_SetIntField( env, cls, hostApiInfo, "defaultInputDevice", info->defaultInputDevice );
+        jpa_SetIntField( env, cls, hostApiInfo, "defaultOutputDevice", info->defaultOutputDevice );
+    }
 }
 
 /*
@@ -201,8 +201,8 @@ JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_getHostApiInfo
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDefaultInputDevice
   (JNIEnv *env, jclass clazz)
 {
-	jint deviceId = Pa_GetDefaultInputDevice();
-	return jpa_CheckError( env, deviceId );
+    jint deviceId = Pa_GetDefaultInputDevice();
+    return jpa_CheckError( env, deviceId );
 }
 
 /*
@@ -213,8 +213,8 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDefaultInputDevice
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDefaultOutputDevice
   (JNIEnv *env, jclass clazz)
 {
-	jint deviceId = Pa_GetDefaultOutputDevice();
-	return jpa_CheckError( env, deviceId );
+    jint deviceId = Pa_GetDefaultOutputDevice();
+    return jpa_CheckError( env, deviceId );
 }
 
 /*
@@ -225,8 +225,8 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDefaultOutputDevice
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDefaultHostApi
   (JNIEnv *env, jclass clazz)
 {
-	jint deviceId = Pa_GetDefaultHostApi();
-	return jpa_CheckError( env, deviceId );
+    jint deviceId = Pa_GetDefaultHostApi();
+    return jpa_CheckError( env, deviceId );
 }
 
 /*
@@ -237,13 +237,13 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_getDefaultHostApi
 JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_isFormatSupported
   (JNIEnv *env, jclass clazz, jobject inParams, jobject outParams, jint sampleRate )
 {
-	PaStreamParameters myInParams, *paInParams;
-	PaStreamParameters myOutParams, *paOutParams;
-	
-	paInParams = jpa_FillStreamParameters(  env, inParams, &myInParams );
-	paOutParams = jpa_FillStreamParameters(  env, outParams, &myOutParams );
-	
-	return Pa_IsFormatSupported( paInParams, paOutParams, sampleRate );
+    PaStreamParameters myInParams, *paInParams;
+    PaStreamParameters myOutParams, *paOutParams;
+
+    paInParams = jpa_FillStreamParameters(  env, inParams, &myInParams );
+    paOutParams = jpa_FillStreamParameters(  env, outParams, &myOutParams );
+
+    return Pa_IsFormatSupported( paInParams, paOutParams, sampleRate );
 
 }
 
@@ -255,25 +255,25 @@ JNIEXPORT jint JNICALL Java_com_portaudio_PortAudio_isFormatSupported
 JNIEXPORT void JNICALL Java_com_portaudio_PortAudio_openStream
   (JNIEnv *env, jclass clazz, jobject blockingStream,  jobject inParams, jobject outParams, jint sampleRate, jint framesPerBuffer, jint flags )
 {
-	int err;
-	PaStreamParameters myInParams, *paInParams;
-	PaStreamParameters myOutParams, *paOutParams;
-	PaStream *stream;
-	
-	paInParams = jpa_FillStreamParameters(  env, inParams, &myInParams );
-	paOutParams = jpa_FillStreamParameters(  env, outParams, &myOutParams );
-	err = Pa_OpenStream( &stream, paInParams, paOutParams, sampleRate, framesPerBuffer, flags, NULL, NULL );
-	if( jpa_CheckError( env, err ) == 0 )
-	{
-		jclass cls = (*env)->GetObjectClass(env, blockingStream);
-		jpa_SetLongField( env, cls, blockingStream, "nativeStream", (jlong) stream );
-		if( paInParams != NULL )
-		{
-			jpa_SetIntField( env, cls, blockingStream, "inputFormat", paInParams->sampleFormat );
-		}
-		if( paOutParams != NULL )
-		{
-			jpa_SetIntField( env, cls, blockingStream, "outputFormat", paOutParams->sampleFormat );
-		}
-	}
+    int err;
+    PaStreamParameters myInParams, *paInParams;
+    PaStreamParameters myOutParams, *paOutParams;
+    PaStream *stream;
+
+    paInParams = jpa_FillStreamParameters(  env, inParams, &myInParams );
+    paOutParams = jpa_FillStreamParameters(  env, outParams, &myOutParams );
+    err = Pa_OpenStream( &stream, paInParams, paOutParams, sampleRate, framesPerBuffer, flags, NULL, NULL );
+    if( jpa_CheckError( env, err ) == 0 )
+    {
+        jclass cls = (*env)->GetObjectClass(env, blockingStream);
+        jpa_SetLongField( env, cls, blockingStream, "nativeStream", (jlong) stream );
+        if( paInParams != NULL )
+        {
+            jpa_SetIntField( env, cls, blockingStream, "inputFormat", paInParams->sampleFormat );
+        }
+        if( paOutParams != NULL )
+        {
+            jpa_SetIntField( env, cls, blockingStream, "outputFormat", paOutParams->sampleFormat );
+        }
+    }
 }

--- a/bindings/java/c/src/jpa_tools.c
+++ b/bindings/java/c/src/jpa_tools.c
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -45,14 +45,14 @@ jint jpa_GetIntField( JNIEnv *env, jclass cls, jobject obj, const char *fieldNam
      /* Look for the instance field maxInputChannels in cls */
      jfieldID fid = (*env)->GetFieldID(env, cls, fieldName, "I");
      if (fid == NULL)
-	 {
-		 jpa_ThrowError( env, "Cannot find integer JNI field." );
-		return 0;
+     {
+         jpa_ThrowError( env, "Cannot find integer JNI field." );
+        return 0;
      }
-	 else
-	 {
-		return (*env)->GetIntField(env, obj, fid );
-	 }
+     else
+     {
+        return (*env)->GetIntField(env, obj, fid );
+     }
 }
 
 void jpa_SetIntField( JNIEnv *env, jclass cls, jobject obj, const char *fieldName, jint value )
@@ -60,13 +60,13 @@ void jpa_SetIntField( JNIEnv *env, jclass cls, jobject obj, const char *fieldNam
      /* Look for the instance field maxInputChannels in cls */
      jfieldID fid = (*env)->GetFieldID(env, cls, fieldName, "I");
      if (fid == NULL)
-	 {
-		 jpa_ThrowError( env, "Cannot find integer JNI field." );
+     {
+         jpa_ThrowError( env, "Cannot find integer JNI field." );
      }
-	 else
-	 {
-		(*env)->SetIntField(env, obj, fid, value );
-	 }
+     else
+     {
+        (*env)->SetIntField(env, obj, fid, value );
+     }
 }
 
 jlong jpa_GetLongField( JNIEnv *env, jclass cls, jobject obj, const char *fieldName )
@@ -74,14 +74,14 @@ jlong jpa_GetLongField( JNIEnv *env, jclass cls, jobject obj, const char *fieldN
      /* Look for the instance field maxInputChannels in cls */
      jfieldID fid = (*env)->GetFieldID(env, cls, fieldName, "J");
      if (fid == NULL)
-	 {
-		 jpa_ThrowError( env, "Cannot find long JNI field." );
-		return 0L;
+     {
+         jpa_ThrowError( env, "Cannot find long JNI field." );
+        return 0L;
      }
-	 else
-	 {
-		return (*env)->GetLongField(env, obj, fid );
-	 }
+     else
+     {
+        return (*env)->GetLongField(env, obj, fid );
+     }
 }
 
 void jpa_SetLongField( JNIEnv *env, jclass cls, jobject obj, const char *fieldName, jlong value )
@@ -89,13 +89,13 @@ void jpa_SetLongField( JNIEnv *env, jclass cls, jobject obj, const char *fieldNa
      /* Look for the instance field maxInputChannels in cls */
      jfieldID fid = (*env)->GetFieldID(env, cls, fieldName, "J");
      if (fid == NULL)
-	 {
-		 jpa_ThrowError( env, "Cannot find long JNI field." );
+     {
+         jpa_ThrowError( env, "Cannot find long JNI field." );
      }
-	 else
-	 {
-		(*env)->SetLongField(env, obj, fid, value );
-	 }
+     else
+     {
+        (*env)->SetLongField(env, obj, fid, value );
+     }
 }
 
 
@@ -104,13 +104,13 @@ void jpa_SetDoubleField( JNIEnv *env, jclass cls, jobject obj, const char *field
      /* Look for the instance field maxInputChannels in cls */
      jfieldID fid = (*env)->GetFieldID(env, cls, fieldName, "D");
      if (fid == NULL)
-	 {
-		 jpa_ThrowError( env, "Cannot find double JNI field." );
+     {
+         jpa_ThrowError( env, "Cannot find double JNI field." );
      }
-	 else
-	 {
-		(*env)->SetDoubleField(env, obj, fid, value );
-	 }
+     else
+     {
+        (*env)->SetDoubleField(env, obj, fid, value );
+     }
 }
 
 
@@ -119,14 +119,14 @@ jdouble jpa_GetDoubleField( JNIEnv *env, jclass cls, jobject obj, const char *fi
      /* Look for the instance field maxInputChannels in cls */
      jfieldID fid = (*env)->GetFieldID(env, cls, fieldName, "D");
      if (fid == NULL)
-	 {
-		 jpa_ThrowError( env, "Cannot find double JNI field." );
-		return 0;
+     {
+         jpa_ThrowError( env, "Cannot find double JNI field." );
+        return 0;
      }
-	 else
-	 {
-		return (*env)->GetDoubleField(env, obj, fid );
-	 }
+     else
+     {
+        return (*env)->GetDoubleField(env, obj, fid );
+     }
 }
 
 void jpa_SetStringField( JNIEnv *env, jclass cls, jobject obj, const char *fieldName, const char *value )
@@ -134,75 +134,75 @@ void jpa_SetStringField( JNIEnv *env, jclass cls, jobject obj, const char *field
      /* Look for the instance field maxInputChannels in cls */
      jfieldID fid = (*env)->GetFieldID(env, cls, fieldName, "Ljava/lang/String;");
      if (fid == NULL)
-	 {
-		 jpa_ThrowError( env, "Cannot find String JNI field." );
+     {
+         jpa_ThrowError( env, "Cannot find String JNI field." );
      }
-	 else
-	 {
-		jstring jstr = (*env)->NewStringUTF(env, value);
-		if (jstr == NULL)
-		{
-			jpa_ThrowError( env, "Cannot create new String." );
-		}
-		else
-		{
-			(*env)->SetObjectField(env, obj, fid, jstr );
-		}
-	 }
+     else
+     {
+        jstring jstr = (*env)->NewStringUTF(env, value);
+        if (jstr == NULL)
+        {
+            jpa_ThrowError( env, "Cannot create new String." );
+        }
+        else
+        {
+            (*env)->SetObjectField(env, obj, fid, jstr );
+        }
+     }
 }
 
 PaStreamParameters *jpa_FillStreamParameters( JNIEnv *env, jobject jstreamParam, PaStreamParameters *myParams )
 {
-	jclass cls;
-	
-	if( jstreamParam == NULL ) return NULL; // OK, not an error
+    jclass cls;
 
-	cls = (*env)->GetObjectClass(env, jstreamParam);
-	
-	myParams->channelCount = jpa_GetIntField( env, cls, jstreamParam, "channelCount" );
-	myParams->device = jpa_GetIntField( env, cls, jstreamParam, "device" );
-	myParams->sampleFormat = jpa_GetIntField( env, cls, jstreamParam, "sampleFormat" );
-	myParams->suggestedLatency = jpa_GetDoubleField( env, cls, jstreamParam, "suggestedLatency" );
-	myParams->hostApiSpecificStreamInfo = NULL;
+    if( jstreamParam == NULL ) return NULL; // OK, not an error
 
-	return myParams;
+    cls = (*env)->GetObjectClass(env, jstreamParam);
+
+    myParams->channelCount = jpa_GetIntField( env, cls, jstreamParam, "channelCount" );
+    myParams->device = jpa_GetIntField( env, cls, jstreamParam, "device" );
+    myParams->sampleFormat = jpa_GetIntField( env, cls, jstreamParam, "sampleFormat" );
+    myParams->suggestedLatency = jpa_GetDoubleField( env, cls, jstreamParam, "suggestedLatency" );
+    myParams->hostApiSpecificStreamInfo = NULL;
+
+    return myParams;
 }
 
 // Create an exception that will be thrown when we return from the JNI call.
 jint jpa_ThrowError( JNIEnv *env, const char *message )
 {
-	return (*env)->ThrowNew(env, (*env)->FindClass( env, "java/lang/RuntimeException"),
+    return (*env)->ThrowNew(env, (*env)->FindClass( env, "java/lang/RuntimeException"),
                   message );
 }
 
 // Throw an exception on error.
 jint jpa_CheckError( JNIEnv *env, PaError err )
 {
-	if( err == -1 )
-	{
+    if( err == -1 )
+    {
         return jpa_ThrowError( env, "-1, possibly no available default device" );
     }
     else if( err < 0 )
     {
-		if( err == paUnanticipatedHostError )
-		{
-			const PaHostErrorInfo *hostErrorInfo = Pa_GetLastHostErrorInfo();
-			return jpa_ThrowError( env, hostErrorInfo->errorText );
-		}
-		else
-		{
-			return jpa_ThrowError( env, Pa_GetErrorText( err ) );
-		}
-	}
-	else
-	{
-		return err;
-	}
+        if( err == paUnanticipatedHostError )
+        {
+            const PaHostErrorInfo *hostErrorInfo = Pa_GetLastHostErrorInfo();
+            return jpa_ThrowError( env, hostErrorInfo->errorText );
+        }
+        else
+        {
+            return jpa_ThrowError( env, Pa_GetErrorText( err ) );
+        }
+    }
+    else
+    {
+        return err;
+    }
 }
 
 // Get the stream pointer from a BlockingStream long field.
 PaStream *jpa_GetStreamPointer( JNIEnv *env, jobject blockingStream )
 {
-	jclass cls = (*env)->GetObjectClass(env, blockingStream);
-	return (PaStream *) jpa_GetLongField( env, cls, blockingStream, "nativeStream" );
+    jclass cls = (*env)->GetObjectClass(env, blockingStream);
+    return (PaStream *) jpa_GetLongField( env, cls, blockingStream, "nativeStream" );
 }

--- a/bindings/java/c/src/jpa_tools.h
+++ b/bindings/java/c/src/jpa_tools.h
@@ -26,13 +26,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 


### PR DESCRIPTION
Same as #454, this one has a lot of changes mostly due to tabs being converted to spaces.