### PR TITLE
Fix user-facing and non-user-facing typos 

### DIFF
--- a/doc/src/tutorial/writing_a_callback.dox
+++ b/doc/src/tutorial/writing_a_callback.dox
@@ -10,7 +10,7 @@ The next task is to write your own "callback" function. The "callback" is a func
 Before we begin, it's important to realize that the callback is a delicate place. This is because some systems perform the callback in a special thread, or interrupt handler, and it is rarely treated the same as the rest of your code.
 For most modern systems, you won't be able to cause crashes by making disallowed calls in the callback, but if you want your code to produce glitch-free audio, you will have to make sure you avoid function calls that may take an unbounded amount of time
 to execute. Exactly what these are depend on your platform but almost certainly include the following:  memory allocation/deallocation, I/O (including file I/O as well as console I/O, such as printf()), context switching (such as exec() or
-yield()), mutex operations, or anything else that might rely on the OS. If you think short critical sections are safe please go read about priority inversion. Windows amd Mac OS schedulers have no real-time safe priority inversion prevention. Other platforms require special mutex flags. In addition, it is not safe to call any PortAudio API functions in the callback except as explicitly permitted in the documentation.
+yield()), mutex operations, or anything else that might rely on the OS. If you think short critical sections are safe please go read about priority inversion. Windows and Mac OS schedulers have no real-time safe priority inversion prevention. Other platforms require special mutex flags. In addition, it is not safe to call any PortAudio API functions in the callback except as explicitly permitted in the documentation.
 
 
 Your callback function must return an int and accept the exact parameters specified in this typedef:

--- a/include/pa_win_wasapi.h
+++ b/include/pa_win_wasapi.h
@@ -332,7 +332,7 @@ typedef struct PaWasapiStreamInfo
     /** Specifies thread priority explicitly. Will be used only if paWinWasapiThreadPriority flag
        is specified.
 
-       Please note, if Input/Output streams are opened simultaniously (Full-Duplex mode)
+       Please note, if Input/Output streams are opened simultaneously (Full-Duplex mode)
        you shall specify same value for threadPriority or othervise one of the values will be used
        to setup thread priority.
     */

--- a/ltmain.sh
+++ b/ltmain.sh
@@ -602,7 +602,7 @@ func_quote_for_eval ()
 
     case $func_quote_for_eval_unquoted_result in
       # Double-quote args containing shell metacharacters to delay
-      # word splitting, command substitution and and variable
+      # word splitting, command substitution and variable
       # expansion for a subsequent eval.
       # Many Bourne shells cannot handle close brackets correctly
       # in scan sets, so we specify it separately.

--- a/src/hostapi/coreaudio/notes.txt
+++ b/src/hostapi/coreaudio/notes.txt
@@ -64,7 +64,7 @@ the extent to which PA will attempt to "play nice" and to what extent it
 will interrupt other apps to improve performance. For example, if 44100 Hz
 sample rate is requested but the device is set at 48000 Hz, PA can either
 change the device for optimal playback ("Pro" mode), which may interrupt
-other programs playing back audio, or simple use a sample-rate coversion,
+other programs playing back audio, or simple use a sample-rate conversion,
 which allows for friendlier sharing of the device ("Play Nice" mode).
 
 Additionally, the user may define a "channel mapping" by calling

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -2200,7 +2200,7 @@ static OSStatus AudioIOProc( void *inRefCon,
    /*
    static int renderCount = 0;
    static int inputCount = 0;
-   printf( "-------------------  starting reder/input\n" );
+   printf( "-------------------  starting render/input\n" );
    if( isRender )
       printf("Render callback (%d):\t", ++renderCount);
    else

--- a/src/hostapi/coreaudio/pa_mac_core_old.c
+++ b/src/hostapi/coreaudio/pa_mac_core_old.c
@@ -96,7 +96,7 @@ typedef struct PaMacCore_S
 //    HANDLE processingThread;
 //    DWORD processingThreadId;
     
-    char throttleProcessingThreadOnOverload; // 0 -> don't throtte, non-0 -> throttle
+    char throttleProcessingThreadOnOverload; // 0 -> don't throttle, non-0 -> throttle
     int processingThreadPriority;
     int highThreadPriority;
     int throttledThreadPriority;

--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -42,7 +42,7 @@
 */
 
 /* Until May 2011 PA/DS has used a multimedia timer to perform the callback.
-   We're replacing this with a new implementation using a thread and a different timer mechanim.
+   We're replacing this with a new implementation using a thread and a different timer mechanism.
    Defining PA_WIN_DS_USE_WMME_TIMER uses the old (pre-May 2011) behavior.
 */
 //#define PA_WIN_DS_USE_WMME_TIMER
@@ -322,7 +322,7 @@ static double PaWinDS_GetMinSystemLatencySeconds( void )
 NOTE: GetVersionEx() is deprecated as of Windows 8.1 and can not be used to reliably detect
 versions of Windows higher than Windows 8 (due to manifest requirements for reporting higher versions).
 Microsoft recommends switching to VerifyVersionInfo (available on Win 2k and later), however GetVersionEx
-is is faster, for now we just disable the deprecation warning.
+is faster, for now we just disable the deprecation warning.
 See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx
 See: http://www.codeproject.com/Articles/678606/Part-Overcoming-Windows-s-deprecation-of-GetVe
 */

--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -365,7 +365,7 @@ enum { WASAPI_PACKETS_PER_INPUT_BUFFER = 6 };
 // Mixer function
 typedef void (*MixMonoToStereoF) (void *__to, const void *__from, UINT32 count);
 
-// AVRT is the new "multimedia schedulling stuff"
+// AVRT is the new "multimedia scheduling stuff"
 #ifndef PA_WINRT
 typedef BOOL   (WINAPI *FAvRtCreateThreadOrderingGroup)  (PHANDLE,PLARGE_INTEGER,GUID*,PLARGE_INTEGER);
 typedef BOOL   (WINAPI *FAvRtDeleteThreadOrderingGroup)  (HANDLE);
@@ -3610,7 +3610,7 @@ static PaError ActivateAudioClientOutput(PaWasapiStream *stream)
     // Correct buffer to max size if it maxed out result of GetBufferSize
     stream->out.bufferSize = maxBufferSize;
 
-    // Get interface latency (actually uneeded as we calculate latency from the size of maxBufferSize)
+    // Get interface latency (actually unneeded as we calculate latency from the size of maxBufferSize)
     if (FAILED(hr = IAudioClient_GetStreamLatency(stream->out.clientParent, &stream->out.deviceLatency)))
     {
         LogHostError(hr);
@@ -3677,7 +3677,7 @@ static PaError ActivateAudioClientInput(PaWasapiStream *stream)
     // Correct buffer to max size if it maxed out result of GetBufferSize
     stream->in.bufferSize = maxBufferSize;
 
-    // Get interface latency (actually uneeded as we calculate latency from the size
+    // Get interface latency (actually unneeded as we calculate latency from the size
     // of maxBufferSize).
     if (FAILED(hr = IAudioClient_GetStreamLatency(stream->in.clientParent, &stream->in.deviceLatency)))
     {

--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -653,7 +653,7 @@ static BOOL IsEarlierThanVista()
 NOTE: GetVersionEx() is deprecated as of Windows 8.1 and can not be used to reliably detect
 versions of Windows higher than Windows 8 (due to manifest requirements for reporting higher versions).
 Microsoft recommends switching to VerifyVersionInfo (available on Win 2k and later), however GetVersionEx
-is is faster, for now we just disable the deprecation warning.
+is faster, for now we just disable the deprecation warning.
 See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx
 See: http://www.codeproject.com/Articles/678606/Part-Overcoming-Windows-s-deprecation-of-GetVe
 */

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -192,7 +192,7 @@
 
 /* When client suggestedLatency could result in many host buffers, we aim to have around 8,
    based off Windows documentation that suggests that the kmixer uses 8 buffers. This choice
-   is somewhat arbitrary here, since we haven't observed significant stability degredation
+   is somewhat arbitrary here, since we haven't observed significant stability degradation
    with using either more, or less buffers.
 */
 #define PA_MME_TARGET_HOST_BUFFER_COUNT_    8
@@ -915,7 +915,7 @@ static void GetDefaultLatencies( PaTime *defaultLowLatency, PaTime *defaultHighL
 NOTE: GetVersionEx() is deprecated as of Windows 8.1 and can not be used to reliably detect
 versions of Windows higher than Windows 8 (due to manifest requirements for reporting higher versions).
 Microsoft recommends switching to VerifyVersionInfo (available on Win 2k and later), however GetVersionEx
-is is faster, for now we just disable the deprecation warning.
+is faster, for now we just disable the deprecation warning.
 See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx
 See: http://www.codeproject.com/Articles/678606/Part-Overcoming-Windows-s-deprecation-of-GetVe
 */
@@ -2156,7 +2156,7 @@ struct PaWinMmeStream
     HANDLE processingThread;
     PA_THREAD_ID processingThreadId;
 
-    char throttleProcessingThreadOnOverload;    /* 0 -> don't throtte, non-0 -> throttle */
+    char throttleProcessingThreadOnOverload;    /* 0 -> don't throttle, non-0 -> throttle */
     int processingThreadPriority;
     int highThreadPriority;
     int throttledThreadPriority;

--- a/src/os/unix/pa_unix_util.c
+++ b/src/os/unix/pa_unix_util.c
@@ -231,7 +231,7 @@ PaError PaUtil_CancelThreading( PaUtilThreading *threading, int wait, PaError *e
 */
 pthread_t paUnixMainThread = 0;
 #else
-/*pthreads are opaque. We don't know that asigning it an int value
+/*pthreads are opaque. We don't know that assigning it an int value
   always makes sense, so we don't initialize it unless we have to.*/
 pthread_t paUnixMainThread = 0;
 #endif

--- a/test/patest_write_stop_hang_illegal.c
+++ b/test/patest_write_stop_hang_illegal.c
@@ -69,7 +69,7 @@ static float s_buffer[FRAMES_PER_BUFFER][2]; /* stereo output buffer */
  * illegal way, it may fail for reasons that are not PA bugs.
  */
 
-/* Wait for awhile then abort the stream. */
+/* Wait awhile then abort the stream. */
 void *stop_thread_proc(void *arg)
 {
     PaStream *stream = (PaStream *)arg;


### PR DESCRIPTION
Found via `codespell v2.1.dev0`  
`codespell -q 3 -L chello,gord,guid,numer,pres,uint,wirth`