### PR TITLE
mac autoconf: support current and future SDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lib-stamp
 lib/*
 libtool
 portaudio-2.0.pc
+autom4te.cache/*
 
 # Precompiled Headers
 *.gch

--- a/configure
+++ b/configure
@@ -723,6 +723,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -821,6 +822,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1073,6 +1075,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1210,7 +1221,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1363,6 +1374,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/configure
+++ b/configure
@@ -15839,12 +15839,12 @@ case "${host_os}" in
               ;;
 
            *)
-                                                                                    if xcodebuild -version -sdk macosx10.5 Path >/dev/null 2>&1 ; then
+                                                                                    if xcrun --sdk macosx10.5 --show-sdk-path >/dev/null 2>&1 ; then
                  mac_version_min="-mmacosx-version-min=10.5"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.5 Path`"
+                 mac_sysroot="-isysroot $(xcrun --sdk macosx10.5 --show-sdk-path)"
               else
                  mac_version_min="-mmacosx-version-min=10.6"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx Path`"
+                 mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
               fi
            esac
 

--- a/configure
+++ b/configure
@@ -723,7 +723,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -822,7 +821,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1075,15 +1073,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1221,7 +1210,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1374,7 +1363,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -15852,40 +15840,11 @@ case "${host_os}" in
 
            *)
                                                                                     if xcodebuild -version -sdk macosx10.5 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.3"
+                 mac_version_min="-mmacosx-version-min=10.5"
                  mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.5 Path`"
-              elif xcodebuild -version -sdk macosx10.6 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.6 Path`"
-              elif xcodebuild -version -sdk macosx10.7 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.7 Path`"
-              elif xcodebuild -version -sdk macosx10.8 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.8 Path`"
-              elif xcodebuild -version -sdk macosx10.9 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.9 Path`"
-              elif xcodebuild -version -sdk macosx10.10 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.10 Path`"
-              elif xcodebuild -version -sdk macosx10.11 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.11 Path`"
-              elif xcodebuild -version -sdk macosx10.12 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.12 Path`"
-              elif xcodebuild -version -sdk macosx10.13 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.13 Path`"
-              elif xcodebuild -version -sdk macosx10.14 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.14 Path`"
-              elif xcodebuild -version -sdk macosx10.15 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.15 Path`"
               else
-                 as_fn_error $? "Could not find 10.5 to 10.13 SDK." "$LINENO" 5
+                 mac_version_min="-mmacosx-version-min=10.6"
+                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx Path`"
               fi
            esac
 

--- a/configure.in
+++ b/configure.in
@@ -234,12 +234,12 @@ case "${host_os}" in
               dnl as there *is* no /Developer, so we use -sdk to check
               dnl what SDKs are available and to get the full path of
               dnl the SDKs.
-              if xcodebuild -version -sdk macosx10.5 Path >/dev/null 2>&1 ; then
+              if xcrun --sdk macosx10.5 --show-sdk-path >/dev/null 2>&1 ; then
                  mac_version_min="-mmacosx-version-min=10.5"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.5 Path`"
+                 mac_sysroot="-isysroot $(xcrun --sdk macosx10.5 --show-sdk-path)"
               else
                  mac_version_min="-mmacosx-version-min=10.6"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx Path`"
+                 mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
               fi
            esac
 

--- a/configure.in
+++ b/configure.in
@@ -235,40 +235,11 @@ case "${host_os}" in
               dnl what SDKs are available and to get the full path of
               dnl the SDKs.
               if xcodebuild -version -sdk macosx10.5 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.3"
+                 mac_version_min="-mmacosx-version-min=10.5"
                  mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.5 Path`"
-              elif xcodebuild -version -sdk macosx10.6 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.6 Path`"
-              elif xcodebuild -version -sdk macosx10.7 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.7 Path`"
-              elif xcodebuild -version -sdk macosx10.8 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.8 Path`"
-              elif xcodebuild -version -sdk macosx10.9 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.9 Path`"
-              elif xcodebuild -version -sdk macosx10.10 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.10 Path`"
-              elif xcodebuild -version -sdk macosx10.11 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.11 Path`"
-              elif xcodebuild -version -sdk macosx10.12 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.12 Path`"
-              elif xcodebuild -version -sdk macosx10.13 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.13 Path`"
-              elif xcodebuild -version -sdk macosx10.14 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.14 Path`"
-              elif xcodebuild -version -sdk macosx10.15 Path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.4"
-                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx10.15 Path`"
               else
-                 AC_MSG_ERROR([Could not find 10.5 to 10.13 SDK.])
+                 mac_version_min="-mmacosx-version-min=10.6"
+                 mac_sysroot="-isysroot `xcodebuild -version -sdk macosx Path`"
               fi
            esac
 


### PR DESCRIPTION
Improve the way we generate the path to the SDK so that it
it not tied to specific versions.

Also changed macosx-version-min to 10.6

Fixes #378
Fixes #468