### PR TITLE
ASIO: Handle buffer size changes

### DIFF
--- a/include/pa_asio.h
+++ b/include/pa_asio.h
@@ -80,8 +80,9 @@ typedef void (*PaAsioResetRequestCallback)();
 
  @param callback The function to call on ASIO reset request.  This is called
  when the driver's buffer size has changed or it needs a reset, usually in
- response to a user changing the configuration.  Pass NULL to unregister a
- callback.
+ response to a user changing the configuration.  Call Pa_Terminate followed by
+ Pa_Initialize to have the changes reflected in Portaudio's API.  Pass NULL to
+ unregister a callback.
 */
 void PaAsio_RegisterResetRequestCallback( PaAsioResetRequestCallback callback );
 

--- a/include/pa_asio.h
+++ b/include/pa_asio.h
@@ -71,6 +71,20 @@ PaError PaAsio_GetAvailableBufferSizes( PaDeviceIndex device,
         long *minBufferSizeFrames, long *maxBufferSizeFrames, long *preferredBufferSizeFrames, long *granularity );
 
 
+typedef void (*PaAsioResetRequestCallback)();
+
+/** Register callback to detect reset requests.
+
+ This correponds to the ASIO kAsioResetRequest and kAsioBufferSizeChange
+ messages.
+
+ @param callback The function to call on ASIO reset request.  This is called
+ when the driver's buffer size has changed or it needs a reset, usually in
+ response to a user changing the configuration.  Pass NULL to unregister a
+ callback.
+*/
+void PaAsio_RegisterResetRequestCallback( PaAsioResetRequestCallback callback );
+
 /** Backwards compatibility alias for PaAsio_GetAvailableBufferSizes
 
  @see PaAsio_GetAvailableBufferSizes

--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -276,7 +276,7 @@ typedef struct PaAsioDriverInfo
     ASIODriverInfo asioDriverInfo;
     long inputChannelCount, outputChannelCount;
     long bufferMinSize, bufferMaxSize, bufferPreferredSize, bufferGranularity;
-    bool postOutput, bufferSizeOutdated;
+    bool postOutput;
 }
 PaAsioDriverInfo;
 
@@ -928,30 +928,6 @@ PaError PaAsio_GetAvailableBufferSizes( PaDeviceIndex device,
             PaAsioDeviceInfo *asioDeviceInfo =
                     (PaAsioDeviceInfo*)hostApi->deviceInfos[hostApiDevice];
 
-            PaAsioHostApiRepresentation *asioApi = (PaAsioHostApiRepresentation*) hostApi;
-            if ( hostApiDevice == asioApi->openAsioDeviceIndex &&
-                 asioApi->openAsioDriverInfo.bufferSizeOutdated )
-            {
-                ASIOError asioError;
-                PaAsioDriverInfo &driverInfo = asioApi->openAsioDriverInfo;
-                if( (asioError = ASIOGetBufferSize(&driverInfo.bufferMinSize,
-                        &driverInfo.bufferMaxSize, &driverInfo.bufferPreferredSize,
-                        &driverInfo.bufferGranularity)) != ASE_OK )
-                {
-                    PA_ASIO_SET_LAST_ASIO_ERROR( asioError );
-                    return paUnanticipatedHostError;
-                }
-                else
-                {
-                    asioDeviceInfo->minBufferSize = driverInfo.bufferMinSize;
-                    asioDeviceInfo->maxBufferSize = driverInfo.bufferMaxSize;
-                    asioDeviceInfo->preferredBufferSize = driverInfo.bufferPreferredSize;
-                    asioDeviceInfo->bufferGranularity = driverInfo.bufferGranularity;
-
-                    driverInfo.bufferSizeOutdated = false;
-                }
-            }
-
             *minBufferSizeFrames = asioDeviceInfo->minBufferSize;
             *maxBufferSizeFrames = asioDeviceInfo->maxBufferSize;
             *preferredBufferSizeFrames = asioDeviceInfo->preferredBufferSize;
@@ -1019,7 +995,6 @@ static PaError LoadAsioDriver( PaAsioHostApiRepresentation *asioHostApi, const c
         PA_ASIO_SET_LAST_ASIO_ERROR( asioError );
         goto error;
     }
-    driverInfo->bufferSizeOutdated = false;
 
     if( ASIOOutputReady() == ASE_OK )
         driverInfo->postOutput = true;
@@ -3231,21 +3206,6 @@ void PaAsio_RegisterResetRequestCallback( PaAsioResetRequestCallback callback )
     resetRequestCallback_ = callback;
 }
 
-static void setBufferSizesOutdated()
-{
-    PaUtilHostApiRepresentation *hostApi;
-    PaAsioHostApiRepresentation *asioApi;
-
-    PaError result = PaUtil_GetHostApiRepresentation( &hostApi, paASIO );
-    if( result != paNoError )
-        return;
-    asioApi = (PaAsioHostApiRepresentation*) hostApi;
-    if ( asioApi->openAsioDeviceIndex == paNoDevice )
-        return;
-
-    asioApi->openAsioDriverInfo.bufferSizeOutdated = true;
-}
-
 static long asioMessages(long selector, long value, void* message, double* opt)
 {
 // TAKEN FROM THE ASIO SDK
@@ -3273,7 +3233,6 @@ static long asioMessages(long selector, long value, void* message, double* opt)
 
         case kAsioBufferSizeChange:
             //printf("kAsioBufferSizeChange \n");
-            setBufferSizesOutdated();
             if (resetRequestCallback_) {
                 resetRequestCallback_();
                 ret = 1L;
@@ -3292,7 +3251,6 @@ static long asioMessages(long selector, long value, void* message, double* opt)
                 http://www.portaudio.com/trac/ticket/108
             */
             //asioDriverInfo.stopped;  // In this sample the processing will just stop
-            setBufferSizesOutdated();
             if (resetRequestCallback_) {
                 resetRequestCallback_();
             }


### PR DESCRIPTION
This fixes #472. I don't know if it's the best approach.

```
When kAsioBufferSizeChange or kAsioResetRequest is received, remember
it and update the buffer sizes the next time
PaAsio_GetAvailableBufferSizes() is called.  Add callbacks for those
messages so that the library user can be aware of them.
```