### PR TITLE
Clean up whitespace in src/hostapi/alsa in preparation for .editorconfig.

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -2052,7 +2052,7 @@ static PaError PaAlsaStreamComponent_InitialConfigure( PaAlsaStreamComponent *se
     }
     else
     {
-       PA_ENSURE( paUnanticipatedHostError );
+        PA_ENSURE( paUnanticipatedHostError );
     }
 
     ENSURE_( alsa_snd_pcm_hw_params_set_channels( pcm, hwParams, self->numHostChannels ), paInvalidChannelCount );
@@ -3807,8 +3807,8 @@ static PaError PaAlsaStream_WaitForFrames( PaAlsaStream *self, unsigned long *fr
             PaError res = PaAlsaStreamComponent_BeginPolling( &self->capture, capturePfds );
             if( res != paNoError)
             {
-              xrun = 1;
-              goto end;
+                xrun = 1;
+                goto end;
             }
             totalFds += self->capture.nfds;
         }
@@ -3819,8 +3819,8 @@ static PaError PaAlsaStream_WaitForFrames( PaAlsaStream *self, unsigned long *fr
             PaError res = PaAlsaStreamComponent_BeginPolling( &self->playback, playbackPfds );
             if( res != paNoError)
             {
-              xrun = 1;
-              goto end;
+                xrun = 1;
+                goto end;
             }
             totalFds += self->playback.nfds;
         }


### PR DESCRIPTION
Indent by 4 spaces.