### PR TITLE
configure: add arm64 for Mac M1

### DIFF
--- a/configure
+++ b/configure
@@ -15861,7 +15861,7 @@ case "${host_os}" in
            esac
 
                                  mac_arches=""
-           for arch in x86_64
+           for arch in x86_64 arm64
            do
               save_CFLAGS="$CFLAGS"
               CFLAGS="$CFLAGS -arch $arch"

--- a/configure.in
+++ b/configure.in
@@ -246,7 +246,7 @@ case "${host_os}" in
            dnl Pick which architectures to build for based on what
            dnl the compiler supports.
            mac_arches=""
-           for arch in x86_64
+           for arch in x86_64 arm64
            do
               save_CFLAGS="$CFLAGS"
               CFLAGS="$CFLAGS -arch $arch"


### PR DESCRIPTION
Add additional architecture to builds.

Fixes #445