### PR TITLE
Cleanup whitespaces in DSound

### DIFF
--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -3257,4 +3257,3 @@ static signed long GetStreamWriteAvailable( PaStream* s )
 
     return 0;
 }
-


### PR DESCRIPTION
Removes a doubled endline at the end.