### PR TITLE
Cleanup whitespaces in OSS

### DIFF
--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -2050,4 +2050,3 @@ error:
     return result;
 #endif
 }
-


### PR DESCRIPTION
Removes a doubled endline at the end.