### PR TITLE
PaWinUtil_SetLastSystemErrorInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ IF(WIN32)
     src/os/win/pa_win_wdmks_utils.c
     src/os/win/pa_win_coinitialize.c)
   SET(PA_PLATFORM_INCLUDES
+    src/os/win/pa_win_util.h
     src/os/win/pa_win_coinitialize.h
     src/os/win/pa_win_wdmks_utils.h)
 

--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -102,6 +102,7 @@
 #include "pa_ringbuffer.h"
 
 #include "pa_win_coinitialize.h"
+#include "pa_win_util.h"
 
 /* This version of pa_asio.cpp is currently only targeted at Win32,
    It would require a few tweaks to work with pre-OS X Macintosh.
@@ -214,18 +215,7 @@ static ASIOCallbacks asioCallbacks_ =
 
 static void PaAsio_SetLastSystemError( DWORD errorCode )
 {
-    LPVOID lpMsgBuf;
-    FormatMessage(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-        NULL,
-        errorCode,
-        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-        (LPTSTR) &lpMsgBuf,
-        0,
-        NULL
-    );
-    PaUtil_SetLastHostErrorInfo( paASIO, errorCode, (const char*)lpMsgBuf );
-    LocalFree( lpMsgBuf );
+    PaWinUtil_SetLastSystemErrorInfo( paASIO, errorCode );
 }
 
 #define PA_ASIO_SET_LAST_SYSTEM_ERROR( errorCode ) \

--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -83,6 +83,7 @@
 #include "pa_process.h"
 #include "pa_debugprint.h"
 
+#include "pa_win_util.h"
 #include "pa_win_ds.h"
 #include "pa_win_ds_dynlink.h"
 #include "pa_win_waveformat.h"
@@ -203,9 +204,14 @@ static signed long GetStreamReadAvailable( PaStream* stream );
 static signed long GetStreamWriteAvailable( PaStream* stream );
 
 
-/* FIXME: should convert hr to a string */
+#if _WIN32_WINNT >= 0x0602 // Windows 8 and above
+#define PA_DS_SET_LAST_DIRECTSOUND_ERROR( hr ) \
+    PaWinUtil_SetLastSystemErrorInfo( paDirectSound, hr )
+#else
+/* FIXME: should use DXGetErrorString/DXGetErrorDescription for Windows 7 and below */
 #define PA_DS_SET_LAST_DIRECTSOUND_ERROR( hr ) \
     PaUtil_SetLastHostErrorInfo( paDirectSound, hr, "DirectSound error" )
+#endif
 
 /************************************************* DX Prototypes **********/
 static BOOL CALLBACK CollectGUIDsProcW(LPGUID lpGUID,

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -112,6 +112,7 @@
 
 #include "pa_win_wmme.h"
 #include "pa_win_waveformat.h"
+#include "pa_win_util.h"
 
 #ifdef PAWIN_USE_WDMKS_DEVICE_INFO
 #include "pa_win_wdmks_utils.h"
@@ -313,18 +314,7 @@ static signed long GetStreamWriteAvailable( PaStream* stream );
 
 static void PaMme_SetLastSystemError( DWORD errorCode )
 {
-    char *lpMsgBuf;
-    FormatMessage(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-        NULL,
-        errorCode,
-        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-        (LPTSTR) &lpMsgBuf,
-        0,
-        NULL
-    );
-    PaUtil_SetLastHostErrorInfo( paMME, errorCode, lpMsgBuf );
-    LocalFree( lpMsgBuf );
+    PaWinUtil_SetLastSystemErrorInfo( paMME, errorCode );
 }
 
 #define PA_MME_SET_LAST_SYSTEM_ERROR( errorCode ) \

--- a/src/os/win/pa_win_coinitialize.c
+++ b/src/os/win/pa_win_coinitialize.c
@@ -50,7 +50,7 @@
 #include "pa_debugprint.h"
 
 #include "pa_win_coinitialize.h"
-
+#include "pa_win_util.h"
 
 #if (defined(WIN32) && (defined(_MSC_VER) && (_MSC_VER >= 1200))) && !defined(_WIN32_WCE) && !(defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)) /* MSC version 6 and above */
 #pragma comment( lib, "ole32.lib" )
@@ -88,20 +88,7 @@ PaError PaWinUtil_CoInitialize( PaHostApiTypeId hostApiType, PaWinUtilComInitial
         if( hr == E_OUTOFMEMORY )
             return paInsufficientMemory;
 
-        {
-            char *lpMsgBuf;
-            FormatMessage(
-                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-                NULL,
-                hr,
-                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                (LPTSTR) &lpMsgBuf,
-                0,
-                NULL
-            );
-            PaUtil_SetLastHostErrorInfo( hostApiType, hr, lpMsgBuf );
-            LocalFree( lpMsgBuf );
-        }
+        PaWinUtil_SetLastSystemErrorInfo( hostApiType, hr );
 
         return paUnanticipatedHostError;
     }

--- a/src/os/win/pa_win_util.c
+++ b/src/os/win/pa_win_util.c
@@ -158,3 +158,20 @@ double PaUtil_GetTime( void )
 #endif
     }
 }
+
+void PaWinUtil_SetLastSystemErrorInfo( PaHostApiTypeId hostApiType, long winError )
+{
+    wchar_t wide_msg[1024]; //PA_LAST_HOST_ERROR_TEXT_LENGTH_
+    FormatMessageW(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        winError,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        wide_msg,
+        1024,
+        NULL
+    );
+    char msg[1024];
+    WideCharToMultiByte( CP_UTF8, 0, wide_msg, -1, msg, 1024, NULL, NULL );
+    PaUtil_SetLastHostErrorInfo( hostApiType, winError, msg );
+}

--- a/src/os/win/pa_win_util.h
+++ b/src/os/win/pa_win_util.h
@@ -1,0 +1,64 @@
+#ifndef PA_WIN_UTIL_H
+#define PA_WIN_UTIL_H
+
+/*
+ * $Id$
+ * Portable Audio I/O Library
+ * Win32 platform-specific support functions
+ *
+ * Based on the Open Source API proposed by Ross Bencina
+ * Copyright (c) 1999-2008 Ross Bencina
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+#include "portaudio.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+/**
+ Convert a Windows error code into a PaError. Sets the host-api specific error
+ information if needed.
+
+ @param hostApiType The calling host api type. Used when reporting paUnanticipatedHostError
+
+ @param winError A Windows error code.
+*/
+void PaWinUtil_SetLastSystemErrorInfo( PaHostApiTypeId hostApiType, long winError );
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* PA_WIN_UTIL_H */


### PR DESCRIPTION
This PR addresses items #176 and #392.

For #176:
It creates a new function `PaWinUtil_ConvertSystemError` which gets the text of a win32 error and passes it
to `PaUtil_SetLastHostErrorInfo`. It changes calls to all win hostapis to call the new function which greatly reduces code duplication.

For #392:
`PaWinUtil_ConvertSystemError` explicitly calls `FormatMessageW` and converts the message buffer.

Additional fixes:
1. `PaWinUtil_ConvertSystemError` does not allocate memory anymore. It uses a stack buffer of size 1024 which is the size of the buffer we use in `PaUtil_SetLastHostErrorInfo` (`PA_LAST_HOST_ERROR_TEXT_LENGTH_==1024`).
2. It adds the `FORMAT_MESSAGE_IGNORE_INSERTS` flag which maybe needed in some cases as explained by Raymond Chen here: https://devblogs.microsoft.com/oldnewthing/20071128-00/?p=24353 