### PR TITLE
wasapi: add PaWasapi_GetIMMDevice function

### DIFF
--- a/build/msvc/portaudio.def
+++ b/build/msvc/portaudio.def
@@ -55,3 +55,4 @@ PaWasapi_GetJackDescription         @66
 PaWasapi_SetStreamStateHandler      @68
 PaWasapiWinrt_SetDefaultDeviceId    @67
 PaWasapiWinrt_PopulateDeviceList    @69
+PaWasapi_GetIMMDevice               @70

--- a/cmake_support/template_portaudio.def
+++ b/cmake_support/template_portaudio.def
@@ -58,3 +58,4 @@ PaUtil_SetDebugPrintFunction        @55
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_SetStreamStateHandler      @68
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_SetDefaultDeviceId    @67
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_PopulateDeviceList    @69
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetIMMDevice               @70

--- a/include/pa_win_wasapi.h
+++ b/include/pa_win_wasapi.h
@@ -437,6 +437,16 @@ int PaWasapi_GetDeviceMixFormat( void *pFormat, unsigned int formatSize, PaDevic
 int/*PaWasapiDeviceRole*/ PaWasapi_GetDeviceRole( PaDeviceIndex device );
 
 
+/** Get device IMMDevice pointer
+
+ @param device Device index.
+ @param pAudioClient Pointer to pointer of IMMDevice.
+
+ @return Error code indicating success or failure.
+*/
+PaError PaWasapi_GetIMMDevice( PaDeviceIndex device, void **pIMMDevice );
+
+
 /** Boost thread priority of calling thread (MMCSS).
 
     Use it for Blocking Interface only inside the thread which makes calls to Pa_WriteStream/Pa_ReadStream.

--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -2615,6 +2615,27 @@ int PaWasapi_GetDeviceRole( PaDeviceIndex device )
 }
 
 // ------------------------------------------------------------------------------------------
+int PaWasapi_GetIMMDevice( PaDeviceIndex device, void **pIMMDevice )
+{
+        PaError ret;
+        PaDeviceIndex index;
+
+        PaWasapiHostApiRepresentation *paWasapi = _GetHostApi(&ret);
+        if (paWasapi == NULL)
+                return paNotInitialized;
+
+        ret = PaUtil_DeviceIndexToHostApiDeviceIndex(&index, device, &paWasapi->inheritedHostApiRep);
+        if (ret != paNoError)
+                return ret;
+
+        if ((UINT32)index >= paWasapi->deviceCount)
+                return paInvalidDevice;
+
+        *pIMMDevice = paWasapi->devInfo[ index ].device;
+        return paNoError;
+}
+
+// ------------------------------------------------------------------------------------------
 PaError PaWasapi_GetFramesPerHostBuffer( PaStream *pStream, unsigned int *pInput, unsigned int *pOutput )
 {
     PaWasapiStream *stream = (PaWasapiStream *)pStream;


### PR DESCRIPTION
The IMMDevice pointer enables access to audio device capabiltiies not exposed by PortAudio.
https://docs.microsoft.com/en-us/windows/win32/api/mmdeviceapi/nn-mmdeviceapi-immdevice
