### PR TITLE
configure/make: export PaWasapi_* and PaWasapiWinrt_* symbols

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ PALIB = libportaudio.la
 PAINC = include/portaudio.h
 
 PA_LDFLAGS = $(LDFLAGS) $(SHARED_FLAGS) -rpath $(libdir) -no-undefined \
-	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS)_.*" \
+	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS|PaWasapi|PaWasapiWinrt)_.*" \
 	     -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
 COMMON_OBJS = \


### PR DESCRIPTION
(i will create a separate pull request later that exports PaWinMME_* symbols and ammend the portaudio.defs)