### PR TITLE
wasapi: Fix compilation for VS2010.

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -87,6 +87,10 @@
     #include <mmdeviceapi.h>
     #include <devicetopology.h>    // Used to get IKsJackDescription interface
     #undef INITGUID
+// Visual Studio 2010 does not support the inline keyword
+#if (_MSC_VER <= 1600)
+    #define inline _inline
+#endif
 #endif
 #ifndef __MWERKS__
     #include <malloc.h>
@@ -2078,6 +2082,7 @@ static PaDeviceInfo *AllocateDeviceListMemory(PaWasapiHostApiRepresentation *paW
 
     if (paWasapi->deviceCount != 0)
     {
+        UINT32 i;
         UINT32 deviceCount = paWasapi->deviceCount;
     #if defined(PA_WASAPI_MAX_CONST_DEVICE_COUNT) && (PA_WASAPI_MAX_CONST_DEVICE_COUNT > 0)
         if (deviceCount < PA_WASAPI_MAX_CONST_DEVICE_COUNT)
@@ -2089,7 +2094,7 @@ static PaDeviceInfo *AllocateDeviceListMemory(PaWasapiHostApiRepresentation *paW
         {
             return NULL;
         }
-        for (UINT32 i = 0; i < deviceCount; ++i)
+        for (i = 0; i < deviceCount; ++i)
             hostApi->deviceInfos[i] = NULL;
 
         // Allocate all device info structs in a contiguous block
@@ -6091,6 +6096,7 @@ static inline INT32 GetNextSleepTime(SystemTimer *timer, ThreadIdleScheduler *sc
     UINT32 sleepTime)
 {
     INT32 nextSleepTime;
+    INT32 procTime;
 
     // Get next sleep time
     if (sleepTime == 0)
@@ -6104,7 +6110,7 @@ static inline INT32 GetNextSleepTime(SystemTimer *timer, ThreadIdleScheduler *sc
     //
     // [9],{2},[8],{1},[9],{1},[9],{3},[7],{2},[8],{3},[7],{2},[8],{2},[8],{3},[7],{2},[8],...
     //
-    INT32 procTime = (INT32)(SystemTimer_GetTime(timer) - startTime);
+    procTime = (INT32)(SystemTimer_GetTime(timer) - startTime);
     nextSleepTime -= procTime;
     if (nextSleepTime < timer->granularity)
         nextSleepTime = 0;


### PR DESCRIPTION
Fix WASAPI compilation on VS2010
- use C89 syntax for variable declaration
- use "_inline" keyword instead of "inline" when compiling with VS2010 and earlier