### PR TITLE
[macOS] drop support for 10.5

### DIFF
--- a/bindings/cpp/INSTALL
+++ b/bindings/cpp/INSTALL
@@ -124,7 +124,7 @@ architecture at a time in the source code directory.  After you have
 installed the package for one architecture, use `make distclean' before
 reconfiguring for another architecture.
 
-   On MacOS X 10.5 and later systems, you can create libraries and
+   On MacOS X 10.6 and later systems, you can create libraries and
 executables that work on multiple system types--known as "fat" or
 "universal" binaries--by specifying multiple `-arch' options to the
 compiler but only a single `-arch' option to the preprocessor.  Like

--- a/configure
+++ b/configure
@@ -15846,29 +15846,9 @@ case "${host_os}" in
         LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices"
 
         if test "x$enable_mac_universal" = "xyes" ; then
-           case `xcodebuild -version | sed -n 's/Xcode \(.*\)/\1/p'` in
-
-           3.0|3.1)
-                                                                                                                              if [ -d /Developer/SDKs/MacOSX10.5.sdk ] ; then
-                 mac_version_min="-mmacosx-version-min=10.3"
-                 mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.5.sdk"
-              else
-                 mac_version_min="-mmacosx-version-min=10.3"
-                 mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.4u.sdk"
-              fi
-              ;;
-
-           *)
-                                                                                    if xcrun --sdk macosx10.5 --show-sdk-path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.5"
-                 mac_sysroot="-isysroot $(xcrun --sdk macosx10.5 --show-sdk-path)"
-              else
-                 mac_version_min="-mmacosx-version-min=10.6"
-                 mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
-              fi
-           esac
-
-                                 mac_arches=""
+           mac_version_min="-mmacosx-version-min=10.6"
+           mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
+           mac_arches=""
            for arch in x86_64 arm64
            do
               save_CFLAGS="$CFLAGS"

--- a/configure.in
+++ b/configure.in
@@ -217,40 +217,8 @@ case "${host_os}" in
         LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices"
 
         if test "x$enable_mac_universal" = "xyes" ; then
-           case `xcodebuild -version | sed -n 's/Xcode \(.*\)/\1/p'` in
-
-           3.0|3.1)
-              dnl In pre-3.2 versions of Xcode, xcodebuild doesn't
-              dnl support -sdk, so we can't use that to look for
-              dnl SDKs.  However, in those versions of Xcode, the
-              dnl SDKs are under /Developer/SDKs, so we can just look
-              dnl there.  Also, we assume they had no SDKs later
-              dnl than 10.5, as 3.2 was the version that came with
-              dnl 10.6, at least if the Wikipedia page for Xcode
-              dnl is to be believed.
-              if [[ -d /Developer/SDKs/MacOSX10.5.sdk ]] ; then
-                 mac_version_min="-mmacosx-version-min=10.3"
-                 mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.5.sdk"
-              else
-                 mac_version_min="-mmacosx-version-min=10.3"
-                 mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.4u.sdk"
-              fi
-              ;;
-
-           *)
-              dnl In 3.2 and later, xcodebuild supports -sdk, and, in
-              dnl 4.3 and later, the SDKs aren't under /Developer/SDKs
-              dnl as there *is* no /Developer, so we use -sdk to check
-              dnl what SDKs are available and to get the full path of
-              dnl the SDKs.
-              if xcrun --sdk macosx10.5 --show-sdk-path >/dev/null 2>&1 ; then
-                 mac_version_min="-mmacosx-version-min=10.5"
-                 mac_sysroot="-isysroot $(xcrun --sdk macosx10.5 --show-sdk-path)"
-              else
-                 mac_version_min="-mmacosx-version-min=10.6"
-                 mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
-              fi
-           esac
+           mac_version_min="-mmacosx-version-min=10.6"
+           mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
 
            dnl Pick which architectures to build for based on what
            dnl the compiler and SDK supports.

--- a/doc/src/tutorial/compile_mac_coreaudio.dox
+++ b/doc/src/tutorial/compile_mac_coreaudio.dox
@@ -3,11 +3,11 @@
 
 @section comp_mac_ca_1 Requirements
 
-* OS X 10.4 or later. PortAudio v19 currently only compiles and runs on OS X version 10.4 or later. Because of its heavy reliance on memory barriers, it's not clear how easy it would be to back-port PortAudio to OS X version 10.3. Leopard support requires the 2007 snapshot or later.
+* OS X 10.6 or later. PortAudio v19.7 currently only compiles and runs on OS X version 10.6 or later. Because of its heavy reliance on memory barriers, it's not clear how easy it would be to back-port PortAudio to OS X version 10.3. Leopard support requires the 2007 snapshot or later.
 
 * Apple's Xcode and its related tools installed in the default location. There is no Xcode project for PortAudio.
 
-* Mac 10.4 SDK. Look for "/Developer/SDKs/MacOSX10.4u.sdk" folder on your system. It may be installed with XCode. If not then you can download it from Apple Developer Connection. http://connect.apple.com/
+* Mac 10.6 SDK. Look for "/Developer/SDKs/MacOSX10.6.sdk" folder on your system. It may be installed with XCode. If not then you can download it from Apple Developer Connection. http://connect.apple.com/
 
 @section comp_mac_ca_2 Building
 
@@ -29,7 +29,7 @@ There are a variety of other options for building PortAudio. The default describ
 
 @subsection comp_mac_ca_3.1 Building Non-Universal Libraries
 
-By default, PortAudio is built as a universal binary. This includes 64-bit versions if you are compiling on 10.5, Leopard. If you want a "thin", or single architecture library, you have two options:
+By default, PortAudio is built as a universal binary. This includes 64-bit versions if you are compiling on 10.6, Snow Leopard. If you want a "thin", or single architecture library, you have two options:
 
  * build a non-universal library using configure options.
  * use lipo(1) on whatever part of the library you plan to use.
@@ -44,11 +44,11 @@ To build a non-universal library for the host architecture, simply use the <i>--
  ./configure --disable-mac-universal && make
 @endcode
 
-The <i>--disable-mac-universal</i> option may also be used in conjunction with environment variables to give you more control over the universal binary build process. For example, to build a universal binary for the i386 and ppc architectures using the 10.4u sdk (which is the default on 10.4, but not 10.5), you might specify this configure command line:
+The <i>--disable-mac-universal</i> option may also be used in conjunction with environment variables to give you more control over the universal binary build process. For example, to build a universal binary for the i386 and ppc architectures using the 10.6 sdk, you might specify this configure command line:
 
 @code
- CFLAGS="-O2 -g -Wall -arch i386 -arch ppc -isysroot /Developer/SDKs/MacOSX10.4u.sdk -mmacosx-version-min=10.3" \
-   LDFLAGS="-arch i386 -arch ppc -isysroot /Developer/SDKs/MacOSX10.4u.sdk -mmacosx-version-min=10.3" \
+ CFLAGS="-O2 -g -Wall -arch i386 -arch ppc -isysroot /Developer/SDKs/MacOSX10.6.sdk -mmacosx-version-min=10.6" \
+   LDFLAGS="-arch i386 -arch ppc -isysroot /Developer/SDKs/MacOSX10.6.sdk -mmacosx-version-min=10.6" \
    ./configure --disable-mac-universal --disable-dependency-tracking
 @endcode
 

--- a/doc/src/tutorial/compile_mac_coreaudio.dox
+++ b/doc/src/tutorial/compile_mac_coreaudio.dox
@@ -3,7 +3,7 @@
 
 @section comp_mac_ca_1 Requirements
 
-* OS X 10.6 or later. PortAudio v19.7 currently only compiles and runs on OS X version 10.6 or later. Because of its heavy reliance on memory barriers, it's not clear how easy it would be to back-port PortAudio to OS X version 10.3. Leopard support requires the 2007 snapshot or later.
+* OS X 10.6 or later. PortAudio v19.7 currently only compiles and runs on OS X version 10.6 or later.
 
 * Apple's Xcode and its related tools installed in the default location. There is no Xcode project for PortAudio.
 


### PR DESCRIPTION
This is the final PR for item #218
It removes support for OS X 10.5 Leopard and removes deprecated calls to `Gestalt`
It also updates the documentation to reflect the changes.
