### PR TITLE
configure: check for arm64 on mac

### DIFF
--- a/configure
+++ b/configure
@@ -15848,6 +15848,7 @@ case "${host_os}" in
                  mac_version_min="-mmacosx-version-min=10.3"
                  mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.4u.sdk"
               fi
+              mac_arches="x86_64"
               ;;
 
            *)
@@ -15858,36 +15859,16 @@ case "${host_os}" in
                  mac_version_min="-mmacosx-version-min=10.6"
                  mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
               fi
+
+                                          mac_arches=""
+              for arch in x86_64 arm64
+              do
+                 if grep -q __${arch}__  $(xcrun --show-sdk-path)/usr/include/sys/cdefs.h; then
+                    mac_arches="$mac_arches -arch ${arch}"
+                 fi
+              done
            esac
 
-                                 mac_arches=""
-           for arch in x86_64 arm64
-           do
-              save_CFLAGS="$CFLAGS"
-              CFLAGS="$CFLAGS -arch $arch"
-              cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-                    if [ -z "$mac_arches" ] ; then
-                       mac_arches="-arch $arch"
-                    else
-                       mac_arches="$mac_arches -arch $arch"
-                    fi
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-              CFLAGS="$save_CFLAGS"
-           done
         else
            mac_arches=""
            mac_sysroot=""

--- a/configure
+++ b/configure
@@ -15848,7 +15848,7 @@ case "${host_os}" in
                  mac_version_min="-mmacosx-version-min=10.3"
                  mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.4u.sdk"
               fi
-              mac_arches="x86_64"
+              mac_arches="-arch x86_64"
               ;;
 
            *)

--- a/configure.in
+++ b/configure.in
@@ -226,7 +226,7 @@ case "${host_os}" in
                  mac_version_min="-mmacosx-version-min=10.3"
                  mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.4u.sdk"
               fi
-              mac_arches="x86_64"
+              mac_arches="-arch x86_64"
               ;;
 
            *)

--- a/configure.in
+++ b/configure.in
@@ -226,6 +226,7 @@ case "${host_os}" in
                  mac_version_min="-mmacosx-version-min=10.3"
                  mac_sysroot="-isysroot /Developer/SDKs/MacOSX10.4u.sdk"
               fi
+              mac_arches="x86_64"
               ;;
 
            *)
@@ -241,25 +242,18 @@ case "${host_os}" in
                  mac_version_min="-mmacosx-version-min=10.6"
                  mac_sysroot="-isysroot $(xcrun --sdk macosx --show-sdk-path)"
               fi
+
+              dnl Pick which architectures to build for based on whether
+              dnl the arch is defined in cdefs.h
+              mac_arches=""
+              for arch in x86_64 arm64
+              do
+                 if grep -q __${arch}__  $(xcrun --show-sdk-path)/usr/include/sys/cdefs.h; then
+                    mac_arches="$mac_arches -arch ${arch}"
+                 fi
+              done
            esac
 
-           dnl Pick which architectures to build for based on what
-           dnl the compiler supports.
-           mac_arches=""
-           for arch in x86_64 arm64
-           do
-              save_CFLAGS="$CFLAGS"
-              CFLAGS="$CFLAGS -arch $arch"
-              AC_TRY_COMPILE([], [return 0;],
-                 [
-                    if [[ -z "$mac_arches" ]] ; then
-                       mac_arches="-arch $arch"
-                    else
-                       mac_arches="$mac_arches -arch $arch"
-                    fi
-                 ])
-              CFLAGS="$save_CFLAGS"
-           done
         else
            mac_arches=""
            mac_sysroot=""


### PR DESCRIPTION
Only include the arm64 architecture if it is defined in cdefs.h

For #505