### PR TITLE
Add support for ASIO messages

### DIFF
--- a/include/pa_asio.h
+++ b/include/pa_asio.h
@@ -88,6 +88,75 @@ PaError PaAsio_ShowControlPanel( PaDeviceIndex device, void* systemSpecific );
 
 
 
+/** ASIO message types.
+    
+ These mostly correspond with asioMessage calls from the ASIO SDK.
+ ASIO's sampleRateDidChange is adapted to use this callback.
+ Refer to ASIO SDK documentation for complete information.
+*/
+typedef enum PaAsioMessageType
+{
+    /** The driver requests that it be reset (by closing and re-opening the stream).
+        Typically dispatched when the user changes driver settings.
+        Recommend closing, re-opening and restarting stream, and always returning 1.
+            
+        params:
+            none.
+    */
+    paAsioResetRequest      = 1,
+    
+    /** Informs the application that a sample-rate change was detected.
+        Recommend noting the new sample-rate, but no action is needed.
+        
+        params:
+            opt[0] -- the new sample-rate.
+    */
+    paAsioSampleRateChanged = 2,
+    
+    /** Informs the application that the driver has a new preferred buffer size.
+        Recommend handling like paAsioResetRequest.
+        
+        params:
+            value -- the new preferred buffer size.
+    */
+    paAsioBufferSizeChange  = 3,
+    
+    /** Informs the application that the driver has gone out of sync, invalidating timestamps.
+        Recommend handling like paAsioResetRequest.
+        
+        params:
+            none.
+    */
+    paAsioResyncRequest     = 4, 
+    
+    /** Informs the application that the driver's latencies have changed.
+        FIXME: The only way to query the new latencies is to reset the stream.
+        Recommend ignoring unless latency reporting is critical.
+        
+        params:
+            none.
+    */
+    paAsioLatenciesChanged = 5,
+    
+} PaAsioMessageType;
+/** ASIO message callback, set in PaAsioStreamInfo.
+    Do not call PortAudio or PaAsio functions inside this callback!
+ 
+ @param value Message-specific integer value.
+ Indicates buffer size in paAsioBufferSizeChange.
+ 
+ @param message Message-specific pointer value.
+ Unused as of the ASIO 2.2 SDK.
+ 
+ @param opt Message-specific double value.
+ opt[0] indicates sample rate in paAsioSampleRateChange.
+ 
+ @param userData The value of a user supplied pointer passed to
+ Pa_OpenStream() intended for storing synthesis data etc.
+    
+ @return True if the application handled the message, false otherwise.
+*/
+typedef long PaAsio_MessageCallback( long messageType, long value, void *message, double *opt, void *userData );
 
 /** Retrieve a pointer to a string containing the name of the specified
  input channel. The string is valid until Pa_Terminate is called.
@@ -125,7 +194,7 @@ PaError PaAsio_SetStreamSampleRate( PaStream* stream, double sampleRate );
 typedef struct PaAsioStreamInfo{
     unsigned long size;             /**< sizeof(PaAsioStreamInfo) */
     PaHostApiTypeId hostApiType;    /**< paASIO */
-    unsigned long version;          /**< 1 */
+    unsigned long version;          /**< 2 */
 
     unsigned long flags;
 
@@ -140,6 +209,13 @@ typedef struct PaAsioStreamInfo{
         result.
     */
     int *channelSelectors;
+
+    /** ASIO message callback and user-defined parameter.
+        Unsupported in Blocking I/O mode.
+        Set to NULL if unused.
+        If a callback is supplied for both input and output, it will be called twice!
+    */
+    PaAsio_MessageCallback *messageCallback;
 }PaAsioStreamInfo;
 
 

--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -1894,14 +1894,11 @@ static PaError ValidateAsioSpecificStreamInfo(
     if( streamInfo )
     {
         switch( streamInfo->version )
-                || streamInfo->version != 1 )
-        {
         {
         case 1:
             /* NOTE: V1 structure's size is smaller by one pointer. */
             if( streamInfo->size < sizeof( PaAsioStreamInfo ) - sizeof(PaAsio_MessageCallback) )
                 return paIncompatibleHostApiSpecificStreamInfo;
-        }
             break;
             
         case 2:

--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -1897,7 +1897,7 @@ static PaError ValidateAsioSpecificStreamInfo(
         {
         case 1:
             /* NOTE: V1 structure's size is smaller by one pointer. */
-            if( streamInfo->size < sizeof( PaAsioStreamInfo ) - sizeof(PaAsio_MessageCallback) )
+            if( streamInfo->size < sizeof( PaAsioStreamInfo ) - sizeof(PaAsio_MessageCallback*) )
                 return paIncompatibleHostApiSpecificStreamInfo;
             break;
             


### PR DESCRIPTION
This PR addresses PortAudio's bad habit of ignoring certain highly actionable messages from ASIO drivers by providing a callback mechanism to the application.  Applications may receive the following events:

- Reset Request
- Resync Request
- Sample Rate Changed
- Buffer Size Changed
- Latencies Changed

In particular, Reset Request is commonly used to notify the ASIO client when the stream should be reset in order to put configuration changes into effect or resume the interrupted flow of audio.  Implementing automatic reset allows the user to interactively re-configure the ASIO stream by way of a driver-specific UI without superfluous manual steps in the client application.

I have been using this functionality in production for over four years in an application with an integrated crash forensics system and haven't identified any faults.