### PR TITLE
wasapi: Fixed compilation with MinGW (W64)

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -168,12 +168,14 @@
         #include <oleidl.h>
         #include <objidl.h>
     #else
-        typedef struct _BYTE_BLOB
-        {
-            unsigned long clSize;
-            unsigned char abData[ 1 ];
-        }     BYTE_BLOB;
-        typedef /* [unique] */  __RPC_unique_pointer BYTE_BLOB *UP_BYTE_BLOB;
+        #ifndef _BLOB_DEFINED
+            typedef struct _BYTE_BLOB
+            {
+                unsigned long clSize;
+                unsigned char abData[ 1 ];
+            }     BYTE_BLOB;
+            typedef /* [unique] */  __RPC_unique_pointer BYTE_BLOB *UP_BYTE_BLOB;
+        #endif
         typedef LONGLONG REFERENCE_TIME;
         #define NONAMELESSUNION
     #endif


### PR DESCRIPTION
Fixed compilation with MinGW (W64) when targeting 32-bit platform by trying to detect presence of BYTE_BLOB presence with _BLOB_DEFINED define which is defined by MinGW (W64).

Fixes #354 issue.
