### PR TITLE
patest_unplug.c: change int32_t to int

### DIFF
--- a/test/patest_unplug.c
+++ b/test/patest_unplug.c
@@ -59,9 +59,9 @@
 typedef struct
 {
     short sine[TABLE_SIZE];
-    int32_t phases[MAX_CHANNELS];
-    int32_t numChannels;
-    int32_t sampsToGo;
+    int   phases[MAX_CHANNELS];
+    int   numChannels;
+    int   sampsToGo;
 }
 paTestData;
 


### PR DESCRIPTION
To prevent compiler errors and to avoid controversy over
stdint.h vs inttypes.h.

Fixes #550