### PR TITLE
paqa_devs.c: define _USE_MATH_DEFINES

### DIFF
--- a/qa/paqa_devs.c
+++ b/qa/paqa_devs.c
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include "portaudio.h"
 #include "pa_trace.h"


### PR DESCRIPTION
before including math.h

Fixes #551