### PR TITLE
alsa: Increase snprintf buffer size to fix warning

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -1280,7 +1280,7 @@ static PaError BuildDeviceList( PaAlsaHostApiRepresentation *alsaApi )
         char *cardName;
         int devIdx = -1;
         snd_ctl_t *ctl;
-        char buf[50];
+        char buf[66];
 
         snprintf( alsaCardName, sizeof (alsaCardName), "hw:%d", cardIdx );
 


### PR DESCRIPTION
Avoid compiler warning suggesting the buffer is too small:

../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c: In function 'BuildDeviceList.constprop':
../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c:1304:45: warning: '%s' directive output may be truncated writing up to 49 bytes into a region of size between 46 and 50 [-Wformat-truncation=]
             snprintf( buf, sizeof (buf), "%s%s,%d", hwPrefix, alsaCardName, devIdx );
                                             ^~                ~~~~~~~~~~~~
../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c:1304:42: note: directive argument in the range [0, 2147483647]
             snprintf( buf, sizeof (buf), "%s%s,%d", hwPrefix, alsaCardName, devIdx );
                                          ^~~~~~~~~
../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c:1304:13: note: 'snprintf' output between 3 and 65 bytes into a destination of size 50
             snprintf( buf, sizeof (buf), "%s%s,%d", hwPrefix, alsaCardName, devIdx );
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~