### PR TITLE
ALSA: fix uninitialized stream pointer in pa_linux_alsa.c

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -4616,11 +4616,13 @@ error:
 
 PaError PaAlsa_GetStreamInputCard( PaStream* s, int* card )
 {
-    PaAlsaStream *stream;
+    PaAlsaStream *stream = NULL;
     PaError result = paNoError;
     snd_pcm_info_t* pcmInfo;
 
     PA_ENSURE( GetAlsaStreamPointer( s, &stream ) );
+
+    if (stream == NULL) return paBadStreamPtr;
 
     /* XXX: More descriptive error? */
     PA_UNLESS( stream->capture.pcm, paDeviceUnavailable );
@@ -4635,11 +4637,13 @@ error:
 
 PaError PaAlsa_GetStreamOutputCard( PaStream* s, int* card )
 {
-    PaAlsaStream *stream;
+    PaAlsaStream *stream = NULL;
     PaError result = paNoError;
     snd_pcm_info_t* pcmInfo;
 
     PA_ENSURE( GetAlsaStreamPointer( s, &stream ) );
+
+    if (stream == NULL) return paBadStreamPtr;
 
     /* XXX: More descriptive error? */
     PA_UNLESS( stream->playback.pcm, paDeviceUnavailable );


### PR DESCRIPTION
Avoid compiler warning about uninitialized pointer being used by assigning NULL explicitly and testing for it.

../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c: In function 'PaAlsa_GetStreamInputCard':
../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c:4629:16: warning: 'stream' may be used uninitialized in this function [-Wmaybe-uninitialized]
     PA_ENSURE( alsa_snd_pcm_info( stream->capture.pcm, pcmInfo ) );
                ^~~~~~~~~~~~~~~~~
../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c: In function 'PaAlsa_GetStreamOutputCard':
../PortAudioLib/portaudio/src/hostapi/alsa/pa_linux_alsa.c:4648:16: warning: 'stream' may be used uninitialized in this function [-Wmaybe-uninitialized]
     PA_ENSURE( alsa_snd_pcm_info( stream->playback.pcm, pcmInfo ) );
                ^~~~~~~~~~~~~~~~~