### PR TITLE
Mac: fix uninitialized streamLatency in pa_mac_core.c

### DIFF
--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -447,11 +447,11 @@ static void DumpDeviceProperties( AudioDeviceID macCoreDeviceId,
 {
     PaError err;
     int i;
-    UInt32 propSize;
-    UInt32 deviceLatency;
-    UInt32 streamLatency;
-    UInt32 bufferFrames;
-    UInt32 safetyOffset;
+    UInt32 propSize = 0;
+    UInt32 deviceLatency = 0;
+    UInt32 streamLatency = 0;
+    UInt32 bufferFrames = 0;
+    UInt32 safetyOffset = 0;
     AudioStreamID streamIDs[128];
 
     printf("\n======= latency query : macCoreDeviceId = %d, isInput %d =======\n", (int)macCoreDeviceId, isInput );


### PR DESCRIPTION
Initializing streamLatency to silence warning about it being used uninitialized.

../PortAudioLib/portaudio/src/hostapi/coreaudio/pa_mac_core.c:537:40: warning: variable 'streamLatency' may be uninitialized when used here [-Wconditional-uninitialized]
    *fixedLatencyPtr = deviceLatency + streamLatency + safetyOffset;
                                       ^~~~~~~~~~~~~
../PortAudioLib/portaudio/src/hostapi/coreaudio/pa_mac_core.c:514:25: note: initialize the variable 'streamLatency' to silence this warning
    UInt32 streamLatency;
                        ^
                         = 0