### PR TITLE
DirectSound: fix recording in 24 bits

### DIFF
--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -2039,6 +2039,9 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         PaSampleFormat nativeInputFormats = paInt16;
         /* PaSampleFormat nativeFormats = paUInt8 | paInt16 | paInt24 | paInt32 | paFloat32; */
 
+        if (userData && *((int*)userData) == 24)
+            nativeInputFormats = paInt24;
+
         hostInputSampleFormat =
             PaUtil_SelectClosestAvailableFormat( nativeInputFormats, inputParameters->sampleFormat );
     }


### PR DESCRIPTION
fixes https://bugzilla.audacityteam.org/show_bug.cgi?id=193

I am upstreaming some old patches from Audacity: https://github.com/audacity/audacity/issues/840