### PR TITLE
- added Pa_GetVersionInfo to portaudio.def

### DIFF
--- a/build/msvc/portaudio.def
+++ b/build/msvc/portaudio.def
@@ -35,6 +35,7 @@ Pa_GetStreamReadAvailable           @31
 Pa_GetStreamWriteAvailable          @32
 Pa_GetSampleSize                    @33
 Pa_Sleep                            @34
+Pa_GetVersionInfo                   @35
 PaAsio_GetAvailableBufferSizes      @50
 PaAsio_ShowControlPanel             @51
 PaUtil_InitializeX86PlainConverters @52

--- a/cmake_support/template_portaudio.def
+++ b/cmake_support/template_portaudio.def
@@ -38,6 +38,7 @@ Pa_GetStreamReadAvailable           @31
 Pa_GetStreamWriteAvailable          @32
 Pa_GetSampleSize                    @33
 Pa_Sleep                            @34
+Pa_GetVersionInfo                   @35
 @DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_GetAvailableBufferSizes      @50
 @DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_ShowControlPanel             @51
 @DEF_EXCLUDE_X86_PLAIN_CONVERTERS@PaUtil_InitializeX86PlainConverters @52


### PR DESCRIPTION
FIXED: `build/msvc/portaudio.def` was missing Pa_GetVersionInfo so given function was not exported to the resulting DLL 