### PR TITLE
Add portaudio:: namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,7 @@ IF(NOT PA_OUTPUT_OSX_FRAMEWORK AND NOT PA_DISABLE_INSTALL)
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib)
-  INSTALL(EXPORT portaudio-targets FILE "portaudioTargets.cmake" DESTINATION "lib/cmake/portaudio")
+  INSTALL(EXPORT portaudio-targets NAMESPACE "portaudio::" FILE "portaudioTargets.cmake" DESTINATION "lib/cmake/portaudio")
   EXPORT(TARGETS ${PA_TARGETS} FILE "${PROJECT_BINARY_DIR}/cmake/portaudio/portaudioTargets.cmake")
   INSTALL(FILES "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfig.cmake"
                 "${CMAKE_BINARY_DIR}/cmake/portaudio/portaudioConfigVersion.cmake"


### PR DESCRIPTION
This PR adds a `portaudio::` namespace to `CMakeLists.txt`. I'm pasting/quoting the answer of https://stackoverflow.com/a/48526017:

The [cmake-developer documentation](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html?highlight=namespace) gives the following advice on namespaces:

> When providing imported targets, these should be namespaced (hence the `Foo::` prefix); CMake will recognize that values passed to `target_link_libraries()` that contain `::` in their name are supposed to be imported targets (rather than just library names), and will produce appropriate diagnostic messages if that target does not exist (see policy *CMP0028*).

And the [*CMP0028* policy documentation](https://cmake.org/cmake/help/latest/policy/CMP0028.html) says on the "common pattern" in the use of namespaces:

> The use of double-colons is a common pattern used to namespace `IMPORTED` targets and `ALIAS` targets. When computing the link dependencies of a target, the name of each dependency could either be a target, or a file on disk. Previously, if a target was not found with a matching name, the name was considered to refer to a file on disk. This can lead to confusing error messages if there is a typo in what should be a target name.

The maintainers of vcpkg guided me to open this PR here because it would be better to fix this upstream. https://github.com/microsoft/vcpkg/pull/18065