### PR TITLE
PA_STRINGIZE

### DIFF
--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -106,11 +106,8 @@
  */
 #define paVersion  paMakeVersionNumber(paVersionMajor, paVersionMinor, paVersionSubMinor)
 
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-
-#define PA_VERSION_STRING_ TOSTRING(paVersionMajor) "." TOSTRING(paVersionMinor) "." TOSTRING(paVersionSubMinor)
-#define PA_VERSION_TEXT_   "PortAudio V" PA_VERSION_STRING_ "-devel, revision " TOSTRING(PA_GIT_REVISION)
+#define PA_VERSION_STRING_ PA_STRINGIZE(paVersionMajor) "." PA_STRINGIZE(paVersionMinor) "." PA_STRINGIZE(paVersionSubMinor)
+#define PA_VERSION_TEXT_   "PortAudio V" PA_VERSION_STRING_ "-devel, revision " PA_STRINGIZE(PA_GIT_REVISION)
 
 int Pa_GetVersion( void )
 {
@@ -126,7 +123,7 @@ static PaVersionInfo versionInfo_ = {
     /*.versionMajor =*/ paVersionMajor,
     /*.versionMinor =*/ paVersionMinor,
     /*.versionSubMinor =*/ paVersionSubMinor,
-    /*.versionControlRevision =*/ TOSTRING(PA_GIT_REVISION),
+    /*.versionControlRevision =*/ PA_STRINGIZE(PA_GIT_REVISION),
     /*.versionText =*/ PA_VERSION_TEXT_
 };
 

--- a/src/common/pa_util.h
+++ b/src/common/pa_util.h
@@ -51,6 +51,13 @@
 
 #include "portaudio.h"
 
+/** Preprocessor Utilities
+*/
+
+#define PA_STRINGIZE_HELPER(x) #x
+#define PA_STRINGIZE(x) PA_STRINGIZE_HELPER(x)
+
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -575,7 +575,7 @@ static void PaAlsa_CloseLibrary()
             { \
                 PaUtil_SetLastHostErrorInfo( paALSA, __pa_unsure_error_id, alsa_snd_strerror( __pa_unsure_error_id ) ); \
             } \
-            PaUtil_DebugPrint( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" ); \
+            PaUtil_DebugPrint( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" ); \
             if( (code) == paUnanticipatedHostError ) \
                 PA_DEBUG(( "Host error description: %s\n", alsa_snd_strerror( __pa_unsure_error_id ) )); \
             result = (code); \

--- a/src/hostapi/asihpi/pa_linux_asihpi.c
+++ b/src/hostapi/asihpi/pa_linux_asihpi.c
@@ -175,7 +175,7 @@
         PaError paError = (expr); \
         if( UNLIKELY( paError < paNoError ) ) \
         { \
-            PA_DEBUG(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PA_DEBUG(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = paError; \
             goto error; \
         } \
@@ -186,7 +186,7 @@
     do { \
         if( UNLIKELY( (expr) == 0 ) ) \
         { \
-            PA_DEBUG(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PA_DEBUG(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = (paError); \
             goto error; \
         } \
@@ -203,7 +203,7 @@
         HPI_GetErrorText( hpiError, szError ); \
         PA_DEBUG(( "HPI error %d occurred: %s\n", hpiError, szError )); \
         /* This message will always be displayed, even if debug info is disabled */ \
-            PA_DEBUG(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PA_DEBUG(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             if( (paError) == paUnanticipatedHostError ) \
         { \
             PA_DEBUG(( "Host error description: %s\n", szError )); \

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -78,9 +78,6 @@ static char *jackErr_ = NULL;
 static const char* clientName_ = "PortAudio";
 static const char* port_regex_suffix = ":.*";
 
-#define STRINGIZE_HELPER(expr) #expr
-#define STRINGIZE(expr) STRINGIZE_HELPER(expr)
-
 /* Check PaError */
 #define ENSURE_PA(expr) \
     do { \
@@ -93,7 +90,7 @@ static const char* port_regex_suffix = ":.*";
                 if (! err ) err = "unknown error"; \
                 PaUtil_SetLastHostErrorInfo( paJACK, -1, err ); \
             } \
-            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = paErr; \
             goto error; \
         } \
@@ -109,7 +106,7 @@ static const char* port_regex_suffix = ":.*";
                 if (!err) err = "unknown error"; \
                 PaUtil_SetLastHostErrorInfo( paJACK, -1, err ); \
             } \
-            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = (code); \
             goto error; \
         } \

--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -104,7 +104,7 @@ static pthread_t mainThread_;
                 PaUtil_SetLastHostErrorInfo( paOSS, sysErr_, strerror( errno ) ); \
             } \
             \
-            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = (code); \
             goto error; \
         } \

--- a/src/os/unix/pa_unix_util.h
+++ b/src/os/unix/pa_unix_util.h
@@ -44,6 +44,7 @@
 #ifndef PA_UNIX_UTIL_H
 #define PA_UNIX_UTIL_H
 
+#include "pa_util.h"
 #include "pa_cpuload.h"
 #include <assert.h>
 #include <pthread.h>
@@ -64,14 +65,11 @@ extern "C"
 #define UNLIKELY(expr) (expr)
 #endif
 
-#define STRINGIZE_HELPER(expr) #expr
-#define STRINGIZE(expr) STRINGIZE_HELPER(expr)
-
 #define PA_UNLESS(expr, code) \
     do { \
         if( UNLIKELY( (expr) == 0 ) ) \
         { \
-            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = (code); \
             goto error; \
         } \
@@ -84,7 +82,7 @@ static PaError paUtilErr_;          /* Used with PA_ENSURE */
     do { \
         if( UNLIKELY( (paUtilErr_ = (expr)) < paNoError ) ) \
         { \
-            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" )); \
+            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = paUtilErr_; \
             goto error; \
         } \
@@ -103,7 +101,7 @@ static PaError paUtilErr_;          /* Used with PA_ENSURE */
             { \
                 PaUtil_SetLastHostErrorInfo( paALSA, paUtilErr_, strerror( paUtilErr_ ) ); \
             } \
-            PaUtil_DebugPrint( "Expression '" #expr "' failed in '" __FILE__ "', line: " STRINGIZE( __LINE__ ) "\n" ); \
+            PaUtil_DebugPrint( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" ); \
             result = paUnanticipatedHostError; \
             goto error; \
         } \


### PR DESCRIPTION
This PR unifies all "stringizing" macros in the code by introducing a single PA_STRINGIZE macro in pa_util.h