### PR TITLE
export WMME host API specific extensions in DLL symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,8 @@ if(WIN32)
     set(PORTAUDIO_PUBLIC_HEADERS "${PORTAUDIO_PUBLIC_HEADERS}" include/pa_win_wmme.h)
     target_compile_definitions(PortAudio PRIVATE PA_USE_WMME=1)
     target_link_libraries(PortAudio PRIVATE ole32 uuid)
+  else()
+    set(DEF_EXCLUDE_WMME_SYMBOLS ";")
   endif()
 
   option(WASAPI "Enable support for WASAPI" ON)

--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ PALIB = libportaudio.la
 PAINC = include/portaudio.h
 
 PA_LDFLAGS = $(LDFLAGS) $(SHARED_FLAGS) -rpath $(libdir) -no-undefined \
-	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS|PaWasapi|PaWasapiWinrt)_.*" \
+	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS|PaWasapi|PaWasapiWinrt|PaWinMME)_.*" \
 	     -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
 COMMON_OBJS = \

--- a/build/msvc/portaudio.def
+++ b/build/msvc/portaudio.def
@@ -57,3 +57,7 @@ PaWasapi_SetStreamStateHandler      @68
 PaWasapiWinrt_SetDefaultDeviceId    @67
 PaWasapiWinrt_PopulateDeviceList    @69
 PaWasapi_GetIMMDevice               @70
+PaWinMME_GetStreamInputHandleCount  @71
+PaWinMME_GetStreamInputHandle       @72
+PaWinMME_GetStreamOutputHandleCount @73
+PaWinMME_GetStreamOutputHandle      @74

--- a/cmake/portaudio.def.in
+++ b/cmake/portaudio.def.in
@@ -60,3 +60,7 @@ PaUtil_SetDebugPrintFunction        @55
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_SetDefaultDeviceId    @67
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_PopulateDeviceList    @69
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetIMMDevice               @70
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandleCount    @71
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandle         @72
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandleCount   @73
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandle        @74


### PR DESCRIPTION
This is a rebased version of #503.