### PR TITLE
CMake: extract OSS finding code to a module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,37 +272,17 @@ elseif(UNIX)
       endif()
     endif()
 
-    option(OSS "Enable support for OSS" OFF)
+    # OSS is intentionally off by default to avoid confusing users of PortAudio
+    # applications. OSS builds but there are no devices available on modern
+    # Linux systems.
+    find_package(OSS)
+    cmake_dependent_option(OSS "Enable support for OSS" OFF "OSS_FOUND" OFF)
     if(OSS)
-      # OSS has no library to link, only a header
-      find_path(OSS_INCLUDE_DIR
-        NAMES sys/soundcard.h
-        DOC "OSS include directory")
-      if(OSS_INCLUDE_DIR)
-        target_compile_definitions(PortAudio PRIVATE HAVE_SYS_SOUNDCARD_H)
-      else()
-        find_path(OSS_INCLUDE_DIR
-          NAMES linux/soundcard.h
-          DOC "OSS include directory")
-        if(OSS_INCLUDE_DIR)
-          target_compile_definitions(PortAudio PRIVATE HAVE_LINUX_SOUNDCARD_H)
-        else()
-          find_path(OSS_INCLUDE_DIR
-            NAMES machine/soundcard.h
-            DOC "OSS include directory")
-          target_compile_definitions(PortAudio PRIVATE HAVE_MACHINE_SOUNDCARD_H)
-        endif()
-      endif()
-
-      mark_as_advanced(OSS_INCLUDE_DIR)
-      if(OSS_INCLUDE_DIR)
-        message(STATUS "Found OSS: ${OSS_INCLUDE_DIR}")
-        target_include_directories(PortAudio PRIVATE "${OSS_INCLUDE_DIR}")
-        target_sources(PortAudio PRIVATE src/hostapi/oss/pa_unix_oss.c)
-        target_compile_definitions(PortAudio PRIVATE PA_USE_OSS=1)
-      else()
-        message(FATAL_ERROR "OSS NOT found. Reconfigure CMake with -DOSS=OFF to build without OSS.")
-      endif()
+      target_sources(PortAudio PRIVATE src/hostapi/oss/pa_unix_oss.c)
+      target_compile_definitions(PortAudio PRIVATE PA_USE_OSS=1)
+      target_link_libraries(PortAudio PRIVATE OSS::oss)
+      # The FindOSS.cmake module does not need to be installed like the JACK modules because it
+      # does not link any library; it only adds an include directory and compile definition.
     endif()
   endif()
 endif()

--- a/cmake/modules/FindOSS.cmake
+++ b/cmake/modules/FindOSS.cmake
@@ -1,0 +1,57 @@
+#[=======================================================================[.rst:
+FindOSS
+--------
+
+Finds the Open Sound System include directory. There is no library to link.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``OSS::oss``
+  Target for the OSS header include directory. One of the following
+  compile definitions is added to the target:
+  HAVE_SYS_SOUNDCARD_H if the header is sys/soundcard.h
+  HAVE_LINUX_SOUNDCARD_H if the header is linux/soundcard.h
+  HAVE_MACHINE_SOUNDCARD_H if the header is machine/soundcard.h
+
+#]=======================================================================]
+
+find_path(OSS_INCLUDE_DIR
+  NAMES sys/soundcard.h
+  DOC "OSS include directory")
+if(OSS_INCLUDE_DIR)
+  set(OSS_DEFINITIONS HAVE_SYS_SOUNDCARD_H)
+else()
+  find_path(OSS_INCLUDE_DIR
+    NAMES linux/soundcard.h
+    DOC "OSS include directory")
+  if(OSS_INCLUDE_DIR)
+    set(OSS_DEFINITIONS HAVE_LINUX_SOUNDCARD_H)
+  else()
+    find_path(OSS_INCLUDE_DIR
+      NAMES machine/soundcard.h
+      DOC "OSS include directory")
+    if(OSS_INCLUDE_DIR)
+      set(OSS_DEFINITIONS HAVE_MACHINE_SOUNDCARD_H)
+    endif()
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  OSS
+  DEFAULT_MSG
+  OSS_INCLUDE_DIR
+  OSS_DEFINITIONS
+)
+
+if(OSS_INCLUDE_DIR AND OSS_DEFINITIONS)
+  set(OSS_FOUND TRUE)
+  if(NOT TARGET OSS::oss)
+    add_library(OSS::oss INTERFACE IMPORTED)
+    target_include_directories(OSS::oss INTERFACE "${OSS_INCLUDE_DIR}")
+    target_compile_definitions(OSS::oss INTERFACE "${OSS_DEFINITIONS}")
+  endif()
+endif()


### PR DESCRIPTION
This makes the root CMakeLists.txt simpler and more maintanable.