### PR TITLE
JACK: add missing #include <pthread.h>

### DIFF
--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -57,6 +57,7 @@
 #include <errno.h>  /* EBUSY */
 #include <signal.h> /* sig_atomic_t */
 #include <math.h>
+#include <pthread.h>
 #include <semaphore.h>
 
 #include <jack/types.h>


### PR DESCRIPTION
This is required for building with MinGW.