### PR TITLE
JACK: use POSIX pthread_equal instead of == to compare pthread_t

### DIFF
--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -84,7 +84,7 @@ static const char* port_regex_suffix = ":.*";
         PaError paErr; \
         if( (paErr = (expr)) < paNoError ) \
         { \
-            if( (paErr) == paUnanticipatedHostError && pthread_self() == mainThread_ ) \
+            if( (paErr) == paUnanticipatedHostError && pthread_equal( pthread_self(), mainThread_ ) ) \
             { \
                 const char *err = jackErr_; \
                 if (! err ) err = "unknown error"; \
@@ -100,7 +100,7 @@ static const char* port_regex_suffix = ":.*";
     do { \
         if( (expr) == 0 ) \
         { \
-            if( (code) == paUnanticipatedHostError && pthread_self() == mainThread_ ) \
+            if( (code) == paUnanticipatedHostError && pthread_equal( pthread_self(), mainThread_ ) ) \
             { \
                 const char *err = jackErr_; \
                 if (!err) err = "unknown error"; \
@@ -695,7 +695,7 @@ static void UpdateSampleRate( PaJackStream *stream, double sampleRate )
 
 static void JackErrorCallback( const char *msg )
 {
-    if( pthread_self() == mainThread_ )
+    if( pthread_equal( pthread_self(), mainThread_ ) )
     {
         assert( msg );
         jackErr_ = realloc( jackErr_, strlen( msg ) + 1 );


### PR DESCRIPTION
pthread_t is not guaranteed to be an arithmetic type by the POSIX
standard. In pthread4w it is implemented as a struct, so ==
does not work to compare two pthread_t values.