### PR TITLE
GH Actions: run CMake build on all branches

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,6 @@
 name: CMake build
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This allows contributors to test builds on GitHub Actions on their
own repositories without needing to open a pull request first.