### PR TITLE
Remove -Werror from autotools/darwin build, enable it on CI for all platforms

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -11,6 +11,9 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Ubuntu
+    env:
+      CFLAGS: "-Werror"
+      CXXFLAGS: "-Werror"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,6 +30,7 @@ jobs:
               -DPA_USE_ASIO=ON
               -DASIO_SDK_ZIP_PATH=asiosdk.zip
               -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/i686-w64-mingw32.cmake
+            werror_flags: "-Werror"
           - name: Windows MSVC
             os: windows-latest
             install_dir: C:\portaudio
@@ -43,6 +44,7 @@ jobs:
               -DPA_USE_ASIO=ON
               -DASIO_SDK_ZIP_PATH="asiosdk.zip"
               -DCMAKE_TOOLCHAIN_FILE=D:\a\portaudio\portaudio\vcpkg\scripts\buildsystems\vcpkg.cmake
+            werror_flags: "" # TODO: use "/WX"
           - name: Windows MinGW
             os: windows-latest
             install_dir: C:\portaudio
@@ -56,6 +58,7 @@ jobs:
               -DPA_USE_ASIO=ON
               -DASIO_SDK_ZIP_PATH="asiosdk.zip"
               -DCMAKE_TOOLCHAIN_FILE=D:\a\portaudio\portaudio\vcpkg\scripts\buildsystems\vcpkg.cmake
+            werror_flags: "-Werror"
           - name: macOS Clang
             os: macOS-latest
             install_dir: ~/portaudio
@@ -64,6 +67,7 @@ jobs:
             cmake_options:
               -DCMAKE_FRAMEWORK=OFF
               -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
+            werror_flags: "-Werror"
           - name: macOS Clang framework
             os: macOS-latest
             install_dir: ~/portaudio
@@ -72,11 +76,14 @@ jobs:
             cmake_options:
               -DCMAKE_FRAMEWORK=ON
               -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
+            werror_flags: "-Werror"
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
     env:
       cmake_build_type: RelWithDebInfo
+      CFLAGS: ${{ matrix.werror_flags }}
+      CXXFLAGS: ${{ matrix.werror_flags }}
     steps:
     - name: checkout Git repository
       uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,7 @@ jobs:
             cmake_options:
               -DPA_USE_OSS=ON
               -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
+            werror_flags: "-Werror"
           - name: Ubuntu MinGW
             os: ubuntu-latest
             install_dir: ~/portaudio

--- a/configure
+++ b/configure
@@ -15866,7 +15866,7 @@ case "${host_os}" in
         $as_echo "#define PA_USE_COREAUDIO 1" >>confdefs.h
 
 
-        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated -Werror"
+        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated"
         LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices"
 
         if test "x$enable_mac_universal" = "xyes" ; then

--- a/configure.in
+++ b/configure.in
@@ -221,7 +221,7 @@ case "${host_os}" in
 
         AC_DEFINE(PA_USE_COREAUDIO,1)
 
-        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated -Werror"
+        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated"
         LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices"
 
         if test "x$enable_mac_universal" = "xyes" ; then


### PR DESCRIPTION
The `-Werror` was added very long time ago: c1e1d067d2f6b0fe184eae7ebf1fcb7b2d5ff5c7
This flag is more suitable for running on CI or during development, but encumbers downstream packaging.

cc NixOS/nixpkgs#136060