### PR TITLE
OpenSLES candidate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,16 @@ elseif(UNIX)
     target_compile_definitions(PortAudio PRIVATE PA_USE_COREAUDIO=1)
     set(PKGCONFIG_LDFLAGS_PRIVATE
       "${PKGCONFIG_LDFLAGS_PRIVATE} -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices")
+  elseif(ANDROID)
+      find_package(OpenSLES)
+      cmake_dependent_option(OPENSLES "Enable support for OpenSLES" ON OPENSLES_FOUND OFF)
+
+      if(OPENSLES)
+        target_link_libraries(PortAudio PRIVATE "${OPENSLES_LIBRARIES}")
+        set(PORTAUDIO_PUBLIC_HEADERS "${PORTAUDIO_PUBLIC_HEADERS}" include/pa_opensles.h)
+        target_sources(PortAudio PRIVATE src/hostapi/opensles/pa_opensles.c)
+        target_compile_definitions(PortAudio PRIVATE PA_USE_OPENSLES=1)
+      endif()
   else()
     # Some BSDs have a reimplementation of alsalib, so do not explicitly check for Linux.
     find_package(ALSA)

--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ PALIB = libportaudio.la
 PAINC = include/portaudio.h
 
 PA_LDFLAGS = $(LDFLAGS) $(SHARED_FLAGS) -rpath $(libdir) -no-undefined \
-	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS|PaWasapi|PaWasapiWinrt|PaWinMME)_.*" \
+	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS|PaWasapi|PaWasapiWinrt|PaWinMME|PaOpenSLES)_.*" \
 	     -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
 COMMON_OBJS = \
@@ -150,6 +150,7 @@ SRC_DIRS = \
 	src/hostapi/wasapi \
 	src/hostapi/wdmks \
 	src/hostapi/wmme \
+	src/hostapi/opensles \
 	src/os/unix \
 	src/os/win
 

--- a/cmake/modules/FindOpenSLES.cmake
+++ b/cmake/modules/FindOpenSLES.cmake
@@ -1,0 +1,36 @@
+# - Find OpenSLES
+# Find the OpenSLES includes and libraries
+#
+#  OPENSLES_INCLUDE_DIR - where to find dsound.h
+#  OPENSLES_LIBRARIES   - List of libraries when using dsound.
+#  OPENSLES_FOUND       - True if dsound found.
+
+if(OPENSLES_INCLUDE_DIR)
+  # Already in cache, be silent
+  set(OPENSLES_FIND_QUIETLY TRUE)
+else()
+  find_package(PkgConfig)
+  pkg_check_modules(PC_OPENSLES QUIET OpenSLES)
+endif(OPENSLES_INCLUDE_DIR)
+
+find_path(OPENSLES_INCLUDE_DIR SLES/OpenSLES.h
+  HINTS ${PC_OPENSLES_INCLUDE_DIR})
+
+find_library(OPENSLES_LIBRARY NAMES OpenSLES
+  HINTS ${PC_OPENSLES_LIBDIR} ${PC_OPENSLES_LIBRARY_DIRS})
+
+# Handle the QUIETLY and REQUIRED arguments and set OPENSL_FOUND to TRUE if
+# all listed variables are TRUE.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OPENSLES DEFAULT_MSG
+  OPENSLES_INCLUDE_DIR OPENSLES_LIBRARY)
+
+if(OPENSLES_FOUND)
+  set(OPENSLES_LIBRARIES ${OPENSLES_LIBRARY})
+else(OPENSLES_FOUND)
+  if (OpenSLES_FIND_REQUIRED)
+    message(FATAL_ERROR "Could NOT find OPENSLES")
+  endif()
+endif(OPENSLES_FOUND)
+
+mark_as_advanced(OPENSLES_INCLUDE_DIR OPENSLES_LIBRARY)

--- a/configure.in
+++ b/configure.in
@@ -41,6 +41,10 @@ AC_ARG_WITH(oss,
             AS_HELP_STRING([--with-oss], [Enable support for OSS @<:@autodetect@:>@]),
             [with_oss=$withval])
 
+AC_ARG_WITH(opensles,
+            AS_HELP_STRING([--with-opensles], [Enable support for OpenSLES @<:@autodetect@:>@]),
+            [with_opensles=$withval])
+
 AC_ARG_WITH(asihpi,
             AS_HELP_STRING([--with-asihpi], [Enable support for ASIHPI @<:@autodetect@:>@]),
             [with_asihpi=$withval])
@@ -144,6 +148,11 @@ fi
 have_jack=no
 if test "x$with_jack" != "xno"; then
     PKG_CHECK_MODULES(JACK, jack, have_jack=yes, have_jack=no)
+fi
+
+have_opensles=no
+if test "x$with_opensles" != "xno"; then
+   AC_CHECK_LIB(OpenSLES, slCreateEngine, have_opensles=yes, have_opensles=no)
 fi
 
 
@@ -353,6 +362,25 @@ case "${host_os}" in
         SHARED_FLAGS=""
         ;;
 
+  linux-android* )
+        dnl Android configuration, this is separate because we don't need to link pthread explicitly
+        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix"
+
+        if [[ "$have_opensles" = "yes" ] && [ "$with_opensles" != "no" ]]; then
+           LIBS="$LIBS -lOpenSLES"
+           DLL_LIBS="$DLL_LIBS -lOpenSLES"
+           OTHER_OBJS="$OTHER_OBJS src/hostapi/opensles/pa_opensles.o"
+           INCLUDES="$INCLUDES pa_opensles.h"
+           AC_DEFINE(PA_USE_OPENSLES,1)
+        fi
+
+        DLL_LIBS="$DLL_LIBS -lm"
+        LIBS="$LIBS -lm"
+        PADLL="libportaudio.so"
+
+        OTHER_OBJS="$OTHER_OBJS src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o"
+        ;;
+
   *)
         dnl Unix configuration
 
@@ -468,6 +496,11 @@ case "$target_os" in
     *darwin*)
         AC_MSG_RESULT([
   Mac debug flags ............. $enable_mac_debug
+])
+        ;;
+     *linux-androideabi*)
+        AC_MSG_RESULT([
+  OpenSLES .................... $have_opensles
 ])
         ;;
      *)

--- a/include/pa_opensles.h
+++ b/include/pa_opensles.h
@@ -1,0 +1,78 @@
+#ifndef PA_OPENSLES_H
+#define PA_OPENSLES_H
+
+/*
+ * $Id:
+ * PortAudio Portable Real-Time Audio Library
+ * Android OpenSLES-specific extensions
+ *
+ * Copyright (c) 1999-2000 Ross Bencina and Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/** @file
+ @ingroup public_header
+ @brief Android OpenSLES-specific PortAudio API extension header file.
+*/
+
+#include <SLES/OpenSLES.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** The android stream type and recording preset as defined in
+ * OpenSLES_AndroidConfiguration.h
+ */
+typedef struct PaOpenslesStreamInfo {
+    SLint32 androidPlaybackStreamType;
+    SLint32 androidRecordingPreset;
+} PaOpenslesStreamInfo;
+
+/** Provide PA OpenSLES with native buffer information. This function must be called before Pa_Initialize.
+ * To have optimal latency, this function should be called. Otherwise PA OpenSLES will use non-optimal values
+ * as default.
+ * @param bufferSize the native buffersize as returned by AudioManager's PROPERTY_OUTPUT_FRAMES_PER_BUFFER. It is recommended you set the number of buffers to 1 if API>17 as well, and use the sample rate defined in AudioManager's android.media.property.OUTPUT_SAMPLE_RATE. All three together will enable the AUDIO_OUTPUT_FLAG_FAST flag.
+ */
+void PaOpenSLES_SetNativeBufferSize( unsigned long bufferSize );
+
+/** Provide PA OpenSLES with native buffer information. This function must be called before Pa_Initialize.
+ * To have optimal latency and enable the AUDIO_OUTPUT_FLAG_FAST flag, this function should be called. Otherwise PA OpenSLES will use non-optimal values (2) as default.
+ * @param The number of buffers can be reduced to 1 on API >17. Make sure you set the native buffer size when doing this, and use the sample rate defined in AudioManager's android.media.property.OUTPUT_SAMPLE_RATE.
+ */
+void PaOpenSLES_SetNumberOfBuffers( unsigned buffers );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/common/pa_hostapi.h
+++ b/src/common/pa_hostapi.h
@@ -153,6 +153,13 @@ are defaulted to 1.
 #define PA_USE_ASIHPI 1
 #endif
 
+#ifndef PA_USE_OPENSLES
+#define PA_USE_OPENSLES 0
+#elif (PA_USE_OPENSLES != 0) && (PA_USE_OPENSLES != 1)
+#undef PA_USE_OPENSLES
+#define PA_USE_OPENSLES 1
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/hostapi/opensles/README.md
+++ b/src/hostapi/opensles/README.md
@@ -1,0 +1,38 @@
+Portaudio implementation for android using opensles.
+
+Building
+----
+To build portaudio with opensles an android NDK is needed to crosscompile it, version r9b has been used during development.
+
+TODOs
+----
+Testing, loads of it.
+
+Misc
+----
+Audio fast track:
+Opensles on android has an audio_output_fast_flag which will be automatically set when you open a device with the right parameters. When this flag is set latency will be reduced dramatically between opensles and the android HAL. The samplerate needed for the fast track flag can be queried using AudioManager's getProperty(PROPERTY_OUTPUT_SAMPLE_RATE).
+
+
+Latency:
+Default latencies and precise stream latencies are hard to calculate since these will depend on device, android version, and whether or not the audio fast track flag has been set. At the moment this implementation only takes into account the user buffers and the opensles buffers.
+
+
+Buffer sizes:
+When using portaudio opensles in an android application it is recommended to query the AudioManager's getProperty(PROPERTY_OUTPUT_FRAMES_PER_BUFFER). Using this buffer size or a multiple of this buffer size is recommended. The implementation does not have any lower bound on the framesPerBuffer argument in Pa_Openstream. This way newer devices can take advantage of improving audio latency on android.
+
+
+Querying audio capabilities:
+OpenSL ES on android does not support the OpenSL ES SLAudioIODeviceCapabilitiesItf. As a result PaOpenSLES_Initialize populates the devices with some amount of heuristics. We simply use one output/input device. And starting API 14 use the SLAndroidConfigurationItf to configure the stream type of said devices. This also means that testing for the support of a certain samplerate or amount of channels quikcly opens and closes the device and checks for errors. This is a pretty dirty way of doing this, suggestions welcomed.
+
+
+Prefetch underflow assert that fails:
+There is an assert(SL_PREFETCHSTATUS_UNDERFLOW == ap->mPrefetchStatus.mStatus) that fails (Src https://android.googlesource.com/platform/frameworks/wilhelm/+/master/src/android/AudioPlayer_to_android.cpp) sometimes with a non-blocking audio output.
+
+This is an assert which tries to make sure that the prefetchitf was in SL_PREFETCHSTATUS_UNDERFLOW, when trying to re-enqueue/restart the buffers because the user didn't enqueue buffers for a while (and the buffers underflowed). This doesn't happen when you can supply the buffer fast enough of course. But the specification states that if you stop enqueueing buffers, it should just stop playing, if you enqueue buffers again, it should start up again, and it shouldn't abort the entire application.
+
+As a result I disabled the prefetchstatus callback for now, so there is no formation available to the user whether the buffers underflowed or overflowed, but at least portaudio just keeps running.
+
+
+Number of buffers:
+As mentioned in the android opensles documentation under performance, the number of buffer sizes can be 1 on api >17

--- a/src/hostapi/opensles/README.md
+++ b/src/hostapi/opensles/README.md
@@ -1,38 +1,77 @@
-Portaudio implementation for android using opensles.
-
-Building
-----
-To build portaudio with opensles an android NDK is needed to crosscompile it, version r9b has been used during development.
-
-TODOs
-----
-Testing, loads of it.
-
-Misc
-----
-Audio fast track:
-Opensles on android has an audio_output_fast_flag which will be automatically set when you open a device with the right parameters. When this flag is set latency will be reduced dramatically between opensles and the android HAL. The samplerate needed for the fast track flag can be queried using AudioManager's getProperty(PROPERTY_OUTPUT_SAMPLE_RATE).
+# Portaudio implementation for android using opensles.
 
 
-Latency:
-Default latencies and precise stream latencies are hard to calculate since these will depend on device, android version, and whether or not the audio fast track flag has been set. At the moment this implementation only takes into account the user buffers and the opensles buffers.
+## Building
+
+The [android-ndk](https://developer.android.com/ndk/downloads) is needed to crosscompile. There are 4 Android specific cmake variables:
+```
+cmake  \
+    -DANDROID=1 \
+    -DANDROID_PLATFORM=android-21 \
+    -DANDROID_ABI=armeabi-v7a \
+    -DCMAKE_TOOLCHAIN_FILE=android-ndk/android-ndk-r[0-9]*/build/cmake/android.toolchain.cmake \
+    ..
+```
+
+- `-DANDROID=1` enables android build
+- `-DANDROID=` specifies the target android version
+- `-DANDROID_ABI=` sets the target architecture
+- `-DCMAKE_TOOLCHAIN_FILE=android-ndk/android-ndk-r[0-9]*/build/cmake/android.toolchain.cmake`
+  configures the build tools needed to compile
 
 
-Buffer sizes:
-When using portaudio opensles in an android application it is recommended to query the AudioManager's getProperty(PROPERTY_OUTPUT_FRAMES_PER_BUFFER). Using this buffer size or a multiple of this buffer size is recommended. The implementation does not have any lower bound on the framesPerBuffer argument in Pa_Openstream. This way newer devices can take advantage of improving audio latency on android.
+## Testing
 
+The PortAudio tests can be compiled as for any other platform with `-DBUILD_TESTING=1`. To execute
+them an Android device with debugging (and potentially sudo) access is required. Simply push the
+tests to a directory that allows executables (like `/data`) and call them from `adb shell`.
 
-Querying audio capabilities:
-OpenSL ES on android does not support the OpenSL ES SLAudioIODeviceCapabilitiesItf. As a result PaOpenSLES_Initialize populates the devices with some amount of heuristics. We simply use one output/input device. And starting API 14 use the SLAndroidConfigurationItf to configure the stream type of said devices. This also means that testing for the support of a certain samplerate or amount of channels quikcly opens and closes the device and checks for errors. This is a pretty dirty way of doing this, suggestions welcomed.
+Testing on a real device is by far the easiest, yet some emulators also support OpenSLES.
 
+## Notes
+#### Audio fast track:
+Opensles on android has an audio_output_fast_flag which will be automatically set when you open a
+device with the right parameters. When this flag is set latency will be reduced dramatically between
+opensles and the android HAL. The samplerate needed for the fast track flag can be queried using
+AudioManager's getProperty(PROPERTY_OUTPUT_SAMPLE_RATE).
 
-Prefetch underflow assert that fails:
-There is an assert(SL_PREFETCHSTATUS_UNDERFLOW == ap->mPrefetchStatus.mStatus) that fails (Src https://android.googlesource.com/platform/frameworks/wilhelm/+/master/src/android/AudioPlayer_to_android.cpp) sometimes with a non-blocking audio output.
+#### Latency:
+Default latencies and precise stream latencies are hard to calculate since these will depend on
+device, android version, and whether or not the audio fast track flag has been set. At the moment
+this implementation only takes into account the user buffers and the opensles buffers.
 
-This is an assert which tries to make sure that the prefetchitf was in SL_PREFETCHSTATUS_UNDERFLOW, when trying to re-enqueue/restart the buffers because the user didn't enqueue buffers for a while (and the buffers underflowed). This doesn't happen when you can supply the buffer fast enough of course. But the specification states that if you stop enqueueing buffers, it should just stop playing, if you enqueue buffers again, it should start up again, and it shouldn't abort the entire application.
+#### Buffer sizes:
+When using portaudio opensles in an android application it is recommended to query the
+AudioManager's getProperty(PROPERTY_OUTPUT_FRAMES_PER_BUFFER). Using this buffer size or a multiple
+of this buffer size is recommended. The implementation does not have any lower bound on the
+framesPerBuffer argument in Pa_Openstream. This way newer devices can take advantage of improving
+audio latency on android.
 
-As a result I disabled the prefetchstatus callback for now, so there is no formation available to the user whether the buffers underflowed or overflowed, but at least portaudio just keeps running.
+#### Querying audio capabilities:
+OpenSL ES on android does not support the OpenSL ES SLAudioIODeviceCapabilitiesItf. As a result
+PaOpenSLES_Initialize populates the devices with some amount of heuristics. We simply use one
+output/input device. And starting API 14 use the SLAndroidConfigurationItf to configure the stream
+type of said devices. This also means that testing for the support of a certain samplerate or amount
+of channels quikcly opens and closes the device and checks for errors. This is a pretty dirty way of
+doing this, suggestions welcomed.
 
+#### Prefetch underflow assert that fails:
+There is an assert(SL_PREFETCHSTATUS_UNDERFLOW == ap->mPrefetchStatus.mStatus) that fails (Src
+https://android.googlesource.com/platform/frameworks/wilhelm/+/master/src/android/AudioPlayer_to_android.cpp)
+sometimes with a non-blocking audio output.
 
-Number of buffers:
-As mentioned in the android opensles documentation under performance, the number of buffer sizes can be 1 on api >17
+This is an assert which tries to make sure that the prefetchitf was in SL_PREFETCHSTATUS_UNDERFLOW,
+when trying to re-enqueue/restart the buffers because the user didn't enqueue buffers for a while
+(and the buffers underflowed). This doesn't happen when you can supply the buffer fast enough of
+course. But the specification states that if you stop enqueueing buffers, it should just stop
+playing, if you enqueue buffers again, it should start up again, and it shouldn't abort the entire
+application.
+
+As a result the prefetchstatus callback is disabled, so there is no formation available to the user
+whether the buffers underflowed or overflowed, but at least portaudio just keeps running. [The issue
+was reported but set to won't fix](https://issuetracker.google.com/issues/37140721).
+
+#### Number of buffers
+As mentioned in the [Android OpenSLES documentation under
+performance](https://developer.android.com/ndk/guides/audio/opensl/opensl-prog-notes#perform), the
+number of buffer sizes can be 1 on api >17

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -50,6 +50,7 @@
 #include <semaphore.h>
 #include <errno.h>
 #include <math.h>
+#include <string.h>
 #include <time.h>
 
 #include <android/api-level.h>

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -690,10 +690,17 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( (streamFlags & paPlatformSpecificFlags) != 0 )
         return paInvalidFlag;
 
-    if( framesPerBuffer == paFramesPerBufferUnspecified )
-        framesPerHostBuffer = (unsigned long) (outputParameters->suggestedLatency * sampleRate);
-    else
+    if( framesPerBuffer == paFramesPerBufferUnspecified ) {
+        if( outputParameters ) {
+            framesPerHostBuffer = (unsigned long) (outputParameters->suggestedLatency * sampleRate);
+        }
+        else {
+            framesPerHostBuffer = (unsigned long) (inputParameters->suggestedLatency * sampleRate);
+        }
+    }
+    else {
         framesPerHostBuffer = framesPerBuffer;
+    }
 
     stream = (OpenslesStream*)PaUtil_AllocateMemory( sizeof(OpenslesStream) );
 
@@ -876,10 +883,10 @@ static PaError InitializeInputStream( PaOpenslesHostApiRepresentation *openslesH
                                            SL_DEFAULTDEVICEID_AUDIOINPUT, NULL};
     SLDataSource audioSrc = {&inputLocator, NULL};
 
-    SLDataFormat_PCM  formatPcm = { SL_DATAFORMAT_PCM, stream->bufferProcessor.outputChannelCount,
+    SLDataFormat_PCM  formatPcm = { SL_DATAFORMAT_PCM, stream->bufferProcessor.inputChannelCount,
                                     sampleRate * 1000.0, SL_PCMSAMPLEFORMAT_FIXED_16,
                                     SL_PCMSAMPLEFORMAT_FIXED_16,
-                                    channelMasks[stream->bufferProcessor.outputChannelCount - 1],
+                                    channelMasks[stream->bufferProcessor.inputChannelCount - 1],
                                     SL_BYTEORDER_LITTLEENDIAN };
 
     SLDataLocator_AndroidSimpleBufferQueue inputBQLocator = { SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE,

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -560,12 +560,14 @@ typedef struct OpenslesStream
     SLAndroidConfigurationItf inputConfigurationItf;
 
     SLboolean isBlocking;
-    SLboolean isStopped;
-    SLboolean isActive;
-    SLboolean doStop;
-    SLboolean doAbort;
     SLboolean hasOutput;
     SLboolean hasInput;
+
+    // Used between callback thread and main thread while it's running
+    volatile SLboolean isStopped;
+    volatile SLboolean isActive;
+    volatile SLboolean doStop;
+    volatile SLboolean doAbort;
 
     int callbackResult;
     sem_t outputSem;

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -1,0 +1,1372 @@
+/*
+ * $Id$
+ * PortAudio Portable Real-Time Audio Library
+ * Latest Version at: http://www.portaudio.com
+ *
+ * Android OpenSL ES implementation by Sanne Raymaekers
+ * Copyright (c) 2016-2017 Sanne Raymaekers <sanne.raymaekers@gmail.com>
+ *
+ * Based on the Open Source API proposed by Ross Bencina
+ * Copyright (c) 1999-2002 Ross Bencina, Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/**
+ @file
+ @ingroup hostapi_src
+ @brief opensles implementation of support for a host API.
+*/
+
+#include <pthread.h>
+#include <semaphore.h>
+#include <errno.h>
+#include <math.h>
+#include <time.h>
+
+#include <android/api-level.h>
+#include <SLES/OpenSLES.h>
+#include <SLES/OpenSLES_Android.h>
+
+#include "pa_util.h"
+#include "pa_allocation.h"
+#include "pa_hostapi.h"
+#include "pa_stream.h"
+#include "pa_cpuload.h"
+#include "pa_process.h"
+#include "pa_unix_util.h"
+#include "pa_debugprint.h"
+
+#include "pa_opensles.h"
+
+#define ENSURE(expr, errorText) \
+    do { \
+        PaError err; \
+        if( UNLIKELY( (err = (expr)) < paNoError ) ) \
+        { \
+            PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
+            PaUtil_SetLastHostErrorInfo( paInDevelopment, err, errorText ); \
+            result = err; \
+            goto error; \
+        } \
+    } while(0);
+
+static void Terminate( struct PaUtilHostApiRepresentation *hostApi );
+static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
+                                  const PaStreamParameters *inputParameters,
+                                  const PaStreamParameters *outputParameters,
+                                  double sampleRate );
+static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
+                           PaStream** s,
+                           const PaStreamParameters *inputParameters,
+                           const PaStreamParameters *outputParameters,
+                           double sampleRate,
+                           unsigned long framesPerBuffer,
+                           PaStreamFlags streamFlags,
+                           PaStreamCallback *streamCallback,
+                           void *userData );
+static PaError CloseStream( PaStream* stream );
+static PaError StartStream( PaStream *stream );
+static PaError StopStream( PaStream *stream );
+static PaError AbortStream( PaStream *stream );
+static PaError IsStreamStopped( PaStream *s );
+static PaError IsStreamActive( PaStream *stream );
+static PaTime GetStreamTime( PaStream *stream );
+static double GetStreamCpuLoad( PaStream* stream );
+static PaError ReadStream( PaStream* stream, void *buffer, unsigned long frames );
+static PaError WriteStream( PaStream* stream, const void *buffer, unsigned long frames );
+static signed long GetStreamReadAvailable( PaStream* stream );
+static signed long GetStreamWriteAvailable( PaStream* stream );
+static unsigned long GetApproximateLowBufferSize();
+
+static unsigned long nativeBufferSize = 0;
+static unsigned numberOfBuffers = 2;
+
+/*  PaOpenslesHostApiRepresentation - host api datastructure specific to this implementation */
+typedef struct
+{
+    PaUtilHostApiRepresentation inheritedHostApiRep;
+    PaUtilStreamInterface callbackStreamInterface;
+    PaUtilStreamInterface blockingStreamInterface;
+
+    PaUtilAllocationGroup *allocations;
+
+    SLObjectItf sl;
+    SLEngineItf slEngineItf;
+}
+PaOpenslesHostApiRepresentation;
+
+PaError Opensles_InitializeEngine(PaOpenslesHostApiRepresentation *openslesHostApi)
+{
+    SLresult slResult;
+    PaError result = paNoError;
+    const SLEngineOption engineOption[] = {{ SL_ENGINEOPTION_THREADSAFE, SL_BOOLEAN_TRUE }};
+
+    slResult = slCreateEngine( &openslesHostApi->sl , 1, engineOption, 0, NULL, NULL);
+    result = slResult == SL_RESULT_SUCCESS ? paNoError : paUnanticipatedHostError;
+    if( result != paNoError ) goto error;
+
+    slResult = (*openslesHostApi->sl)->Realize( openslesHostApi->sl, SL_BOOLEAN_FALSE );
+    result = slResult == SL_RESULT_SUCCESS ? paNoError : paUnanticipatedHostError;
+    if( result != paNoError ) goto error;
+
+    slResult = (*openslesHostApi->sl)->GetInterface( openslesHostApi->sl, SL_IID_ENGINE,
+                                                     (void *) &openslesHostApi->slEngineItf );
+    result = slResult == SL_RESULT_SUCCESS ? paNoError : paUnanticipatedHostError;
+error:
+    return result;
+}
+
+/* expects samplerate to be in milliHertz */
+static PaError IsOutputSampleRateSupported(PaOpenslesHostApiRepresentation *openslesHostApi, double sampleRate)
+{
+    SLresult slResult;
+    SLObjectItf audioPlayer;
+    SLObjectItf outputMixObject;
+
+    (*openslesHostApi->slEngineItf)->CreateOutputMix( openslesHostApi->slEngineItf,
+                                                      &outputMixObject, 0, NULL, NULL );
+    (*outputMixObject)->Realize( outputMixObject, SL_BOOLEAN_FALSE );
+
+    SLDataLocator_OutputMix outputLocator = { SL_DATALOCATOR_OUTPUTMIX, outputMixObject };
+    SLDataSink audioSink = { &outputLocator, NULL };
+    SLDataLocator_AndroidSimpleBufferQueue outputBQLocator = { SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, 2 };
+    SLDataFormat_PCM  formatPcm = { SL_DATAFORMAT_PCM, 1, sampleRate,
+                                     SL_PCMSAMPLEFORMAT_FIXED_16, SL_PCMSAMPLEFORMAT_FIXED_16,
+                                     SL_SPEAKER_FRONT_CENTER, SL_BYTEORDER_LITTLEENDIAN };
+    SLDataSource audioSrc = { &outputBQLocator, &formatPcm };
+
+    slResult = (*openslesHostApi->slEngineItf)->CreateAudioPlayer( openslesHostApi->slEngineItf,
+                                                                   &audioPlayer, &audioSrc,
+                                                                   &audioSink, 0, NULL, NULL );
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+        (*outputMixObject)->Destroy( outputMixObject );
+        return paInvalidSampleRate;
+    }
+    else
+    {
+        (*audioPlayer)->Destroy( audioPlayer );
+        (*outputMixObject)->Destroy( outputMixObject );
+        return paNoError;
+    }
+}
+
+/* expects samplerate to be in milliHertz */
+static PaError IsInputSampleRateSupported(PaOpenslesHostApiRepresentation *openslesHostApi, double sampleRate)
+{
+    SLresult slResult;
+    SLObjectItf audioRecorder;
+
+    SLDataLocator_IODevice inputLocator = {SL_DATALOCATOR_IODEVICE,
+                                           SL_IODEVICE_AUDIOINPUT,
+                                           SL_DEFAULTDEVICEID_AUDIOINPUT, NULL};
+    SLDataSource audioSrc = {&inputLocator, NULL};
+    SLDataLocator_AndroidSimpleBufferQueue inputBQLocator = {SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, 2};
+    SLDataFormat_PCM formatPcm = {SL_DATAFORMAT_PCM, 1, sampleRate,
+                                  SL_PCMSAMPLEFORMAT_FIXED_16, SL_PCMSAMPLEFORMAT_FIXED_16,
+                                  SL_SPEAKER_FRONT_CENTER, SL_BYTEORDER_LITTLEENDIAN};
+    SLDataSink audioSink = {&inputBQLocator, &formatPcm};
+
+    slResult = (*openslesHostApi->slEngineItf)->CreateAudioRecorder(openslesHostApi->slEngineItf,
+                                                                    &audioRecorder, &audioSrc,
+                                                                    &audioSink, 0, NULL, NULL);
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+        return paInvalidSampleRate;
+    }
+    else
+    {
+        (*audioRecorder)->Destroy( audioRecorder );
+        return paNoError;
+    }
+}
+
+static PaError IsOutputChannelCountSupported(PaOpenslesHostApiRepresentation *openslesHostApi, SLuint32 numOfChannels)
+{
+
+    if( numOfChannels > 2 || numOfChannels == 0 )
+        return paInvalidChannelCount;
+
+    SLresult slResult;
+    SLObjectItf audioPlayer;
+    SLObjectItf outputMixObject;
+    const SLuint32 channelMasks[] = { SL_SPEAKER_FRONT_CENTER, SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT };
+
+    (*openslesHostApi->slEngineItf)->CreateOutputMix( openslesHostApi->slEngineItf, &outputMixObject, 0, NULL, NULL );
+    (*outputMixObject)->Realize( outputMixObject, SL_BOOLEAN_FALSE );
+
+    SLDataLocator_OutputMix outputLocator = { SL_DATALOCATOR_OUTPUTMIX, outputMixObject };
+    SLDataSink audioSink = { &outputLocator, NULL };
+    SLDataLocator_AndroidSimpleBufferQueue outputBQLocator = { SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, 2 };
+    SLDataFormat_PCM  formatPcm = { SL_DATAFORMAT_PCM, numOfChannels, SL_SAMPLINGRATE_16,
+                                     SL_PCMSAMPLEFORMAT_FIXED_16, SL_PCMSAMPLEFORMAT_FIXED_16,
+                                     channelMasks[numOfChannels - 1], SL_BYTEORDER_LITTLEENDIAN };
+    SLDataSource audioSrc = { &outputBQLocator, &formatPcm };
+
+    slResult = (*openslesHostApi->slEngineItf)->CreateAudioPlayer( openslesHostApi->slEngineItf,
+                                                                   &audioPlayer, &audioSrc,
+                                                                   &audioSink, 0, NULL, NULL );
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+        (*outputMixObject)->Destroy( outputMixObject );
+        return paInvalidChannelCount;
+    }
+    else
+    {
+        (*audioPlayer)->Destroy( audioPlayer );
+        (*outputMixObject)->Destroy( outputMixObject );
+        return paNoError;
+    }
+}
+
+static PaError IsInputChannelCountSupported(PaOpenslesHostApiRepresentation *openslesHostApi, SLuint32 numOfChannels)
+{
+    SLresult slResult;
+    SLObjectItf audioRecorder;
+    const SLuint32 channelMasks[] = { SL_SPEAKER_FRONT_CENTER, SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT };
+
+    SLDataLocator_IODevice inputLocator = {SL_DATALOCATOR_IODEVICE,
+                                           SL_IODEVICE_AUDIOINPUT,
+                                           SL_DEFAULTDEVICEID_AUDIOINPUT, NULL};
+    SLDataSource audioSrc = {&inputLocator, NULL};
+
+    SLDataLocator_AndroidSimpleBufferQueue inputBQLocator = {SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, 2};
+    SLDataFormat_PCM formatPcm = {SL_DATAFORMAT_PCM, numOfChannels, SL_SAMPLINGRATE_16,
+                                  SL_PCMSAMPLEFORMAT_FIXED_16, SL_PCMSAMPLEFORMAT_FIXED_16,
+                                  channelMasks[numOfChannels - 1], SL_BYTEORDER_LITTLEENDIAN};
+    SLDataSink audioSink = {&inputBQLocator, &formatPcm};
+
+    slResult = (*openslesHostApi->slEngineItf)->CreateAudioRecorder(openslesHostApi->slEngineItf,
+                                                                    &audioRecorder, &audioSrc,
+                                                                    &audioSink, 0, NULL, NULL);
+
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+
+        return paInvalidChannelCount;
+    }
+    else
+    {
+        (*audioRecorder)->Destroy( audioRecorder );
+        return paNoError;
+    }
+}
+
+PaError PaOpenSLES_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex )
+{
+    PaError result = paNoError;
+    int i, deviceCount;
+    PaOpenslesHostApiRepresentation *openslesHostApi;
+    PaDeviceInfo *deviceInfoArray;
+
+    openslesHostApi = (PaOpenslesHostApiRepresentation*)PaUtil_AllocateMemory( sizeof(PaOpenslesHostApiRepresentation) );
+    if( !openslesHostApi )
+    {
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    openslesHostApi->allocations = PaUtil_CreateAllocationGroup();
+    if( !openslesHostApi->allocations )
+    {
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    *hostApi = &openslesHostApi->inheritedHostApiRep;
+    (*hostApi)->info.structVersion = 1;
+    (*hostApi)->info.type = paInDevelopment;
+    (*hostApi)->info.name = "android OpenSLES";
+    (*hostApi)->info.defaultOutputDevice = 0;
+    (*hostApi)->info.defaultInputDevice = 0;
+    (*hostApi)->info.deviceCount = 0;
+
+    ENSURE( Opensles_InitializeEngine(openslesHostApi), "Initializing engine failed" );
+
+    deviceCount = 1;
+    (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+        openslesHostApi->allocations, sizeof(PaDeviceInfo*) * deviceCount );
+
+    if( !(*hostApi)->deviceInfos )
+    {
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    /* allocate all device info structs in a contiguous block */
+    deviceInfoArray = (PaDeviceInfo*)PaUtil_GroupAllocateMemory(
+        openslesHostApi->allocations, sizeof(PaDeviceInfo) * deviceCount );
+    if( !deviceInfoArray )
+    {
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    for( i=0; i < deviceCount; ++i )
+    {
+        PaDeviceInfo *deviceInfo = &deviceInfoArray[i];
+        deviceInfo->structVersion = 2;
+        deviceInfo->hostApi = hostApiIndex;
+        /* android selects it's own device, so we'll just expose a default device */
+        deviceInfo->name = "default";
+
+        const SLuint32 channelsToTry[] = { 2, 1 };
+        const SLuint32 channelsToTryLength = 2;
+        deviceInfo->maxOutputChannels = 0;
+        deviceInfo->maxInputChannels = 0;
+        for( i = 0; i < channelsToTryLength; ++i )
+        {
+            if( IsOutputChannelCountSupported(openslesHostApi, channelsToTry[i]) == paNoError )
+            {
+                deviceInfo->maxOutputChannels = channelsToTry[i];
+                break;
+            }
+        }
+        for( i = 0; i < channelsToTryLength; ++i )
+        {
+            if( IsInputChannelCountSupported(openslesHostApi, channelsToTry[i]) == paNoError )
+            {
+                deviceInfo->maxInputChannels = channelsToTry[i];
+                break;
+            }
+        }
+
+        /* check samplerates in order of preference */
+        const SLuint32 sampleRates[] = { SL_SAMPLINGRATE_48, SL_SAMPLINGRATE_44_1,
+                                         SL_SAMPLINGRATE_32, SL_SAMPLINGRATE_24,
+                                         SL_SAMPLINGRATE_16};
+        const SLuint32 numberOfSampleRates = 5;
+        deviceInfo->defaultSampleRate = 0;
+        for( i = 0; i < numberOfSampleRates; ++i )
+        {
+            if( IsOutputSampleRateSupported(openslesHostApi, sampleRates[i]) == paNoError
+                && IsInputSampleRateSupported(openslesHostApi, sampleRates[i]) == paNoError )
+            {
+                /* opensl defines sampling rates in milliHertz, so we divide by 1000 */
+                deviceInfo->defaultSampleRate = sampleRates[i] / 1000;
+                break;
+            }
+        }
+        if( deviceInfo->defaultSampleRate == 0 )
+            goto error;
+
+        /* If the user has set nativeBufferSize by querying the optimal buffer size via java,
+         * use the user-defined value since that will offer the lowest possible latency
+         */
+        if( nativeBufferSize != 0 )
+        {
+            deviceInfo->defaultLowInputLatency = (double) nativeBufferSize / deviceInfo->defaultSampleRate;
+            deviceInfo->defaultLowOutputLatency = (double) nativeBufferSize / deviceInfo->defaultSampleRate;
+            deviceInfo->defaultHighInputLatency = (double) nativeBufferSize * 4 / deviceInfo->defaultSampleRate;
+            deviceInfo->defaultHighOutputLatency = (double) nativeBufferSize * 4 / deviceInfo->defaultSampleRate;
+        }
+        else
+        {
+            deviceInfo->defaultLowInputLatency = (double) GetApproximateLowBufferSize() / deviceInfo->defaultSampleRate;
+            deviceInfo->defaultLowOutputLatency = (double) GetApproximateLowBufferSize() / deviceInfo->defaultSampleRate;
+            deviceInfo->defaultHighInputLatency = (double) GetApproximateLowBufferSize() * 4 / deviceInfo->defaultSampleRate;
+            deviceInfo->defaultHighOutputLatency = (double) GetApproximateLowBufferSize() * 4 / deviceInfo->defaultSampleRate;
+        }
+
+        (*hostApi)->deviceInfos[i] = deviceInfo;
+        ++(*hostApi)->info.deviceCount;
+
+    }
+
+    (*hostApi)->Terminate = Terminate;
+    (*hostApi)->OpenStream = OpenStream;
+    (*hostApi)->IsFormatSupported = IsFormatSupported;
+
+    PaUtil_InitializeStreamInterface( &openslesHostApi->callbackStreamInterface, CloseStream, StartStream,
+                                      StopStream, AbortStream, IsStreamStopped, IsStreamActive,
+                                      GetStreamTime, GetStreamCpuLoad,
+                                      PaUtil_DummyRead, PaUtil_DummyWrite,
+                                      PaUtil_DummyGetReadAvailable, PaUtil_DummyGetWriteAvailable );
+
+    PaUtil_InitializeStreamInterface( &openslesHostApi->blockingStreamInterface, CloseStream, StartStream,
+                                      StopStream, AbortStream, IsStreamStopped, IsStreamActive,
+                                      GetStreamTime, PaUtil_DummyGetCpuLoad,
+                                      ReadStream, WriteStream, GetStreamReadAvailable, GetStreamWriteAvailable );
+
+    return result;
+
+error:
+    if( openslesHostApi )
+    {
+        if( openslesHostApi->allocations )
+        {
+            PaUtil_FreeAllAllocations( openslesHostApi->allocations );
+            PaUtil_DestroyAllocationGroup( openslesHostApi->allocations );
+        }
+
+        PaUtil_FreeMemory( openslesHostApi );
+    }
+    return result;
+}
+
+static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
+{
+    PaOpenslesHostApiRepresentation *openslesHostApi = (PaOpenslesHostApiRepresentation*)hostApi;
+
+    if( openslesHostApi->sl )
+    {
+        (*openslesHostApi->sl)->Destroy(openslesHostApi->sl);
+    }
+
+    if( openslesHostApi->allocations )
+    {
+        PaUtil_FreeAllAllocations( openslesHostApi->allocations );
+        PaUtil_DestroyAllocationGroup( openslesHostApi->allocations );
+    }
+
+    PaUtil_FreeMemory( openslesHostApi );
+}
+
+static PaError IsFormatSupported( struct PaUtilHostApiRepresentation *hostApi,
+                                  const PaStreamParameters *inputParameters,
+                                  const PaStreamParameters *outputParameters,
+                                  double sampleRate )
+{
+    int inputChannelCount, outputChannelCount;
+    PaSampleFormat inputSampleFormat, outputSampleFormat;
+    PaOpenslesHostApiRepresentation *openslesHostApi = (PaOpenslesHostApiRepresentation*) hostApi;
+
+    if( inputParameters )
+    {
+        inputChannelCount = inputParameters->channelCount;
+        inputSampleFormat = inputParameters->sampleFormat;
+
+        if( inputSampleFormat & paCustomFormat )
+            return paSampleFormatNotSupported;
+
+        if( inputParameters->device == paUseHostApiSpecificDeviceSpecification )
+            return paInvalidDevice;
+
+        if( inputChannelCount > hostApi->deviceInfos[ inputParameters->device ]->maxInputChannels )
+            return paInvalidChannelCount;
+
+        if( inputParameters->hostApiSpecificStreamInfo )
+        {
+#if __ANDROID_API__ >= 14
+            SLint32 androidRecordingPreset = ( (PaOpenslesStreamInfo*)outputParameters->hostApiSpecificStreamInfo )->androidRecordingPreset;
+            if( androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_NONE
+                && androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_GENERIC
+                && androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_CAMCORDER
+                && androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION )
+                return paIncompatibleHostApiSpecificStreamInfo;
+#endif
+        }
+    }
+    else
+    {
+        inputChannelCount = 0;
+    }
+
+    if( outputParameters )
+    {
+        outputChannelCount = outputParameters->channelCount;
+        outputSampleFormat = outputParameters->sampleFormat;
+
+        if( outputSampleFormat & paCustomFormat )
+            return paSampleFormatNotSupported;
+
+        if( outputParameters->device == paUseHostApiSpecificDeviceSpecification )
+            return paInvalidDevice;
+
+        if( outputChannelCount > hostApi->deviceInfos[ outputParameters->device ]->maxOutputChannels )
+            return paInvalidChannelCount;
+
+        if( outputParameters->hostApiSpecificStreamInfo )
+        {
+#if __ANDROID_API__ >= 14
+            SLint32 androidPlaybackStreamType = ( (PaOpenslesStreamInfo*)outputParameters->hostApiSpecificStreamInfo )->androidPlaybackStreamType;
+            if( androidPlaybackStreamType != SL_ANDROID_STREAM_VOICE
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_SYSTEM
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_RING
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_MEDIA
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_ALARM
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_NOTIFICATION )
+                return paIncompatibleHostApiSpecificStreamInfo;
+#endif
+        }
+    }
+    else
+    {
+        outputChannelCount = 0;
+    }
+
+    if( outputChannelCount > 0 )
+    {
+        if( IsOutputSampleRateSupported( openslesHostApi, sampleRate * 1000 ) != paNoError )
+            return paInvalidSampleRate;
+    }
+    if( inputChannelCount > 0 )
+    {
+        if( IsInputSampleRateSupported( openslesHostApi, sampleRate * 1000 ) != paNoError )
+            return paInvalidSampleRate;
+    }
+
+    return paFormatIsSupported;
+}
+
+typedef struct OpenslesStream
+{
+    PaUtilStreamRepresentation streamRepresentation;
+    PaUtilCpuLoadMeasurer cpuLoadMeasurer;
+    PaUtilBufferProcessor bufferProcessor;
+
+    SLObjectItf audioPlayer;
+    SLObjectItf outputMixObject;
+    SLPlayItf playerItf;
+    SLAndroidSimpleBufferQueueItf outputBufferQueueItf;
+    /* SLPrefetchStatusItf prefetchStatusItf; */
+    SLVolumeItf volumeItf;
+    SLAndroidConfigurationItf outputConfigurationItf;
+
+    SLObjectItf audioRecorder;
+    SLRecordItf recorderItf;
+    SLAndroidSimpleBufferQueueItf inputBufferQueueItf;
+    SLAndroidConfigurationItf inputConfigurationItf;
+
+    SLboolean isBlocking;
+    SLboolean isStopped;
+    SLboolean isActive;
+    SLboolean doStop;
+    SLboolean doAbort;
+    SLboolean hasOutput;
+    SLboolean hasInput;
+
+    int callbackResult;
+    sem_t outputSem;
+    sem_t inputSem;
+
+    PaStreamCallbackFlags cbFlags;
+    PaUnixThread streamThread;
+
+    void **outputBuffers;
+    int currentOutputBuffer;
+    void **inputBuffers;
+    int currentInputBuffer;
+
+    unsigned long framesPerHostCallback;
+    unsigned bytesPerFrame;
+}
+OpenslesStream;
+
+static PaError InitializeOutputStream( PaOpenslesHostApiRepresentation *openslesHostApi, OpenslesStream *stream,
+                                       SLint32 androidPlaybackStreamType, double sampleRate );
+static PaError InitializeInputStream( PaOpenslesHostApiRepresentation *openslesHostApi, OpenslesStream *stream,
+                                      SLint32 androidRecordingPreset, double sampleRate );
+static void StreamProcessingCallback( void *userData );
+static void NotifyBufferFreeCallback( SLAndroidSimpleBufferQueueItf bufferQueueItf, void *userData );
+/* static void PrefetchStatusCallback( SLPrefetchStatusItf prefetchStatusItf, void *userData, SLuint32 event ); */
+
+static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
+                           PaStream** s,
+                           const PaStreamParameters *inputParameters,
+                           const PaStreamParameters *outputParameters,
+                           double sampleRate,
+                           unsigned long framesPerBuffer,
+                           PaStreamFlags streamFlags,
+                           PaStreamCallback *streamCallback,
+                           void *userData )
+{
+    PaError result = paNoError;
+    PaOpenslesHostApiRepresentation *openslesHostApi = (PaOpenslesHostApiRepresentation*)hostApi;
+    OpenslesStream *stream = 0;
+    unsigned long framesPerHostBuffer; /* these may not be equivalent for all implementations */
+    int inputChannelCount, outputChannelCount;
+    PaSampleFormat inputSampleFormat, outputSampleFormat;
+    PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
+#if __ANDROID_API__ >= 14
+    SLint32 androidPlaybackStreamType = SL_ANDROID_STREAM_MEDIA;
+    SLint32 androidRecordingPreset = SL_ANDROID_RECORDING_PRESET_GENERIC;
+#else
+    SLint32 androidPlaybackStreamType = -1;
+    SLint32 androidRecordingPreset = -1;
+#endif
+
+    if( inputParameters )
+    {
+        inputChannelCount = inputParameters->channelCount;
+        inputSampleFormat = inputParameters->sampleFormat;
+
+        if( inputParameters->device == paUseHostApiSpecificDeviceSpecification )
+            return paInvalidDevice;
+
+        /* check that input device can support inputChannelCount */
+        if( inputChannelCount > hostApi->deviceInfos[ inputParameters->device ]->maxInputChannels )
+            return paInvalidChannelCount;
+
+        /* validate inputStreamInfo */
+        if( inputParameters->hostApiSpecificStreamInfo )
+        {
+#if __ANDROID_API__ >= 14
+            androidRecordingPreset = ( (PaOpenslesStreamInfo*)outputParameters->hostApiSpecificStreamInfo )->androidRecordingPreset;
+            if( androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_NONE
+                && androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_GENERIC
+                && androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_CAMCORDER
+                && androidRecordingPreset != SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION )
+                return paIncompatibleHostApiSpecificStreamInfo;
+#endif
+        }
+
+        hostInputSampleFormat = PaUtil_SelectClosestAvailableFormat( paInt16, inputSampleFormat );
+    }
+    else
+    {
+        inputChannelCount = 0;
+        inputSampleFormat = hostInputSampleFormat = paInt16; /* Surpress 'uninitialised var' warnings. */
+    }
+
+    if( outputParameters )
+    {
+        outputChannelCount = outputParameters->channelCount;
+        outputSampleFormat = outputParameters->sampleFormat;
+
+        if( outputParameters->device == paUseHostApiSpecificDeviceSpecification )
+            return paInvalidDevice;
+
+        /* check that output device can support inputChannelCount */
+        if( outputChannelCount > hostApi->deviceInfos[ outputParameters->device ]->maxOutputChannels )
+            return paInvalidChannelCount;
+
+        /* validate outputStreamInfo */
+        if( outputParameters->hostApiSpecificStreamInfo )
+        {
+#if __ANDROID_API__ >= 14
+            androidPlaybackStreamType = ( (PaOpenslesStreamInfo*)outputParameters->hostApiSpecificStreamInfo )->androidPlaybackStreamType;
+            if( androidPlaybackStreamType != SL_ANDROID_STREAM_VOICE
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_SYSTEM
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_RING
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_MEDIA
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_ALARM
+                && androidPlaybackStreamType != SL_ANDROID_STREAM_NOTIFICATION )
+                return paIncompatibleHostApiSpecificStreamInfo;
+#endif
+        }
+
+        if( IsOutputSampleRateSupported( openslesHostApi, sampleRate * 1000 ) != paNoError )
+            return paInvalidSampleRate;
+
+        hostOutputSampleFormat = PaUtil_SelectClosestAvailableFormat( paInt16, outputSampleFormat );
+    }
+    else
+    {
+        outputChannelCount = 0;
+        outputSampleFormat = hostOutputSampleFormat = paInt16;
+    }
+
+    /* validate platform specific flags */
+    if( (streamFlags & paPlatformSpecificFlags) != 0 )
+        return paInvalidFlag;
+
+    if( framesPerBuffer == paFramesPerBufferUnspecified )
+        framesPerHostBuffer = (unsigned long) (outputParameters->suggestedLatency * sampleRate);
+    else
+        framesPerHostBuffer = framesPerBuffer;
+
+    stream = (OpenslesStream*)PaUtil_AllocateMemory( sizeof(OpenslesStream) );
+
+    if( !stream )
+    {
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    if( streamCallback )
+    {
+        PaUtil_InitializeStreamRepresentation( &stream->streamRepresentation,
+                                               &openslesHostApi->callbackStreamInterface, streamCallback, userData );
+    }
+    else
+    {
+        PaUtil_InitializeStreamRepresentation( &stream->streamRepresentation,
+                                               &openslesHostApi->blockingStreamInterface, streamCallback, userData );
+    }
+
+    PaUtil_InitializeCpuLoadMeasurer( &stream->cpuLoadMeasurer, sampleRate );
+
+    result =  PaUtil_InitializeBufferProcessor( &stream->bufferProcessor,
+              inputChannelCount, inputSampleFormat, hostInputSampleFormat,
+              outputChannelCount, outputSampleFormat, hostOutputSampleFormat,
+              sampleRate, streamFlags, framesPerBuffer,
+              framesPerHostBuffer, paUtilFixedHostBufferSize,
+              streamCallback, userData );
+    if( result != paNoError )
+        goto error;
+
+    stream->streamRepresentation.streamInfo.sampleRate = sampleRate;
+    stream->isBlocking = streamCallback ? SL_BOOLEAN_FALSE : SL_BOOLEAN_TRUE;
+    stream->framesPerHostCallback = framesPerHostBuffer;
+    stream->bytesPerFrame = sizeof(SLint16);
+    stream->cbFlags = 0;
+    stream->isStopped = SL_BOOLEAN_TRUE;
+    stream->isActive = SL_BOOLEAN_FALSE;
+
+    if( !stream->isBlocking )
+        PaUnixThreading_Initialize();
+
+    if( inputChannelCount > 0 )
+    {
+        stream->hasInput = SL_BOOLEAN_TRUE;
+        stream->streamRepresentation.streamInfo.inputLatency =
+            ((PaTime)PaUtil_GetBufferProcessorInputLatencyFrames(&stream->bufferProcessor)
+             + stream->framesPerHostCallback) / sampleRate;
+        ENSURE( InitializeInputStream( openslesHostApi, stream, androidRecordingPreset, sampleRate ),
+                "Initializing inputstream failed" );
+    }
+    else
+        stream->hasInput = SL_BOOLEAN_FALSE;
+
+    if( outputChannelCount > 0 )
+    {
+        stream->hasOutput = SL_BOOLEAN_TRUE;
+        stream->streamRepresentation.streamInfo.outputLatency =
+            ((PaTime)PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor)
+             + stream->framesPerHostCallback) / sampleRate;
+        ENSURE( InitializeOutputStream( openslesHostApi, stream, androidPlaybackStreamType, sampleRate ),
+                "Initializing outputstream failed" );
+    }
+    else
+        stream->hasOutput = SL_BOOLEAN_FALSE;
+
+    *s = (PaStream*)stream;
+    return result;
+
+error:
+    if( stream )
+        PaUtil_FreeMemory( stream );
+    return result;
+}
+
+static PaError InitializeOutputStream(PaOpenslesHostApiRepresentation *openslesHostApi, OpenslesStream *stream, SLint32 androidPlaybackStreamType, double sampleRate)
+{
+    PaError result = paNoError;
+    SLresult slResult;
+    int i, j;
+    const SLuint32 channelMasks[] = { SL_SPEAKER_FRONT_CENTER, SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT };
+    SLDataLocator_AndroidSimpleBufferQueue outputBQLocator = { SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, numberOfBuffers };
+    SLDataFormat_PCM  formatPcm = { SL_DATAFORMAT_PCM, stream->bufferProcessor.outputChannelCount,
+                                    sampleRate * 1000.0, SL_PCMSAMPLEFORMAT_FIXED_16, SL_PCMSAMPLEFORMAT_FIXED_16,
+                                    channelMasks[stream->bufferProcessor.outputChannelCount - 1], SL_BYTEORDER_LITTLEENDIAN };
+    SLDataSource audioSrc = { &outputBQLocator, &formatPcm };
+
+    (*openslesHostApi->slEngineItf)->CreateOutputMix( openslesHostApi->slEngineItf, &stream->outputMixObject, 0, NULL, NULL );
+    (*stream->outputMixObject)->Realize( stream->outputMixObject, SL_BOOLEAN_FALSE );
+    SLDataLocator_OutputMix outputLocator = { SL_DATALOCATOR_OUTPUTMIX, stream->outputMixObject };
+    SLDataSink audioSink = { &outputLocator, &formatPcm };
+
+    if( !stream->isBlocking )
+    {
+        const SLInterfaceID ids[] = { SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_VOLUME, SL_IID_ANDROIDCONFIGURATION };
+        const SLboolean req[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
+        const unsigned interfaceCount = 3;
+        slResult = (*openslesHostApi->slEngineItf)->CreateAudioPlayer(openslesHostApi->slEngineItf, &stream->audioPlayer,
+                                                                      &audioSrc, &audioSink, interfaceCount, ids, req);
+    }
+    else
+    {
+        const SLInterfaceID ids[] = { SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_VOLUME, SL_IID_ANDROIDCONFIGURATION };
+        const SLboolean req[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
+        const unsigned interfaceCount = 3;
+        slResult = (*openslesHostApi->slEngineItf)->CreateAudioPlayer( openslesHostApi->slEngineItf, &stream->audioPlayer,
+                                                                       &audioSrc, &audioSink, interfaceCount, ids, req );
+    }
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+        (*stream->outputMixObject)->Destroy( stream->outputMixObject );
+        result = paUnanticipatedHostError;
+        goto error;
+    }
+
+#if __ANDROID_API__ >= 14
+    (*stream->audioPlayer)->GetInterface( stream->audioPlayer, SL_IID_ANDROIDCONFIGURATION, &stream->outputConfigurationItf );
+    (*stream->outputConfigurationItf)->SetConfiguration( stream->outputConfigurationItf, SL_ANDROID_KEY_STREAM_TYPE,
+                                                   &androidPlaybackStreamType, sizeof(androidPlaybackStreamType) );
+#endif
+
+    slResult = (*stream->audioPlayer)->Realize( stream->audioPlayer, SL_BOOLEAN_FALSE );
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+        (*stream->audioPlayer)->Destroy( stream->audioPlayer );
+        (*stream->outputMixObject)->Destroy( stream->outputMixObject );
+        result = paUnanticipatedHostError;
+        goto error;
+    }
+
+    (*stream->audioPlayer)->GetInterface( stream->audioPlayer, SL_IID_PLAY, &stream->playerItf );
+    (*stream->audioPlayer)->GetInterface( stream->audioPlayer, SL_IID_ANDROIDSIMPLEBUFFERQUEUE, &stream->outputBufferQueueItf );
+    (*stream->audioPlayer)->GetInterface( stream->audioPlayer, SL_IID_VOLUME, &stream->volumeItf );
+
+    stream->outputBuffers = (void **) PaUtil_AllocateMemory( numberOfBuffers * sizeof(SLint16 *) );
+    for( i = 0; i < numberOfBuffers; ++i )
+    {
+        stream->outputBuffers[i] = (void*) PaUtil_AllocateMemory( stream->framesPerHostCallback * stream->bytesPerFrame
+                                                                  * stream->bufferProcessor.outputChannelCount );
+        if( !stream->outputBuffers[i] )
+        {
+            for( j = 0; j < i; ++j )
+                PaUtil_FreeMemory( stream->outputBuffers[j] );
+            PaUtil_FreeMemory( stream->outputBuffers );
+            (*stream->audioPlayer)->Destroy( stream->audioPlayer );
+            (*stream->outputMixObject)->Destroy( stream->outputMixObject );
+            result = paInsufficientMemory;
+            goto error;
+        }
+    }
+    stream->currentOutputBuffer = 0;
+
+    if( !stream->isBlocking )
+    {
+        /* (*stream->audioPlayer)->GetInterface( stream->audioPlayer, SL_IID_PREFETCHSTATUS, &stream->prefetchStatusItf );
+         * (*stream->prefetchStatusItf)->SetCallbackEventsMask( stream->prefetchStatusItf,
+         *                                                      SL_PREFETCHEVENT_STATUSCHANGE );
+         * (*stream->prefetchStatusItf)->SetFillUpdatePeriod( stream->prefetchStatusItf, 200 );
+         * Disabled this for now, because the stream gets aborted from android_audioPlayer_bufferQueue_onRefilled_l
+         * (*stream->prefetchStatusItf)->RegisterCallback( stream->prefetchStatusItf, PrefetchStatusCallback, (void*) stream );
+         */
+    }
+    (*stream->outputBufferQueueItf)->RegisterCallback( stream->outputBufferQueueItf, NotifyBufferFreeCallback, &stream->outputSem );
+    sem_init( &stream->outputSem, 0, 0 );
+
+error:
+    return result;
+}
+
+static PaError InitializeInputStream( PaOpenslesHostApiRepresentation *openslesHostApi, OpenslesStream *stream,
+                                      SLint32 androidRecordingPreset, double sampleRate )
+{
+    PaError result = paNoError;
+    SLresult slResult = SL_RESULT_SUCCESS;
+    int i, j;
+    const SLuint32 channelMasks[] = { SL_SPEAKER_FRONT_CENTER, SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT };
+
+    SLDataLocator_IODevice inputLocator = {SL_DATALOCATOR_IODEVICE,
+                                           SL_IODEVICE_AUDIOINPUT,
+                                           SL_DEFAULTDEVICEID_AUDIOINPUT, NULL};
+    SLDataSource audioSrc = {&inputLocator, NULL};
+
+    SLDataFormat_PCM  formatPcm = { SL_DATAFORMAT_PCM, stream->bufferProcessor.outputChannelCount,
+                                    sampleRate * 1000.0, SL_PCMSAMPLEFORMAT_FIXED_16,
+                                    SL_PCMSAMPLEFORMAT_FIXED_16,
+                                    channelMasks[stream->bufferProcessor.outputChannelCount - 1],
+                                    SL_BYTEORDER_LITTLEENDIAN };
+
+    SLDataLocator_AndroidSimpleBufferQueue inputBQLocator = { SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE,
+                                                              numberOfBuffers };
+    SLDataSink audioSink = {&inputBQLocator, &formatPcm};
+
+    const SLInterfaceID ids[] = { SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION };
+    const SLboolean req[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
+    const unsigned interfaceCount = 2;
+    slResult = (*openslesHostApi->slEngineItf)->CreateAudioRecorder(openslesHostApi->slEngineItf, &stream->audioRecorder,
+                                                                    &audioSrc, &audioSink, interfaceCount, ids, req);
+
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+
+        result = paUnanticipatedHostError;
+        goto error;
+    }
+
+#if __ANDROID_API__ >= 14
+    (*stream->audioRecorder)->GetInterface( stream->audioRecorder, SL_IID_ANDROIDCONFIGURATION, &stream->inputConfigurationItf );
+    (*stream->inputConfigurationItf)->SetConfiguration( stream->inputConfigurationItf, SL_ANDROID_KEY_STREAM_TYPE,
+                                                   &androidRecordingPreset, sizeof(androidRecordingPreset) );
+#endif
+
+    slResult = (*stream->audioRecorder)->Realize( stream->audioRecorder, SL_BOOLEAN_FALSE );
+    if( slResult != SL_RESULT_SUCCESS )
+    {
+        (*stream->audioRecorder)->Destroy( stream->audioRecorder );
+        result = paUnanticipatedHostError;
+        goto error;
+    }
+
+    (*stream->audioRecorder)->GetInterface( stream->audioRecorder,
+                                            SL_IID_ANDROIDSIMPLEBUFFERQUEUE,
+                                            &stream->inputBufferQueueItf );
+    (*stream->audioRecorder)->GetInterface( stream->audioRecorder,
+                                            SL_IID_RECORD,
+                                            &stream->recorderItf );
+
+    stream->inputBuffers = (void **) PaUtil_AllocateMemory( numberOfBuffers * sizeof(SLint16 *) );
+    for( i = 0; i < numberOfBuffers; ++i )
+    {
+        stream->inputBuffers[i] = (void*) PaUtil_AllocateMemory( stream->framesPerHostCallback
+                                                                 * stream->bytesPerFrame
+                                                                 * stream->bufferProcessor.inputChannelCount );
+        if( !stream->inputBuffers[i] )
+        {
+            for( j = 0; j < i; ++j )
+                PaUtil_FreeMemory( stream->inputBuffers[j] );
+            PaUtil_FreeMemory( stream->inputBuffers );
+            (*stream->audioRecorder)->Destroy( stream->audioRecorder );
+            result = paInsufficientMemory;
+            goto error;
+        }
+    }
+    stream->currentInputBuffer = 0;
+    (*stream->inputBufferQueueItf)->RegisterCallback( stream->inputBufferQueueItf,
+                                                      NotifyBufferFreeCallback, &stream->inputSem );
+    sem_init( &stream->inputSem, 0, 0 );
+
+error:
+    return result;
+}
+
+static void StreamProcessingCallback( void *userData )
+{
+    OpenslesStream *stream = (OpenslesStream*)userData;
+    PaStreamCallbackTimeInfo timeInfo = {0,0,0};
+    unsigned long framesProcessed = 0;
+    struct timespec timeSpec;
+
+    while( 1 )
+    {
+        framesProcessed = 0;
+
+        clock_gettime( CLOCK_REALTIME, &timeSpec );
+        timeInfo.currentTime = (PaTime)(timeSpec.tv_sec + (timeSpec.tv_nsec / 1000000000.0));
+        timeInfo.outputBufferDacTime = (PaTime)(stream->framesPerHostCallback
+                                                 / stream->streamRepresentation.streamInfo.sampleRate
+                                                 + timeInfo.currentTime);
+        timeInfo.inputBufferAdcTime = (PaTime)(stream->framesPerHostCallback
+                                                / stream->streamRepresentation.streamInfo.sampleRate
+                                                + timeInfo.currentTime);
+
+        /* check if StopStream or AbortStream was called */
+        if( stream->doStop )
+            stream->callbackResult = paComplete;
+        else if( stream->doAbort )
+            stream->callbackResult = paAbort;
+
+        PaUtil_BeginCpuLoadMeasurement( &stream->cpuLoadMeasurer );
+        PaUtil_BeginBufferProcessing( &stream->bufferProcessor, &timeInfo, stream->cbFlags );
+
+        if( stream->hasOutput )
+        {
+            sem_wait( &stream->outputSem );
+            PaUtil_SetOutputFrameCount( &stream->bufferProcessor, 0 );
+            PaUtil_SetInterleavedOutputChannels( &stream->bufferProcessor, 0,
+                                                 (void*) ((SLint16 **)stream->outputBuffers)[stream->currentOutputBuffer], 0 );
+        }
+        if( stream->hasInput )
+        {
+            sem_wait( &stream->inputSem );
+            PaUtil_SetInputFrameCount( &stream->bufferProcessor, 0 );
+            PaUtil_SetInterleavedInputChannels( &stream->bufferProcessor, 0,
+                                                (void*) ((SLint16 **)stream->inputBuffers)[stream->currentInputBuffer], 0 );
+        }
+
+        /* continue processing user buffers if cbresult is pacontinue or if cbresult is  pacomplete and userbuffers aren't empty yet  */
+        if( stream->callbackResult == paContinue
+            || ( stream->callbackResult == paComplete
+                 && !PaUtil_IsBufferProcessorOutputEmpty( &stream->bufferProcessor )) )
+            framesProcessed = PaUtil_EndBufferProcessing( &stream->bufferProcessor, &stream->callbackResult );
+
+        /* enqueue a buffer only when there are frames to be processed,
+         * this will be 0 when paComplete + empty buffers or paAbort
+         */
+        if( framesProcessed  > 0 )
+        {
+            if( stream->hasOutput )
+            {
+                (*stream->outputBufferQueueItf)->Enqueue( stream->outputBufferQueueItf,
+                                                          (void*) stream->outputBuffers[stream->currentOutputBuffer],
+                                                          framesProcessed * stream->bytesPerFrame
+                                                          * stream->bufferProcessor.outputChannelCount );
+                stream->currentOutputBuffer = (stream->currentOutputBuffer + 1) % numberOfBuffers;
+            }
+            if( stream->hasInput )
+            {
+                (*stream->inputBufferQueueItf)->Enqueue( stream->inputBufferQueueItf,
+                                                         (void*) stream->inputBuffers[stream->currentInputBuffer],
+                                                         framesProcessed * stream->bytesPerFrame
+                                                         * stream->bufferProcessor.inputChannelCount );
+                stream->currentInputBuffer = (stream->currentInputBuffer + 1) % numberOfBuffers;
+            }
+        }
+
+        PaUtil_EndCpuLoadMeasurement( &stream->cpuLoadMeasurer, framesProcessed);
+
+        if( framesProcessed == 0 && stream->doStop ) /* StopStream was called */
+        {
+            if( stream->hasOutput )
+            {
+                (*stream->playerItf)->SetPlayState( stream->playerItf, SL_PLAYSTATE_STOPPED );
+                (*stream->outputBufferQueueItf)->Clear( stream->outputBufferQueueItf );
+
+            }
+            if( stream->hasInput )
+            {
+                (*stream->recorderItf)->SetRecordState( stream->recorderItf, SL_RECORDSTATE_STOPPED );
+                (*stream->inputBufferQueueItf)->Clear( stream->inputBufferQueueItf );
+            }
+            return;
+        }
+        else if( framesProcessed == 0 && !(stream->doAbort || stream->doStop) ) /* if AbortStream or StopStream weren't called, stop from the cb */
+        {
+            if( stream->hasOutput )
+            {
+                (*stream->playerItf)->SetPlayState( stream->playerItf, SL_PLAYSTATE_STOPPED );
+                (*stream->outputBufferQueueItf)->Clear( stream->outputBufferQueueItf );
+            }
+            if( stream->hasInput )
+            {
+                (*stream->recorderItf)->SetRecordState( stream->recorderItf, SL_RECORDSTATE_STOPPED );
+                (*stream->inputBufferQueueItf)->Clear( stream->inputBufferQueueItf );
+            }
+
+            stream->isActive = SL_BOOLEAN_FALSE;
+            stream->isStopped = SL_BOOLEAN_TRUE;
+            if( stream->streamRepresentation.streamFinishedCallback != NULL )
+                stream->streamRepresentation.streamFinishedCallback( stream->streamRepresentation.userData );
+           return;
+        }
+    }
+}
+
+/* static void PrefetchStatusCallback( SLPrefetchStatusItf prefetchStatusItf, void *userData, SLuint32 event )
+ * {
+ *     SLuint32 prefetchStatus;
+ *     OpenslesStream *stream = (OpenslesStream*) userData;
+
+ *     (*stream->prefetchStatusItf)->GetPrefetchStatus( stream->prefetchStatusItf, &prefetchStatus );
+ *     if( event & SL_PREFETCHEVENT_STATUSCHANGE && prefetchStatus == SL_PREFETCHSTATUS_UNDERFLOW )
+ *         stream->cbFlags = paOutputUnderflow;
+ *     else if( event & SL_PREFETCHEVENT_STATUSCHANGE && prefetchStatus == SL_PREFETCHSTATUS_OVERFLOW )
+ *         stream->cbFlags = paOutputOverflow;
+ * }
+ */
+
+static void NotifyBufferFreeCallback( SLAndroidSimpleBufferQueueItf bufferQueueItf, void *userData )
+{
+    sem_t *sem = (sem_t*) userData;
+    sem_post( sem );
+}
+
+static PaError CloseStream( PaStream* s )
+{
+    PaError result = paNoError;
+    OpenslesStream *stream = (OpenslesStream*)s;
+    int i;
+
+    if( stream->hasOutput )
+    {
+        sem_destroy( &stream->outputSem );
+        (*stream->audioPlayer)->Destroy( stream->audioPlayer );
+        (*stream->outputMixObject)->Destroy( stream->outputMixObject );
+    }
+    if( stream->hasInput )
+    {
+        sem_destroy( &stream->inputSem );
+        (*stream->audioRecorder)->Destroy( stream->audioRecorder );
+    }
+
+    PaUtil_TerminateBufferProcessor( &stream->bufferProcessor );
+    PaUtil_TerminateStreamRepresentation( &stream->streamRepresentation );
+
+    for( i = 0; i < numberOfBuffers; ++i )
+    {
+        if( stream->hasOutput )
+            PaUtil_FreeMemory( stream->outputBuffers[i] );
+        if( stream->hasInput )
+            PaUtil_FreeMemory( stream->inputBuffers[i] );
+    }
+
+    if( stream->hasOutput )
+        PaUtil_FreeMemory( stream->outputBuffers );
+    if( stream->hasInput )
+        PaUtil_FreeMemory( stream->inputBuffers );
+
+    PaUtil_FreeMemory( stream );
+    return result;
+}
+
+static PaError StartStream( PaStream *s )
+{
+    SLresult slResult;
+    PaError result = paNoError;
+    OpenslesStream *stream = (OpenslesStream*)s;
+    int i;
+
+    PaUtil_ResetBufferProcessor( &stream->bufferProcessor );
+
+    stream->isStopped = SL_BOOLEAN_FALSE;
+    stream->isActive = SL_BOOLEAN_TRUE;
+    stream->doStop = SL_BOOLEAN_FALSE;
+    stream->doAbort = SL_BOOLEAN_FALSE;
+    stream->currentOutputBuffer = 0;
+    stream->currentInputBuffer = 0;
+
+    /* Initialize buffers */
+    for( i = 0; i < numberOfBuffers; ++i )
+    {
+        if( stream->hasOutput )
+        {
+            memset( stream->outputBuffers[stream->currentOutputBuffer], 0,
+                    stream->framesPerHostCallback * stream->bytesPerFrame
+                    * stream->bufferProcessor.outputChannelCount );
+            slResult = (*stream->outputBufferQueueItf)->Enqueue( stream->outputBufferQueueItf,
+                                                                 (void*) stream->outputBuffers[stream->currentOutputBuffer],
+                                                                 stream->framesPerHostCallback * stream->bytesPerFrame
+                                                                 * stream->bufferProcessor.outputChannelCount  );
+            if( slResult != SL_RESULT_SUCCESS )
+                goto error;
+            stream->currentOutputBuffer = (stream->currentOutputBuffer + 1) % numberOfBuffers;
+        }
+        if( stream->hasInput )
+        {
+            memset( stream->inputBuffers[stream->currentInputBuffer], 0,
+                    stream->framesPerHostCallback * stream->bytesPerFrame * stream->bufferProcessor.inputChannelCount );
+            slResult = (*stream->inputBufferQueueItf)->Enqueue( stream->inputBufferQueueItf,
+                                                                 (void*) stream->inputBuffers[stream->currentInputBuffer],
+                                                                 stream->framesPerHostCallback * stream->bytesPerFrame
+                                                                 * stream->bufferProcessor.inputChannelCount  );
+            if( slResult != SL_RESULT_SUCCESS )
+                goto error;
+            stream->currentInputBuffer = (stream->currentInputBuffer + 1) % numberOfBuffers;
+        }
+    }
+
+    /* Start the processing thread */
+    if( !stream->isBlocking )
+    {
+        stream->callbackResult = paContinue;
+        PaUnixThread_New(&stream->streamThread, (void*) StreamProcessingCallback,
+                         (void *) stream, 0, 0);
+    }
+
+    /* Start OpenSL ES devices */
+    if( stream->hasOutput )
+    {
+        slResult = (*stream->playerItf)->SetPlayState( stream->playerItf, SL_PLAYSTATE_PLAYING );
+        if( slResult != SL_RESULT_SUCCESS )
+            goto error;
+    }
+    if( stream->hasInput )
+    {
+        slResult = (*stream->recorderItf)->SetRecordState( stream->recorderItf, SL_RECORDSTATE_RECORDING);
+        if( slResult != SL_RESULT_SUCCESS )
+            goto error;
+    }
+
+    return result;
+error:
+    return paUnanticipatedHostError;
+}
+
+static PaError StopStream( PaStream *s )
+{
+    PaError result = paNoError;
+    OpenslesStream *stream = (OpenslesStream*)s;
+    SLAndroidSimpleBufferQueueState state;
+
+    if( stream->isBlocking )
+    {
+        if( stream->hasOutput )
+        {
+            do {
+                (*stream->outputBufferQueueItf)->GetState( stream->outputBufferQueueItf, &state);
+            } while( state.count > 0 );
+            (*stream->playerItf)->SetPlayState( stream->playerItf, SL_PLAYSTATE_STOPPED );
+            (*stream->outputBufferQueueItf)->Clear( stream->outputBufferQueueItf );
+        }
+        if( stream->hasInput )
+        {
+            do {
+                (*stream->inputBufferQueueItf)->GetState( stream->inputBufferQueueItf, &state);
+            } while( state.count > 0 );
+            (*stream->recorderItf)->SetRecordState( stream->recorderItf, SL_RECORDSTATE_STOPPED );
+            (*stream->inputBufferQueueItf)->Clear( stream->inputBufferQueueItf );
+        }
+        stream->isActive = SL_BOOLEAN_FALSE;
+        stream->isStopped = SL_BOOLEAN_TRUE;
+    }
+    else
+    {
+        stream->doStop = SL_BOOLEAN_TRUE;
+        PaUnixThread_Terminate( &stream->streamThread, 1, &result );
+    }
+
+    stream->isActive = SL_BOOLEAN_FALSE;
+    stream->isStopped = SL_BOOLEAN_TRUE;
+    if( stream->streamRepresentation.streamFinishedCallback != NULL )
+        stream->streamRepresentation.streamFinishedCallback( stream->streamRepresentation.userData );
+
+    return result;
+}
+
+static PaError AbortStream( PaStream *s )
+{
+    PaError result = paNoError;
+    OpenslesStream *stream = (OpenslesStream*)s;
+
+    if( !stream->isBlocking )
+    {
+        stream->doAbort = SL_BOOLEAN_TRUE;
+        PaUnixThread_Terminate( &stream->streamThread, 0, &result );
+    }
+
+    /* stop immediately so enqueue has no effect */
+    if( stream->hasOutput )
+        (*stream->playerItf)->SetPlayState( stream->playerItf, SL_PLAYSTATE_STOPPED );
+    if( stream->hasInput)
+        (*stream->recorderItf)->SetRecordState( stream->recorderItf, SL_RECORDSTATE_STOPPED );
+
+    stream->isActive = SL_BOOLEAN_FALSE;
+    stream->isStopped = SL_BOOLEAN_TRUE;
+    if( stream->streamRepresentation.streamFinishedCallback != NULL )
+        stream->streamRepresentation.streamFinishedCallback( stream->streamRepresentation.userData );
+
+    return result;
+}
+
+static PaError IsStreamStopped( PaStream *s )
+{
+    OpenslesStream *stream = (OpenslesStream*)s;
+    return stream->isStopped;
+}
+
+static PaError IsStreamActive( PaStream *s )
+{
+    OpenslesStream *stream = (OpenslesStream*)s;
+    return stream->isActive;
+}
+
+static PaTime GetStreamTime( PaStream *s )
+{
+    return PaUtil_GetTime();
+}
+
+static double GetStreamCpuLoad( PaStream* s )
+{
+    OpenslesStream *stream = (OpenslesStream*)s;
+
+    return PaUtil_GetCpuLoad( &stream->cpuLoadMeasurer );
+}
+
+static PaError ReadStream( PaStream* s,
+                           void *buffer,
+                           unsigned long frames )
+{
+    OpenslesStream *stream = (OpenslesStream*)s;
+    void *userBuffer = buffer;
+    unsigned framesToRead;
+
+    while( frames > 0 )
+    {
+        sem_wait( &stream->inputSem );
+        framesToRead = PA_MIN( stream->framesPerHostCallback, frames );
+        PaUtil_SetInputFrameCount( &stream->bufferProcessor, framesToRead );
+        PaUtil_SetInterleavedInputChannels( &stream->bufferProcessor, 0,
+                                            stream->inputBuffers[stream->currentInputBuffer], 0 );
+
+        (*stream->inputBufferQueueItf)->Enqueue( stream->inputBufferQueueItf,
+                                                 stream->inputBuffers[stream->currentInputBuffer],
+                                                 framesToRead * stream->bytesPerFrame
+                                                 * stream->bufferProcessor.inputChannelCount );
+         PaUtil_CopyInput( &stream->bufferProcessor, &userBuffer, framesToRead );
+         stream->currentInputBuffer = (stream->currentInputBuffer + 1) % numberOfBuffers;
+
+         frames -= framesToRead;
+    }
+
+    return paNoError;
+}
+
+static PaError WriteStream( PaStream* s,
+                            const void *buffer,
+                            unsigned long frames )
+{
+    OpenslesStream *stream = (OpenslesStream*)s;
+    const void *userBuffer = buffer;
+    unsigned framesToWrite;
+
+    while( frames > 0 )
+    {
+        sem_wait( &stream->outputSem );
+        framesToWrite = PA_MIN( stream->framesPerHostCallback, frames );
+        PaUtil_SetOutputFrameCount( &stream->bufferProcessor, framesToWrite );
+        PaUtil_SetInterleavedOutputChannels( &stream->bufferProcessor, 0,
+                                             stream->outputBuffers[stream->currentOutputBuffer], 0 );
+        PaUtil_CopyOutput( &stream->bufferProcessor, &userBuffer, framesToWrite);
+        (*stream->outputBufferQueueItf)->Enqueue( stream->outputBufferQueueItf, stream->outputBuffers[stream->currentOutputBuffer],
+                                                  framesToWrite * stream->bytesPerFrame
+                                                  * stream->bufferProcessor.outputChannelCount );
+        stream->currentOutputBuffer = (stream->currentOutputBuffer + 1) % numberOfBuffers;
+        frames -= framesToWrite;
+    }
+    return paNoError;
+}
+
+static signed long GetStreamReadAvailable( PaStream* s )
+{
+    OpenslesStream *stream = (OpenslesStream*)s;
+    SLAndroidSimpleBufferQueueState state;
+
+    (*stream->inputBufferQueueItf)->GetState( stream->inputBufferQueueItf, &state );
+    return stream->framesPerHostCallback * ( numberOfBuffers - state.count );
+}
+
+static signed long GetStreamWriteAvailable( PaStream* s )
+{
+    OpenslesStream *stream = (OpenslesStream*)s;
+    SLAndroidSimpleBufferQueueState state;
+
+    (*stream->outputBufferQueueItf)->GetState( stream->outputBufferQueueItf, &state );
+    return stream->framesPerHostCallback * ( numberOfBuffers - state.count );
+}
+
+static unsigned long GetApproximateLowBufferSize()
+{
+    if( __ANDROID_API__ <= 14 )
+        return 1024;
+    else if( __ANDROID_API__ <= 20 )
+        return 512;
+    else if( __ANDROID_API__ <= 23 )
+        return 256;
+    else
+        return 192;
+}
+
+void PaOpenSLES_SetNativeBufferSize( unsigned long bufferSize )
+{
+    nativeBufferSize = bufferSize;
+}
+
+void PaOpenSLES_SetNumberOfBuffers( unsigned buffers )
+{
+    numberOfBuffers = buffers;
+}

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -50,6 +50,7 @@
 #include <semaphore.h>
 #include <errno.h>
 #include <math.h>
+#include <malloc.h>
 #include <string.h>
 #include <time.h>
 
@@ -1041,6 +1042,7 @@ static void StreamProcessingCallback( void *userData )
                 (*stream->recorderItf)->SetRecordState( stream->recorderItf, SL_RECORDSTATE_STOPPED );
                 (*stream->inputBufferQueueItf)->Clear( stream->inputBufferQueueItf );
             }
+            PaUnixThreading_EXIT( paNoError );
             return;
         }
         else if( framesProcessed == 0 && !(stream->doAbort || stream->doStop) ) /* if AbortStream or StopStream weren't called, stop from the cb */
@@ -1060,7 +1062,8 @@ static void StreamProcessingCallback( void *userData )
             stream->isStopped = SL_BOOLEAN_TRUE;
             if( stream->streamRepresentation.streamFinishedCallback != NULL )
                 stream->streamRepresentation.streamFinishedCallback( stream->streamRepresentation.userData );
-           return;
+            PaUnixThreading_EXIT( paNoError );
+            return;
         }
     }
 }

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -54,7 +54,6 @@
 #include <string.h>
 #include <time.h>
 
-#include <android/api-level.h>
 #include <SLES/OpenSLES.h>
 #include <SLES/OpenSLES_Android.h>
 

--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -547,7 +547,6 @@ typedef struct OpenslesOutputStream
     SLPlayItf playerItf;
     SLAndroidSimpleBufferQueueItf outputBufferQueueItf;
     /* SLPrefetchStatusItf prefetchStatusItf; */
-    SLVolumeItf volumeItf;
     SLAndroidConfigurationItf outputConfigurationItf;
 
     sem_t outputSem;
@@ -836,17 +835,17 @@ static PaError InitializeOutputStream(PaOpenslesHostApiRepresentation *openslesH
 
     if( !stream->isBlocking )
     {
-        const SLInterfaceID ids[] = { SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_VOLUME, SL_IID_ANDROIDCONFIGURATION };
-        const SLboolean req[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
-        const unsigned interfaceCount = 3;
+        const SLInterfaceID ids[] = { SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION };
+        const SLboolean req[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
+        const unsigned interfaceCount = 2;
         slResult = (*openslesHostApi->slEngineItf)->CreateAudioPlayer(openslesHostApi->slEngineItf, &stream->outputStream->audioPlayer,
                                                                       &audioSrc, &audioSink, interfaceCount, ids, req);
     }
     else
     {
-        const SLInterfaceID ids[] = { SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_VOLUME, SL_IID_ANDROIDCONFIGURATION };
-        const SLboolean req[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
-        const unsigned interfaceCount = 3;
+        const SLInterfaceID ids[] = { SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION };
+        const SLboolean req[] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
+        const unsigned interfaceCount = 2;
         slResult = (*openslesHostApi->slEngineItf)->CreateAudioPlayer( openslesHostApi->slEngineItf, &stream->outputStream->audioPlayer,
                                                                        &audioSrc, &audioSink, interfaceCount, ids, req );
     }
@@ -874,7 +873,6 @@ static PaError InitializeOutputStream(PaOpenslesHostApiRepresentation *openslesH
 
     (*stream->outputStream->audioPlayer)->GetInterface( stream->outputStream->audioPlayer, SL_IID_PLAY, &stream->outputStream->playerItf );
     (*stream->outputStream->audioPlayer)->GetInterface( stream->outputStream->audioPlayer, SL_IID_ANDROIDSIMPLEBUFFERQUEUE, &stream->outputStream->outputBufferQueueItf );
-    (*stream->outputStream->audioPlayer)->GetInterface( stream->outputStream->audioPlayer, SL_IID_VOLUME, &stream->outputStream->volumeItf );
 
     stream->outputStream->outputBuffers = (void **) PaUtil_AllocateMemory( numberOfBuffers * sizeof(SLint16 *) );
     for( i = 0; i < numberOfBuffers; ++i )

--- a/src/os/unix/pa_unix_hostapis.c
+++ b/src/os/unix/pa_unix_hostapis.c
@@ -52,6 +52,8 @@ PaError PaAsiHpi_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
 PaError PaMacCore_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 
+PaError PaOpenSLES_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+
 /** Note that on Linux, ALSA is placed before OSS so that the former is preferred over the latter.
  */
 
@@ -97,6 +99,10 @@ PaUtilHostApiInitializer *paHostApiInitializers[] =
 
 #if PA_USE_SKELETON
         PaSkeleton_Initialize,
+#endif
+
+#if PA_USE_OPENSLES
+        PaOpenSLES_Initialize,
 #endif
 
         0   /* NULL terminated array */

--- a/src/os/unix/pa_unix_util.c
+++ b/src/os/unix/pa_unix_util.c
@@ -280,7 +280,7 @@ PaError PaUnixThread_New( PaUnixThread* self, void* (*threadFunc)( void* ), void
     memset( self, 0, sizeof (PaUnixThread) );
     PaUnixMutex_Initialize( &self->mtx );
     PA_ASSERT_CALL( pthread_condattr_init( &cattr ), 0 );
-#if defined(CLOCK_MONOTONIC) && !defined(__APPLE__)
+#if defined(CLOCK_MONOTONIC) && !defined(__APPLE__) && (!defined(__ANDROID__) || __ANDROID_API__ >= 21)
     PA_ASSERT_CALL( pthread_condattr_setclock( &cattr, CLOCK_MONOTONIC ), 0 );
 #endif
     PA_ASSERT_CALL( pthread_cond_init( &self->cond, &cattr), 0 );


### PR DESCRIPTION
Since PortAudio is on GH now I figured I might as well make a PR. I had some conversations on mailing lists & the old tracker ages ago but that sort of died down.

This is an OpenSLES hostapi for PortAudio and up, for Android 14 and up. And I would love some feedback on it. I added a README.md under `src/hostapi/opensles` which has some extra notes.

Because testing this on Android is a bit of a hassle, there might be some blind spots, but most of the tests included under `test/` work fine.

I'm sure there are also some areas where it could conform better to the PortAudio (hostapi-)api.

There's still loads of potential improvements, like exposing more of the OpenSLES specific features, like [the ability to choose a  performance mode](https://developer.android.com/ndk/guides/audio/opensl/opensl-prog-notes#performancemodes). I think there might be some support for sample rate conversion if low-latency isn't enabled (which is the default). Also https://github.com/Gundersanne/portaudio_opensles/issues/14 needs investigating.

Linking  #154 and  #281

---

Also has contributions from @jwinarske for CMake support and bugfixes, and @darksylinc for more bugfixing.