### PR TITLE
Fix include directories missing in PortAudioTargets.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(PortAudio
 target_include_directories(PortAudio PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/common>
-  $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 if(UNIX)
   target_compile_options(PortAudio PRIVATE -fPIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(PortAudio
 target_include_directories(PortAudio PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/common>
+  $<INSTALL_INTERFACE:include>
 )
 if(UNIX)
   target_compile_options(PortAudio PRIVATE -fPIC)


### PR DESCRIPTION
It seems that this was refactored recently, leading to nothing being added to PortAudioTargets.cmake, thus causing apps importing PortAudio that way not being able to find the PA includes.