### PR TITLE
Use the proper libasound shared object name for dlopen

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -241,7 +241,7 @@ _PA_DEFINE_FUNC(snd_output_stdio_attach);
 
 /* Redefine 'PA_ALSA_PATHNAME' to a different Alsa library name if desired. */
 #ifndef PA_ALSA_PATHNAME
-    #define PA_ALSA_PATHNAME "libasound.so"
+    #define PA_ALSA_PATHNAME "libasound.so.2"
 #endif
 static const char *g_AlsaLibName = PA_ALSA_PATHNAME;
 


### PR DESCRIPTION
Currently, it searches libasound.so which is generally only available when dev packages are installed (e.g. libasound-dev on Debian derivatives, alsa-lib-devel on RH-derivatives).
The proper name for applications to use is libasound.so.2 which is what packages such as alsa-lib or libasound2 do provide.

Sources:

- https://packages.debian.org/fr/sid/amd64/libasound-dev/filelist
- https://packages.debian.org/fr/sid/amd64/libasound2/filelist

- https://centos.pkgs.org/7/okey-x86_64/alsa-lib-1.0.28-3.el7.centos.x86_64.rpm.html
- https://centos.pkgs.org/7/centos-x86_64/alsa-lib-devel-1.1.8-1.el7.x86_64.rpm.html