### PR TITLE
alsa: Fix distorted sound from half-duplex capture.

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -2694,7 +2694,7 @@ static PaError PaAlsaStream_DetermineFramesPerBuffer( PaAlsaStream* self, double
     PA_UNLESS( framesPerHostBuffer != 0, paInternalError );
     self->maxFramesPerHostBuffer = framesPerHostBuffer;
 
-    if( (!self->playback.canMmap && self->playback.pcm) || !accurate )
+    if( (self->playback.pcm && !self->playback.canMmap) || !accurate )
     {
         /* Don't know the exact size per host buffer */
         *hostBufferSizeMode = paUtilBoundedHostBufferSize;

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -2694,7 +2694,7 @@ static PaError PaAlsaStream_DetermineFramesPerBuffer( PaAlsaStream* self, double
     PA_UNLESS( framesPerHostBuffer != 0, paInternalError );
     self->maxFramesPerHostBuffer = framesPerHostBuffer;
 
-    if( !self->playback.canMmap || !accurate )
+    if( (!self->playback.canMmap && self->playback.pcm) || !accurate )
     {
         /* Don't know the exact size per host buffer */
         *hostBufferSizeMode = paUtilBoundedHostBufferSize;


### PR DESCRIPTION
If an audio stream is only opened for capture in half-duplex
mode, then the self->playback.canMmap variable is false by
default. This triggers setup of a hostBufferSizeMode of
paUtilBoundedHostBufferSize, something that is only meant to
happen for playback streams under some conditions. This leads
to very distorted captured sound.

Fix this by also checking for self->playback.pcm, ie. that
the playback component is actually used, so this setting
only gets applied for half-duplex playback or full-duplex
playback + capture streams if needed.

Tested to work correctly now for playback, capture, and
full-duplex playback + capture.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>