### PR TITLE
mac: use atomic_thread_fence() to avoid deprecation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ elseif(UNIX)
     set(PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS} -DPA_USE_COREAUDIO=1")
 
     # Use C11 so that we can make use of atomic library and avoid deprecation errors.
-    target_compile_definitions(PortAudio PRIVATE std=c11)
+    set_property(TARGET PortAudio PROPERTY C_STANDARD 11)
 
     set(PKGCONFIG_LDFLAGS_PRIVATE
       "${PKGCONFIG_LDFLAGS_PRIVATE} -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,14 @@ elseif(UNIX)
     )
     target_compile_definitions(PortAudio PUBLIC PA_USE_COREAUDIO=1)
     set(PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS} -DPA_USE_COREAUDIO=1")
+
+    include(CheckIncludeFiles)
+    check_include_files(stdatomic.h HAVE_STDATOMIC_H)
+    if(NOT HAVE_STDATOMIC_H)
+        target_compile_definitions(PortAudio PRIVATE PA_MAC_USE_OSS_MEMORY_BARRIER=1)
+        set(PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS} -DPA_MAC_USE_OSS_MEMORY_BARRIER=1")
+    endif()
+
     set(PKGCONFIG_LDFLAGS_PRIVATE
       "${PKGCONFIG_LDFLAGS_PRIVATE} -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices")
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,11 +285,8 @@ elseif(UNIX)
     target_compile_definitions(PortAudio PUBLIC PA_USE_COREAUDIO=1)
     set(PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS} -DPA_USE_COREAUDIO=1")
 
-    include(CheckIncludeFiles)
-    check_include_files(stdatomic.h HAVE_STDATOMIC_H)
-    if(NOT HAVE_STDATOMIC_H)
-        target_compile_definitions(PortAudio PRIVATE PA_MAC_USE_OS_MEMORY_BARRIER=1)
-    endif()
+    # Use C11 so that we can make use of atomic library and avoid deprecation errors.
+    target_compile_definitions(PortAudio PRIVATE std=c11)
 
     set(PKGCONFIG_LDFLAGS_PRIVATE
       "${PKGCONFIG_LDFLAGS_PRIVATE} -framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,8 +288,7 @@ elseif(UNIX)
     include(CheckIncludeFiles)
     check_include_files(stdatomic.h HAVE_STDATOMIC_H)
     if(NOT HAVE_STDATOMIC_H)
-        target_compile_definitions(PortAudio PRIVATE PA_MAC_USE_OSS_MEMORY_BARRIER=1)
-        set(PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS} -DPA_MAC_USE_OSS_MEMORY_BARRIER=1")
+        target_compile_definitions(PortAudio PRIVATE PA_MAC_USE_OS_MEMORY_BARRIER=1)
     endif()
 
     set(PKGCONFIG_LDFLAGS_PRIVATE

--- a/src/common/pa_memorybarrier.h
+++ b/src/common/pa_memorybarrier.h
@@ -61,10 +61,9 @@
  ****************/
 
 #if defined(__APPLE__)
-/* Support for stdatomic was added in XCode 7.
- * If you need to build on an older version, define PA_MAC_USE_OS_MEMORY_BARRIER.
+/* Support for the atomic library was added in C11.
  */
-#   if PA_MAC_USE_OS_MEMORY_BARRIER
+#   if (__STDC_VERSION__ < 201112L) || defined(__STDC_NO_ATOMICS__)
 #       include <libkern/OSAtomic.h>
         /* Here are the memory barrier functions. Mac OS X only provides
            full memory barriers, so the three types of barriers are the same,

--- a/src/common/pa_memorybarrier.h
+++ b/src/common/pa_memorybarrier.h
@@ -74,7 +74,7 @@
 #       define PaUtil_WriteMemoryBarrier() OSMemoryBarrier()
 #   else
 #       include <stdatomic.h>
-#       define PaUtil_FullMemoryBarrier()  atomic_thread_fence(memory_order_acq_rel)
+#       define PaUtil_FullMemoryBarrier()  atomic_thread_fence(memory_order_seq_cst)
 #       define PaUtil_ReadMemoryBarrier()  atomic_thread_fence(memory_order_acquire)
 #       define PaUtil_WriteMemoryBarrier() atomic_thread_fence(memory_order_release)
 #   endif

--- a/src/common/pa_memorybarrier.h
+++ b/src/common/pa_memorybarrier.h
@@ -63,7 +63,7 @@
 #if defined(__APPLE__)
 /* Support for stdatomic was added in XCode 7.
  * If you need to build on an older version, define PA_MAC_USE_OS_MEMORY_BARRIER.
- * TODO Find an automated way to check for stdatomic support. */
+ */
 #   if PA_MAC_USE_OS_MEMORY_BARRIER
 #       include <libkern/OSAtomic.h>
         /* Here are the memory barrier functions. Mac OS X only provides


### PR DESCRIPTION
OSMemoryBarrier() is deprecated and causes build failures
when "-Wall -Werror" are used.

Use -DPA_MAC_USE_OS_MEMORY_BARRIER if you want to use the old code
on APPLE.

Fixes #639