### PR TITLE
dsound: Fix warning of redefining _WIN32_WINNT when compiling with GCC/MinGW

### DIFF
--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -47,11 +47,15 @@
 */
 //#define PA_WIN_DS_USE_WMME_TIMER
 
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0400)
+    #undef _WIN32_WINNT
+    #define _WIN32_WINNT 0x0400 /* required to get waitable timer APIs */
+#endif
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h> /* strlen() */
 
-#define _WIN32_WINNT 0x0400 /* required to get waitable timer APIs */
 #include <initguid.h> /* make sure ds guids get defined */
 #include <windows.h>
 #include <objbase.h>


### PR DESCRIPTION
The warning is thrown as follows:
```c
[  5%] Building C object CMakeFiles/PortAudio.dir/src/hostapi/dsound/pa_win_ds.c.obj
pa_win_ds.c:54: warning: "_WIN32_WINNT" redefined
   54 | #define _WIN32_WINNT 0x0400 /* required to get waitable timer APIs */
      |
<command-line>: note: this is the location of the previous definition
```

`_WIN32_WINNT` is defined by GCC/MinGW and therefore it has to be checked before defining to 0x0400. If `_WIN32_WINNT` is defined to a lower value it will be redefined to 0x0400, therefore the expected behavior is preserved.

Closes #549