### PR TITLE
dsound: Remove _WIN32_WINNT guard clause due to its needlessness

### DIFF
--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -47,11 +47,6 @@
 */
 //#define PA_WIN_DS_USE_WMME_TIMER
 
-#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0400)
-    #undef _WIN32_WINNT
-    #define _WIN32_WINNT 0x0400 /* required to get waitable timer APIs */
-#endif
-
 #include <assert.h>
 #include <stdio.h>
 #include <string.h> /* strlen() */


### PR DESCRIPTION
DirectSound is supported on min. Windows 95 (`_WIN32_WINNT_NT4 0x0400`) therefore checking for `_WIN32_WINNT < 0x0400` is ambiguous.

It is a continuation of discussion in PR #667 raised by @jmelas.