### PR TITLE
Fix WASAPI stream stopped check

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -601,9 +601,9 @@ typedef struct PaWasapiStream
     // must be volatile to avoid race condition on user query while
     // thread is being started
     volatile BOOL running;
-    BOOL stopped;
 
     // stream has not or is no longer started
+    BOOL stopped;
 
     PA_THREAD_ID dwThreadId;
     HANDLE hThread;


### PR DESCRIPTION
This fixes a bug in the WASAPI implementation, specifically the ``IsStreamStopped`` function. It would essentially return ``false`` when the stream was actually stopped and where it should've returned ``true``.

This is a patch from Audacity but that isn't really correlated to it.

Patch source: https://github.com/SartoxSoftware/audacium/blob/9e763b8f420c1569a9024087859349b28b888035/lib-src/portaudio-v19/wasapi-fix.patch