### PR TITLE
cmake: fix invalid config file being generated in some cases

### DIFF
--- a/cmake/PortAudioConfig.cmake.in
+++ b/cmake/PortAudioConfig.cmake.in
@@ -8,11 +8,11 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Threads)
 
-if(@PA_USE_JACK@)
+if("@PA_USE_JACK@")
   find_dependency(Regex)
   find_dependency(JACK)
 endif()
 
-if(@PA_USE_ALSA@)
+if("@PA_USE_ALSA@")
   find_dependency(ALSA)
 endif()


### PR DESCRIPTION
The problem being, that e.g. if(@PA_USE_ALSA@) expands to if() which is not valid CMake code