### PR TITLE
Add documentation for MinGW-w64

### DIFF
--- a/doc/src/tutorial/compile_windows.dox
+++ b/doc/src/tutorial/compile_windows.dox
@@ -96,6 +96,17 @@ Project Properties -> Configuration Properties -> C/C++ -> Preprocessor -> Prepr
 4) Remove PaAsio_* entry points from portaudio.def
 
 
+@section comp_win5 List of Windows audio APIs
+
+WASAPI: recommended by Microsoft. Supported since Windows Vista (includes 7/8/10+).
+
+ASIO: Low latency API intended for pro audio users; this requires the user to install ASIO drivers.
+
+WMME, DirectSound: Legacy APIs for greater backward compatibility
+
+WDM/KS: Low level direct-to-driver API.
+
+
 -----
 David Viens, davidv@plogue.com
 

--- a/doc/src/tutorial/compile_windows_mingw-w64.dox
+++ b/doc/src/tutorial/compile_windows_mingw-w64.dox
@@ -8,13 +8,7 @@ Install MinGW-w64 from https://www.msys2.org/. Follow the instructions on this p
 
 Brief excursion: there are many toolchain variants in Msys2, and you must use the same toolchain to compile all projects together. In this tutorial, we will use the msvcrt-gcc toolchain, simply because it's already present on all Windows versions. Readers may eventually want to switch to the ucrt-gcc toolchain later, for their Windows 10+ builds, although there is hardly any benefit to doing so. A list of available toolchains is at https://www.msys2.org/docs/environments/.
 
-In addition, you have a choice of Windows audio APIs. Here's a summary:
-
-WASAPI: recommended by Microsoft. Supported since Windows Vista (includes 7/8/10+). This should be the default in most cases; it has the best performance of the APIs that work out of the box. If you want to support Windows XP or earlier, you will need to add in another API as a fallback. See the diagram at the top of \ref api_overview for a list of Windows APIs.
-
-ASIO: intended for pro audio users; this requires the user to install ASIO drivers, which can be finicky and annoying. Compared to WASAPI exclusive mode, ASIO may or may not have latency advantages (I have not tested).
-
-WMME, DirectSound, WDM/KS: these are worse than WASAPI, but can be used if WASAPI is not available (such as on Windows XP).
+In addition, you have a choice of Windows audio APIs; see the bottom of \ref compile_windows for a list.
 
 You can either use msys2's precompiled PortAudio or compile PortAudio yourself. To install msys2's precompiled PortAudio, see the next section. To compile PortAudio on your own, skip to the next next section.
 

--- a/doc/src/tutorial/compile_windows_mingw-w64.dox
+++ b/doc/src/tutorial/compile_windows_mingw-w64.dox
@@ -1,0 +1,45 @@
+/** @page compile_windows_mingw-w64 Building PortAudio for Windows with MinGW-w64
+@ingroup tutorial
+
+@section comp_mingw-w64_1 PortAudio for Windows with MinGW-w64
+
+MinGW-w64 is a port of Linux toolchains (gcc, clang) to Windows. It comes packaged with Msys2 in its preferred configuration. Msys2 provides a Linux environment and the package manager pacman.
+Install MinGW-w64 from https://www.msys2.org/. Follow the instructions on this page.
+
+Brief excursion: there are many toolchain variants in Msys2, and you must use the same toolchain to compile all projects together. In this tutorial, we will use the msvcrt-gcc toolchain, simply because it's already present on all Windows versions. Readers may eventually want to switch to the ucrt-gcc toolchain later, for their Windows 10+ builds, although there is hardly any benefit to doing so. A list of available toolchains is at https://www.msys2.org/docs/environments/.
+
+In addition, you have a choice of Windows audio APIs. Here's a summary:
+
+WASAPI: recommended by Microsoft. Supported since Windows Vista (includes 7/8/10+). This should be the default in most cases; it has the best performance of the APIs that work out of the box. If you want to support Windows XP or earlier, you will need to add in another API as a fallback. See the diagram at the top of \ref api_overview for a list of Windows APIs.
+
+ASIO: intended for pro audio users; this requires the user to install ASIO drivers, which can be finicky and annoying. Compared to WASAPI exclusive mode, ASIO may or may not have latency advantages (I have not tested).
+
+WMME, DirectSound, WDM/KS: these are worse than WASAPI, but can be used if WASAPI is not available (such as on Windows XP).
+
+You can either use msys2's precompiled PortAudio or compile PortAudio yourself. To install msys2's precompiled PortAudio, see the next section. To compile PortAudio on your own, skip to the next next section.
+
+@section comp_mingw-w64_2 Pre-compiled package
+
+Open your msys2 shell and run "pacman -S mingw-w64-x86_64-portaudio". This will get you a default build of PortAudio. I believe it comes with DirectSound, WASAPI, WD/MKS, WD/MKS_DEVICE_INFO, and WMME. Note the "-x86_64" in the middle of the package name. When you install msys2 packages, you specify the toolchain name in the middle, and "-x86_64" chooses the msvcrt-gcc toolchain.
+
+@section comp_mingw-w64_3 Compiling
+
+We will build with WASAPI only, with no fallback APIs, simply as an example. In the msys2 shell, navigate into your folder of PortAudio. Run:
+
+@code
+pacman -S mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+mkdir build
+cd build
+cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DPA_USE_DS=0 -DPA_USE_WDMKS=0 -DPA_USE_WDMKS_DEVICE_INFO=0 -DPA_USE_WMME=0
+cmake --build .
+gcc ../examples/paex_saw.c -I../src/common -lportaudio
+./a.exe
+@endcode
+
+You can enable the desired fallback APIs again by deleting the terms like "-DPA_USE_WMME=0" in the cmake command. When releasing your application to the public, make sure to copy libportaudio.dll (in the build folder) into your own application's folder. (You'll also need to ship a copy of MinGW-w64's various shared libraries; you can figure out which ones using Microsoft's Process Explorer, and seeing which dlls are accessed from your msys64 folder.)
+
+Or, compile statically to avoid the issue of dll copies.
+
+Back to the Tutorial: \ref tutorial_start
+
+*/

--- a/doc/src/tutorial/compile_windows_mingw.dox
+++ b/doc/src/tutorial/compile_windows_mingw.dox
@@ -7,6 +7,7 @@
 a draft of new MinGW information on our
 Wiki: <a href="https://github.com/PortAudio/portaudio/wiki/Notes_about_building_PortAudio_with_MinGW">
 PortAudio Wiki: Notes about building PortAudio with MinGW</a></strong>
+If you are new to MinGW, this is the wrong page, and the correct page is almost certainly \ref compile_windows_mingw-w64. (MinGW is a largely defunct and unused project; MinGW-w64 is its current iteration.)
 
 = MinGW/MSYS =
 

--- a/doc/src/tutorial/compile_windows_mingw.dox
+++ b/doc/src/tutorial/compile_windows_mingw.dox
@@ -7,7 +7,7 @@
 a draft of new MinGW information on our
 Wiki: <a href="https://github.com/PortAudio/portaudio/wiki/Notes_about_building_PortAudio_with_MinGW">
 PortAudio Wiki: Notes about building PortAudio with MinGW</a></strong>
-If you are new to MinGW, this is the wrong page, and the correct page is almost certainly \ref compile_windows_mingw-w64. (MinGW is a largely defunct and unused project; MinGW-w64 is its current iteration.)
+If you are new to MinGW, consider MinGW-64: \ref compile_windows_mingw-w64. It is a newer project.
 
 = MinGW/MSYS =
 

--- a/doc/src/tutorial/tutorial_start.dox
+++ b/doc/src/tutorial/tutorial_start.dox
@@ -13,6 +13,7 @@ Once you've downloaded PortAudio you'll need to compile it, which of course, dep
 
  - Windows
    - \ref compile_windows
+   - \ref compile_windows_mingw-w64
    - \ref compile_windows_mingw
    - \ref compile_windows_asio_msvc
  - Mac OS X


### PR DESCRIPTION
issue #426 

Thanks to Ross for directions to the doc files. I am just cruising by with no expertise on cmake, portaudio, mingw-w64, or Windows audio APIs. All of these are directly relevant to these proposed changes, so if a preference looks strange, know that it is not likely a preference I hold strongly.

I did not build the doxygen docs. I hope the links work, because there is a "-" inside the link "compile_windows_mingw-w64" and I am not sure if doxygen allows "-" in links.

Comparing to https://github.com/PortAudio/portaudio/wiki/Notes_about_building_PortAudio_with_MinGW: ASIO information is omitted because I don't know anything about ASIO. The other APIs build, but I have not tested using them.

I added a warning to mingw's documentation page because it appears to be a zombie project, as newbie bait for people who are looking for the "mingw" name and don't realize that people have moved to a different project. (This has happened to me and others in a few settings.) Ross notes that mingw's project page has moved, which I didn't know. But looking at their issue tracker, the activity is very low, reflecting an absence of use. Also, a wide diversity of programmers have recommended mingw-w64 over mingw for five years. These are evident through googling and appear unanimous. I do not believe anyone is making an informed choice of mingw over mingw-w64; the few people left are those confused by the brand name.