### PR TITLE
Update compile_windows_mingw-w64.dox

### DIFF
--- a/doc/src/tutorial/compile_windows_mingw-w64.dox
+++ b/doc/src/tutorial/compile_windows_mingw-w64.dox
@@ -16,7 +16,9 @@ You can either use msys2's precompiled PortAudio or compile PortAudio yourself. 
 
 Open your msys2 shell and run "pacman -S mingw-w64-x86_64-portaudio". This will get you a default build of PortAudio. I believe it comes with DirectSound, WASAPI, WD/MKS, WD/MKS_DEVICE_INFO, and WMME. Note the "-x86_64" in the middle of the package name. When you install msys2 packages, you specify the toolchain name in the middle, and "-x86_64" chooses the msvcrt-gcc toolchain.
 
-@section comp_mingw-w64_3 Compiling
+A downside of this approach is that it does not come with the API-specific headers, such as pa_win_wasapi.h. Thus, if you are interested in WASAPI exclusive mode, you must compile from scratch.
+
+@section comp_mingw-w64_3 Compiling from scratch
 
 We will build with WASAPI only, with no fallback APIs, simply as an example. In the msys2 shell, navigate into your folder of PortAudio. Run:
 
@@ -26,6 +28,11 @@ mkdir build
 cd build
 cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DPA_USE_DS=0 -DPA_USE_WDMKS=0 -DPA_USE_WDMKS_DEVICE_INFO=0 -DPA_USE_WMME=0
 cmake --build .
+@endcode
+
+To test if it is working, you can run the sawtooth example (warning, it is very loud!):
+
+@code
 gcc ../examples/paex_saw.c -I../src/common -lportaudio
 ./a.exe
 @endcode

--- a/doc/src/tutorial/compile_windows_mingw-w64.dox
+++ b/doc/src/tutorial/compile_windows_mingw-w64.dox
@@ -16,8 +16,6 @@ You can either use msys2's precompiled PortAudio or compile PortAudio yourself. 
 
 Open your msys2 shell and run "pacman -S mingw-w64-x86_64-portaudio". This will get you a default build of PortAudio. I believe it comes with DirectSound, WASAPI, WD/MKS, WD/MKS_DEVICE_INFO, and WMME. Note the "-x86_64" in the middle of the package name. When you install msys2 packages, you specify the toolchain name in the middle, and "-x86_64" chooses the msvcrt-gcc toolchain.
 
-A downside of this approach is that it does not come with the API-specific headers, such as pa_win_wasapi.h. Thus, if you are interested in WASAPI exclusive mode, you must compile from scratch.
-
 @section comp_mingw-w64_3 Compiling from scratch
 
 We will build with WASAPI only, with no fallback APIs, simply as an example. In the msys2 shell, navigate into your folder of PortAudio. Run:


### PR DESCRIPTION
The sawtooth example is absurdly loud. If it's left as part of the default build steps, it will probably cause some hearing damage. This moves it into a separate section with a warning.

An alternative fix would be to lower the sawtooth example to a reasonable volume; after all, if someone compiles it and runs it for another reason, it will have the same problem. Though, many of the examples are probably no different.