### PR TITLE
Make internal memory allocation utility functions allocate zero-initialized memory

### DIFF
--- a/examples/paex_ocean_shore.c
+++ b/examples/paex_ocean_shore.c
@@ -367,7 +367,7 @@ OceanWave* InitializeWave(double SR, float attackInSeconds, float maxLevel, floa
     static unsigned lastNoOfRows = 12;
     unsigned newNoOfRows;
 
-    wave = (OceanWave*)PaUtil_AllocateMemory(sizeof(OceanWave));
+    wave = (OceanWave*)PaUtil_AllocateZeroInitializedMemory(sizeof(OceanWave));
     if (wave != NULL)
     {
         InitializePinkNoise(&wave->wave_left, lastNoOfRows);
@@ -407,14 +407,14 @@ int main(void)
     static const int    FPB = 128; /* Frames per buffer: 2.9 ms buffers. */
 
     /* Initialize communication buffers (queues) */
-    data.rBufToRTData = PaUtil_AllocateMemory(sizeof(OceanWave*) * 256);
+    data.rBufToRTData = PaUtil_AllocateZeroInitializedMemory(sizeof(OceanWave*) * 256);
     if (data.rBufToRTData == NULL)
     {
         return 1;
     }
     PaUtil_InitializeRingBuffer(&data.rBufToRT, sizeof(OceanWave*), 256, data.rBufToRTData);
 
-    data.rBufFromRTData = PaUtil_AllocateMemory(sizeof(OceanWave*) * 256);
+    data.rBufFromRTData = PaUtil_AllocateZeroInitializedMemory(sizeof(OceanWave*) * 256);
     if (data.rBufFromRTData == NULL)
     {
         return 1;

--- a/examples/paex_record_file.c
+++ b/examples/paex_record_file.c
@@ -315,7 +315,7 @@ int main(void)
     /* We set the ring buffer size to about 500 ms */
     numSamples = NextPowerOf2((unsigned)(SAMPLE_RATE * 0.5 * NUM_CHANNELS));
     numBytes = numSamples * sizeof(SAMPLE);
-    data.ringBufferData = (SAMPLE *) PaUtil_AllocateMemory( numBytes );
+    data.ringBufferData = (SAMPLE *) PaUtil_AllocateZeroInitializedMemory( numBytes );
     if( data.ringBufferData == NULL )
     {
         printf("Could not allocate ring buffer data.\n");

--- a/src/common/pa_allocation.c
+++ b/src/common/pa_allocation.c
@@ -144,7 +144,7 @@ void PaUtil_DestroyAllocationGroup( PaUtilAllocationGroup* group )
 }
 
 
-void* PaUtil_GroupAllocateMemory( PaUtilAllocationGroup* group, long size )
+void* PaUtil_GroupAllocateZeroInitializedMemory( PaUtilAllocationGroup* group, long size )
 {
     struct PaUtilAllocationGroupLink *links, *link;
     void *result = 0;

--- a/src/common/pa_allocation.c
+++ b/src/common/pa_allocation.c
@@ -79,7 +79,7 @@ static struct PaUtilAllocationGroupLink *AllocateLinks( long count,
     struct PaUtilAllocationGroupLink *result;
     int i;
 
-    result = (struct PaUtilAllocationGroupLink *)PaUtil_AllocateMemory(
+    result = (struct PaUtilAllocationGroupLink *)PaUtil_AllocateZeroInitializedMemory(
             sizeof(struct PaUtilAllocationGroupLink) * count );
     if( result )
     {
@@ -109,7 +109,8 @@ PaUtilAllocationGroup* PaUtil_CreateAllocationGroup( void )
     links = AllocateLinks( PA_INITIAL_LINK_COUNT_, 0, 0 );
     if( links != 0 )
     {
-        result = (PaUtilAllocationGroup*)PaUtil_AllocateMemory( sizeof(PaUtilAllocationGroup) );
+        result = (PaUtilAllocationGroup*)PaUtil_AllocateZeroInitializedMemory(
+                sizeof(PaUtilAllocationGroup) );
         if( result )
         {
             result->linkCount = PA_INITIAL_LINK_COUNT_;
@@ -163,7 +164,7 @@ void* PaUtil_GroupAllocateMemory( PaUtilAllocationGroup* group, long size )
 
     if( group->spareLinks )
     {
-        result = PaUtil_AllocateMemory( size );
+        result = PaUtil_AllocateZeroInitializedMemory( size );
         if( result )
         {
             link = group->spareLinks;

--- a/src/common/pa_allocation.h
+++ b/src/common/pa_allocation.h
@@ -80,11 +80,12 @@ PaUtilAllocationGroup* PaUtil_CreateAllocationGroup( void );
 */
 void PaUtil_DestroyAllocationGroup( PaUtilAllocationGroup* group );
 
-/** Allocate a block of memory though an allocation group.
+/** Allocate a block of memory through the specified allocation group.
+The allocated block is zero-initialized.
 */
 void* PaUtil_GroupAllocateMemory( PaUtilAllocationGroup* group, long size );
 
-/** Free a block of memory that was previously allocated though an allocation
+/** Free a block of memory that was allocated through the specified allocation
  group. Calling this function is a relatively time consuming operation.
  Under normal circumstances clients should call PaUtil_FreeAllAllocations to
  free all allocated blocks simultaneously.

--- a/src/common/pa_allocation.h
+++ b/src/common/pa_allocation.h
@@ -83,7 +83,7 @@ void PaUtil_DestroyAllocationGroup( PaUtilAllocationGroup* group );
 /** Allocate a block of memory through the specified allocation group.
 The allocated block is zero-initialized.
 */
-void* PaUtil_GroupAllocateMemory( PaUtilAllocationGroup* group, long size );
+void* PaUtil_GroupAllocateZeroInitializedMemory( PaUtilAllocationGroup* group, long size );
 
 /** Free a block of memory that was allocated through the specified allocation
  group. Calling this function is a relatively time consuming operation.

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -201,7 +201,7 @@ static PaError InitializeHostApis( void )
 
     initializerCount = CountHostApiInitializers();
 
-    hostApis_ = (PaUtilHostApiRepresentation**)PaUtil_AllocateMemory(
+    hostApis_ = (PaUtilHostApiRepresentation**)PaUtil_AllocateZeroInitializedMemory(
             sizeof(PaUtilHostApiRepresentation*) * initializerCount );
     if( !hostApis_ )
     {

--- a/src/common/pa_process.c
+++ b/src/common/pa_process.c
@@ -257,7 +257,10 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         }
 
         if( bp->framesInTempInputBuffer > 0 )
-            memset( bp->tempInputBuffer, 0, tempInputBufferSize );
+        {
+            /* NOTE: we depend on bp->tempInputBuffer being zero-initialized by the allocator. */
+            /* memset( bp->tempInputBuffer, 0, tempInputBufferSize ); */
+        }
 
         if( userInputSampleFormat & paNonInterleaved )
         {
@@ -327,7 +330,10 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         }
 
         if( bp->framesInTempOutputBuffer > 0 )
-            memset( bp->tempOutputBuffer, 0, tempOutputBufferSize );
+        {
+            /* NOTE: we depend on bp->tempOutputBuffer being zero-initialized by the allocator. */
+            /* memset( bp->tempOutputBuffer, 0, tempOutputBufferSize ); */
+        }
 
         if( userOutputSampleFormat & paNonInterleaved )
         {

--- a/src/common/pa_process.c
+++ b/src/common/pa_process.c
@@ -249,7 +249,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         tempInputBufferSize =
             bp->framesPerTempBuffer * bp->bytesPerUserInputSample * inputChannelCount;
 
-        bp->tempInputBuffer = PaUtil_AllocateMemory( tempInputBufferSize );
+        bp->tempInputBuffer = PaUtil_AllocateZeroInitializedMemory( tempInputBufferSize );
         if( bp->tempInputBuffer == 0 )
         {
             result = paInsufficientMemory;
@@ -262,7 +262,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         if( userInputSampleFormat & paNonInterleaved )
         {
             bp->tempInputBufferPtrs =
-                (void **)PaUtil_AllocateMemory( sizeof(void*)*inputChannelCount );
+                (void **)PaUtil_AllocateZeroInitializedMemory( sizeof(void*)*inputChannelCount );
             if( bp->tempInputBufferPtrs == 0 )
             {
                 result = paInsufficientMemory;
@@ -271,7 +271,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         }
 
         bp->hostInputChannels[0] = (PaUtilChannelDescriptor*)
-                PaUtil_AllocateMemory( sizeof(PaUtilChannelDescriptor) * inputChannelCount * 2);
+                PaUtil_AllocateZeroInitializedMemory( sizeof(PaUtilChannelDescriptor) * inputChannelCount * 2);
         if( bp->hostInputChannels[0] == 0 )
         {
             result = paInsufficientMemory;
@@ -319,7 +319,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         tempOutputBufferSize =
                 bp->framesPerTempBuffer * bp->bytesPerUserOutputSample * outputChannelCount;
 
-        bp->tempOutputBuffer = PaUtil_AllocateMemory( tempOutputBufferSize );
+        bp->tempOutputBuffer = PaUtil_AllocateZeroInitializedMemory( tempOutputBufferSize );
         if( bp->tempOutputBuffer == 0 )
         {
             result = paInsufficientMemory;
@@ -332,7 +332,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         if( userOutputSampleFormat & paNonInterleaved )
         {
             bp->tempOutputBufferPtrs =
-                (void **)PaUtil_AllocateMemory( sizeof(void*)*outputChannelCount );
+                (void **)PaUtil_AllocateZeroInitializedMemory( sizeof(void*)*outputChannelCount );
             if( bp->tempOutputBufferPtrs == 0 )
             {
                 result = paInsufficientMemory;
@@ -341,7 +341,7 @@ PaError PaUtil_InitializeBufferProcessor( PaUtilBufferProcessor* bp,
         }
 
         bp->hostOutputChannels[0] = (PaUtilChannelDescriptor*)
-                PaUtil_AllocateMemory( sizeof(PaUtilChannelDescriptor)*outputChannelCount * 2 );
+                PaUtil_AllocateZeroInitializedMemory( sizeof(PaUtilChannelDescriptor)*outputChannelCount * 2 );
         if( bp->hostOutputChannels[0] == 0 )
         {
             result = paInsufficientMemory;

--- a/src/common/pa_trace.c
+++ b/src/common/pa_trace.c
@@ -120,7 +120,7 @@ static const unsigned kMagik = 0xcafebabe;
 
 int PaUtil_InitializeHighSpeedLog( LogHandle* phLog, unsigned maxSizeInBytes )
 {
-    PaHighPerformanceLog* pLog = (PaHighPerformanceLog*)PaUtil_AllocateMemory(sizeof(PaHighPerformanceLog));
+    PaHighPerformanceLog* pLog = (PaHighPerformanceLog*)PaUtil_AllocateZeroInitializedMemory(sizeof(PaHighPerformanceLog));
     if (pLog == 0)
     {
         return paInsufficientMemory;
@@ -128,7 +128,7 @@ int PaUtil_InitializeHighSpeedLog( LogHandle* phLog, unsigned maxSizeInBytes )
     assert(phLog != 0);
     *phLog = pLog;
 
-    pLog->data = (char*)PaUtil_AllocateMemory(maxSizeInBytes);
+    pLog->data = (char*)PaUtil_AllocateZeroInitializedMemory(maxSizeInBytes);
     if (pLog->data == 0)
     {
         PaUtil_FreeMemory(pLog);

--- a/src/common/pa_util.h
+++ b/src/common/pa_util.h
@@ -124,11 +124,14 @@ void PaUtil_SetLastHostErrorInfo( PaHostApiTypeId hostApiType, long errorCode,
  .c file
 */
 
-/** Allocate size bytes, guaranteed to be aligned to a FIXME byte boundary */
+/** Allocate size bytes of zero-initialized memory.
+Guaranteed to be aligned to a FIXME byte boundary.
+*/
 void *PaUtil_AllocateMemory( long size );
 
 
-/** Release block if non-NULL. block may be NULL */
+/** Release block previously allocated by PaUtil_AllocateMemory() if non-NULL.
+block may be NULL */
 void PaUtil_FreeMemory( void *block );
 
 

--- a/src/common/pa_util.h
+++ b/src/common/pa_util.h
@@ -127,11 +127,11 @@ void PaUtil_SetLastHostErrorInfo( PaHostApiTypeId hostApiType, long errorCode,
 /** Allocate size bytes of zero-initialized memory.
 Guaranteed to be aligned to a FIXME byte boundary.
 */
-void *PaUtil_AllocateMemory( long size );
+void *PaUtil_AllocateZeroInitializedMemory( long size );
 
 
-/** Release block previously allocated by PaUtil_AllocateMemory() if non-NULL.
-block may be NULL */
+/** Release block allocated by PaUtil_AllocateZeroInitializedMemory()
+if block is non-NULL. block may be NULL */
 void PaUtil_FreeMemory( void *block );
 
 

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -1056,7 +1056,7 @@ static PaError PaAlsa_StrDup( PaAlsaHostApiRepresentation *alsaApi,
 
     /* PA_DEBUG(("PaStrDup %s %d\n", src, len)); */
 
-    PA_UNLESS( *dst = (char *)PaUtil_GroupAllocateMemory( alsaApi->allocations, len ),
+    PA_UNLESS( *dst = (char *)PaUtil_GroupAllocateZeroInitializedMemory( alsaApi->allocations, len ),
             paInsufficientMemory );
     strncpy( *dst, src, len );
 
@@ -1332,7 +1332,7 @@ static PaError BuildDeviceList( PaAlsaHostApiRepresentation *alsaApi )
 
             /* The length of the string written by snprintf plus terminating 0 */
             len = snprintf( NULL, 0, "%s: %s (%s)", cardName, infoName, buf ) + 1;
-            PA_UNLESS( deviceName = (char *)PaUtil_GroupAllocateMemory( alsaApi->allocations, len ),
+            PA_UNLESS( deviceName = (char *)PaUtil_GroupAllocateZeroInitializedMemory( alsaApi->allocations, len ),
                     paInsufficientMemory );
             snprintf( deviceName, len, "%s: %s (%s)", cardName, infoName, buf );
 
@@ -1397,10 +1397,10 @@ static PaError BuildDeviceList( PaAlsaHostApiRepresentation *alsaApi )
             }
             PA_DEBUG(( "%s: Found plugin [%s] of type [%s]\n", __FUNCTION__, idStr, tpStr ));
 
-            PA_UNLESS( alsaDeviceName = (char*)PaUtil_GroupAllocateMemory( alsaApi->allocations,
+            PA_UNLESS( alsaDeviceName = (char*)PaUtil_GroupAllocateZeroInitializedMemory( alsaApi->allocations,
                                                             strlen(idStr) + 6 ), paInsufficientMemory );
             strcpy( alsaDeviceName, idStr );
-            PA_UNLESS( deviceName = (char*)PaUtil_GroupAllocateMemory( alsaApi->allocations,
+            PA_UNLESS( deviceName = (char*)PaUtil_GroupAllocateZeroInitializedMemory( alsaApi->allocations,
                                                             strlen(idStr) + 1 ), paInsufficientMemory );
             strcpy( deviceName, idStr );
 
@@ -1434,11 +1434,11 @@ static PaError BuildDeviceList( PaAlsaHostApiRepresentation *alsaApi )
         PA_DEBUG(( "%s: Iterating over ALSA plugins failed: %s\n", __FUNCTION__, alsa_snd_strerror( res ) ));
 
     /* allocate deviceInfo memory based on the number of devices */
-    PA_UNLESS( baseApi->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+    PA_UNLESS( baseApi->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
             alsaApi->allocations, sizeof(PaDeviceInfo*) * (numDeviceNames) ), paInsufficientMemory );
 
     /* allocate all device info structs in a contiguous block */
-    PA_UNLESS( deviceInfoArray = (PaAlsaDeviceInfo*)PaUtil_GroupAllocateMemory(
+    PA_UNLESS( deviceInfoArray = (PaAlsaDeviceInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
             alsaApi->allocations, sizeof(PaAlsaDeviceInfo) * numDeviceNames ), paInsufficientMemory );
 
     /* Loop over list of cards, filling in info. If a device is deemed unavailable (can't get name),

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -749,7 +749,7 @@ PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
     if (!PaAlsa_LoadLibrary())
         return paHostApiNotFound;
 
-    PA_UNLESS( alsaHostApi = (PaAlsaHostApiRepresentation*) PaUtil_AllocateMemory(
+    PA_UNLESS( alsaHostApi = (PaAlsaHostApiRepresentation*) PaUtil_AllocateZeroInitializedMemory(
                 sizeof(PaAlsaHostApiRepresentation) ), paInsufficientMemory );
     PA_UNLESS( alsaHostApi->allocations = PaUtil_CreateAllocationGroup(), paInsufficientMemory );
     alsaHostApi->hostApiIndex = hostApiIndex;
@@ -1927,7 +1927,7 @@ static PaError PaAlsaStreamComponent_Initialize( PaAlsaStreamComponent *self, Pa
     if( !callbackMode && !self->userInterleaved )
     {
         /* Pre-allocate non-interleaved user provided buffers */
-        PA_UNLESS( self->userBuffers = PaUtil_AllocateMemory( sizeof (void *) * self->numUserChannels ),
+        PA_UNLESS( self->userBuffers = PaUtil_AllocateZeroInitializedMemory( sizeof (void *) * self->numUserChannels ),
                 paInsufficientMemory );
     }
 
@@ -2183,7 +2183,7 @@ static PaError PaAlsaStream_Initialize( PaAlsaStream *self, PaAlsaHostApiReprese
 
     assert( self->capture.nfds || self->playback.nfds );
 
-    PA_UNLESS( self->pfds = (struct pollfd*)PaUtil_AllocateMemory( ( self->capture.nfds +
+    PA_UNLESS( self->pfds = (struct pollfd*)PaUtil_AllocateZeroInitializedMemory( ( self->capture.nfds +
                     self->playback.nfds ) * sizeof( struct pollfd ) ), paInsufficientMemory );
 
     PaUtil_InitializeCpuLoadMeasurer( &self->cpuLoadMeasurer, sampleRate );
@@ -2842,7 +2842,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         framesPerBuffer = atoi( getenv("PA_ALSA_PERIODSIZE") );
     }
 
-    PA_UNLESS( stream = (PaAlsaStream*)PaUtil_AllocateMemory( sizeof(PaAlsaStream) ), paInsufficientMemory );
+    PA_UNLESS( stream = (PaAlsaStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAlsaStream) ), paInsufficientMemory );
     PA_ENSURE( PaAlsaStream_Initialize( stream, alsaHostApi, inputParameters, outputParameters, sampleRate,
                 framesPerBuffer, callback, streamFlags, userData ) );
 

--- a/src/hostapi/asihpi/pa_linux_asihpi.c
+++ b/src/hostapi/asihpi/pa_linux_asihpi.c
@@ -1684,7 +1684,6 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     /* Create blank stream structure */
     PA_UNLESS_( stream = (PaAsiHpiStream *)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsiHpiStream) ),
                 paInsufficientMemory );
-    memset( stream, 0, sizeof(PaAsiHpiStream) );
 
     /* If the number of frames per buffer is unspecified, we have to come up with one. */
     if( framesPerHostBuffer == paFramesPerBufferUnspecified )
@@ -1721,7 +1720,6 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         /* Create blank stream component structure */
         PA_UNLESS_( stream->input = (PaAsiHpiStreamComponent *)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsiHpiStreamComponent) ),
                     paInsufficientMemory );
-        memset( stream->input, 0, sizeof(PaAsiHpiStreamComponent) );
         /* Create/validate format */
         PA_ENSURE_( PaAsiHpi_CreateFormat( hostApi, inputParameters, sampleRate,
                                            &stream->input->hpiDevice, &stream->input->hpiFormat ) );
@@ -1742,7 +1740,6 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         /* Create blank stream component structure */
         PA_UNLESS_( stream->output = (PaAsiHpiStreamComponent *)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsiHpiStreamComponent) ),
                     paInsufficientMemory );
-        memset( stream->output, 0, sizeof(PaAsiHpiStreamComponent) );
         /* Create/validate format */
         PA_ENSURE_( PaAsiHpi_CreateFormat( hostApi, outputParameters, sampleRate,
                                            &stream->output->hpiDevice, &stream->output->hpiFormat ) );

--- a/src/hostapi/asihpi/pa_linux_asihpi.c
+++ b/src/hostapi/asihpi/pa_linux_asihpi.c
@@ -750,7 +750,7 @@ PaError PaAsiHpi_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
     }
 
     /* Allocate host API structure */
-    PA_UNLESS_( hpiHostApi = (PaAsiHpiHostApiRepresentation*) PaUtil_AllocateMemory(
+    PA_UNLESS_( hpiHostApi = (PaAsiHpiHostApiRepresentation*) PaUtil_AllocateZeroInitializedMemory(
                                  sizeof(PaAsiHpiHostApiRepresentation) ), paInsufficientMemory );
     PA_UNLESS_( hpiHostApi->allocations = PaUtil_CreateAllocationGroup(), paInsufficientMemory );
 
@@ -1622,7 +1622,7 @@ static PaError PaAsiHpi_SetupBuffers( PaAsiHpiStreamComponent *streamComp, uint3
     /* Temp buffer size should be multiple of PA host buffer size (or 1x, if using fixed blocks) */
     streamComp->tempBufferSize = paHostBufferSize;
     /* Allocate temp buffer */
-    PA_UNLESS_( streamComp->tempBuffer = (uint8_t *)PaUtil_AllocateMemory( streamComp->tempBufferSize ),
+    PA_UNLESS_( streamComp->tempBuffer = (uint8_t *)PaUtil_AllocateZeroInitializedMemory( streamComp->tempBufferSize ),
                 paInsufficientMemory );
 error:
     return result;
@@ -1682,7 +1682,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         return paInvalidFlag; /* unexpected platform-specific flag */
 
     /* Create blank stream structure */
-    PA_UNLESS_( stream = (PaAsiHpiStream *)PaUtil_AllocateMemory( sizeof(PaAsiHpiStream) ),
+    PA_UNLESS_( stream = (PaAsiHpiStream *)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsiHpiStream) ),
                 paInsufficientMemory );
     memset( stream, 0, sizeof(PaAsiHpiStream) );
 
@@ -1719,7 +1719,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( inputParameters )
     {
         /* Create blank stream component structure */
-        PA_UNLESS_( stream->input = (PaAsiHpiStreamComponent *)PaUtil_AllocateMemory( sizeof(PaAsiHpiStreamComponent) ),
+        PA_UNLESS_( stream->input = (PaAsiHpiStreamComponent *)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsiHpiStreamComponent) ),
                     paInsufficientMemory );
         memset( stream->input, 0, sizeof(PaAsiHpiStreamComponent) );
         /* Create/validate format */
@@ -1740,7 +1740,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( outputParameters )
     {
         /* Create blank stream component structure */
-        PA_UNLESS_( stream->output = (PaAsiHpiStreamComponent *)PaUtil_AllocateMemory( sizeof(PaAsiHpiStreamComponent) ),
+        PA_UNLESS_( stream->output = (PaAsiHpiStreamComponent *)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsiHpiStreamComponent) ),
                     paInsufficientMemory );
         memset( stream->output, 0, sizeof(PaAsiHpiStreamComponent) );
         /* Create/validate format */
@@ -1790,7 +1790,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
                                                streamCallback, userData );
         /* Pre-allocate non-interleaved user buffer pointers for blocking interface */
         PA_UNLESS_( stream->blockingUserBufferCopy =
-                        PaUtil_AllocateMemory( sizeof(void *) * PA_MAX( inputChannelCount, outputChannelCount ) ),
+                        PaUtil_AllocateZeroInitializedMemory( sizeof(void *) * PA_MAX( inputChannelCount, outputChannelCount ) ),
                     paInsufficientMemory );
         stream->callbackMode = 0;
     }

--- a/src/hostapi/asihpi/pa_linux_asihpi.c
+++ b/src/hostapi/asihpi/pa_linux_asihpi.c
@@ -579,11 +579,11 @@ static PaError PaAsiHpi_BuildDeviceList( PaAsiHpiHostApiRepresentation *hpiHostA
     if( deviceCount > 0 )
     {
         /* Memory allocation */
-        PA_UNLESS_( hostApi->deviceInfos = (PaDeviceInfo**) PaUtil_GroupAllocateMemory(
+        PA_UNLESS_( hostApi->deviceInfos = (PaDeviceInfo**) PaUtil_GroupAllocateZeroInitializedMemory(
                                                hpiHostApi->allocations, sizeof(PaDeviceInfo*) * deviceCount ),
                     paInsufficientMemory );
         /* Allocate all device info structs in a contiguous block */
-        PA_UNLESS_( hpiDeviceList = (PaAsiHpiDeviceInfo*) PaUtil_GroupAllocateMemory(
+        PA_UNLESS_( hpiDeviceList = (PaAsiHpiDeviceInfo*) PaUtil_GroupAllocateZeroInitializedMemory(
                                         hpiHostApi->allocations, sizeof(PaAsiHpiDeviceInfo) * deviceCount ),
                     paInsufficientMemory );
 
@@ -640,7 +640,7 @@ static PaError PaAsiHpi_BuildDeviceList( PaAsiHpiHostApiRepresentation *hpiHostA
                 /* Make sure name string is owned by API info structure */
                 sprintf( srcName,
                          "Adapter %d (%4X) - Input Stream %d", i+1, type, j+1 );
-                PA_UNLESS_( deviceName = (char *) PaUtil_GroupAllocateMemory(
+                PA_UNLESS_( deviceName = (char *) PaUtil_GroupAllocateZeroInitializedMemory(
                                              hpiHostApi->allocations, strlen(srcName) + 1 ), paInsufficientMemory );
                 strcpy( deviceName, srcName );
                 baseDeviceInfo->name = deviceName;
@@ -682,7 +682,7 @@ static PaError PaAsiHpi_BuildDeviceList( PaAsiHpiHostApiRepresentation *hpiHostA
                 /* Make sure name string is owned by API info structure */
                 sprintf( srcName,
                          "Adapter %d (%4X) - Output Stream %d", i+1, type, j+1 );
-                PA_UNLESS_( deviceName = (char *) PaUtil_GroupAllocateMemory(
+                PA_UNLESS_( deviceName = (char *) PaUtil_GroupAllocateZeroInitializedMemory(
                                              hpiHostApi->allocations, strlen(srcName) + 1 ), paInsufficientMemory );
                 strcpy( deviceName, srcName );
                 baseDeviceInfo->name = deviceName;

--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -1164,7 +1164,7 @@ PaError PaAsio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
     PaAsioHostApiRepresentation *asioHostApi;
     PaAsioDeviceInfo *deviceInfoArray;
     char **names;
-    asioHostApi = (PaAsioHostApiRepresentation*)PaUtil_AllocateMemory( sizeof(PaAsioHostApiRepresentation) );
+    asioHostApi = (PaAsioHostApiRepresentation*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsioHostApiRepresentation) );
     if( !asioHostApi )
     {
         result = paInsufficientMemory;
@@ -2164,7 +2164,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     }
 
 
-    stream = (PaAsioStream*)PaUtil_AllocateMemory( sizeof(PaAsioStream) );
+    stream = (PaAsioStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsioStream) );
     if( !stream )
     {
         result = paInsufficientMemory;
@@ -2208,7 +2208,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     PaUtil_InitializeCpuLoadMeasurer( &stream->cpuLoadMeasurer, sampleRate );
 
 
-    stream->asioBufferInfos = (ASIOBufferInfo*)PaUtil_AllocateMemory(
+    stream->asioBufferInfos = (ASIOBufferInfo*)PaUtil_AllocateZeroInitializedMemory(
             sizeof(ASIOBufferInfo) * (inputChannelCount + outputChannelCount) );
     if( !stream->asioBufferInfos )
     {
@@ -2326,7 +2326,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 
     asioBuffersCreated = 1;
 
-    stream->asioChannelInfos = (ASIOChannelInfo*)PaUtil_AllocateMemory(
+    stream->asioChannelInfos = (ASIOChannelInfo*)PaUtil_AllocateZeroInitializedMemory(
             sizeof(ASIOChannelInfo) * (inputChannelCount + outputChannelCount) );
     if( !stream->asioChannelInfos )
     {
@@ -2349,7 +2349,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         }
     }
 
-    stream->bufferPtrs = (void**)PaUtil_AllocateMemory(
+    stream->bufferPtrs = (void**)PaUtil_AllocateZeroInitializedMemory(
             2 * sizeof(void*) * (inputChannelCount + outputChannelCount) );
     if( !stream->bufferPtrs )
     {
@@ -2443,7 +2443,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( usingBlockingIo )
     {
         /* Allocate the blocking i/o input ring buffer memory. */
-        stream->blockingState = (PaAsioStreamBlockingState*)PaUtil_AllocateMemory( sizeof(PaAsioStreamBlockingState) );
+        stream->blockingState = (PaAsioStreamBlockingState*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaAsioStreamBlockingState) );
         if( !stream->blockingState )
         {
             result = paInsufficientMemory;
@@ -2526,7 +2526,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 
 
             /* Create pointer buffer to access non-interleaved data in ReadStream() */
-            stream->blockingState->readStreamBuffer = (void**)PaUtil_AllocateMemory( sizeof(void*) * inputChannelCount );
+            stream->blockingState->readStreamBuffer = (void**)PaUtil_AllocateZeroInitializedMemory( sizeof(void*) * inputChannelCount );
             if( !stream->blockingState->readStreamBuffer )
             {
                 result = paInsufficientMemory;
@@ -2583,7 +2583,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             lBytesPerFrame = inputChannelCount * Pa_GetSampleSize(inputSampleFormat );
 
             /* Allocate the blocking i/o input ring buffer memory. */
-            stream->blockingState->readRingBufferData = (void*)PaUtil_AllocateMemory( lBlockingBufferSize * lBytesPerFrame );
+            stream->blockingState->readRingBufferData = (void*)PaUtil_AllocateZeroInitializedMemory( lBlockingBufferSize * lBytesPerFrame );
             if( !stream->blockingState->readRingBufferData )
             {
                 result = paInsufficientMemory;
@@ -2612,7 +2612,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             blockingWriteBuffersReadyEventInitialized = 1;
 
             /* Create pointer buffer to access non-interleaved data in WriteStream() */
-            stream->blockingState->writeStreamBuffer = (const void**)PaUtil_AllocateMemory( sizeof(const void*) * outputChannelCount );
+            stream->blockingState->writeStreamBuffer = (const void**)PaUtil_AllocateZeroInitializedMemory( sizeof(const void*) * outputChannelCount );
             if( !stream->blockingState->writeStreamBuffer )
             {
                 result = paInsufficientMemory;
@@ -2674,7 +2674,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             lBytesPerFrame = outputChannelCount * Pa_GetSampleSize(outputSampleFormat);
 
             /* Allocate the blocking i/o output ring buffer memory. */
-            stream->blockingState->writeRingBufferData = (void*)PaUtil_AllocateMemory( lBlockingBufferSize * lBytesPerFrame );
+            stream->blockingState->writeRingBufferData = (void*)PaUtil_AllocateZeroInitializedMemory( lBlockingBufferSize * lBytesPerFrame );
             if( !stream->blockingState->writeRingBufferData )
             {
                 result = paInsufficientMemory;

--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -312,12 +312,12 @@ static char **GetAsioDriverNames( PaAsioHostApiRepresentation *asioHostApi, PaUt
     char **result = 0;
     int i;
 
-    result =(char**)PaUtil_GroupAllocateMemory(
+    result =(char**)PaUtil_GroupAllocateZeroInitializedMemory(
             group, sizeof(char*) * driverCount );
     if( !result )
         goto error;
 
-    result[0] = (char*)PaUtil_GroupAllocateMemory(
+    result[0] = (char*)PaUtil_GroupAllocateZeroInitializedMemory(
             group, 32 * driverCount );
     if( !result[0] )
         goto error;
@@ -1097,7 +1097,7 @@ static PaError InitPaDeviceInfoFromAsioDriver( PaAsioHostApiRepresentation *asio
         asioDeviceInfo->bufferGranularity = paAsioDriver.info.bufferGranularity;
 
 
-        asioDeviceInfo->asioChannelInfos = (ASIOChannelInfo*)PaUtil_GroupAllocateMemory(
+        asioDeviceInfo->asioChannelInfos = (ASIOChannelInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
                 asioHostApi->allocations,
                 sizeof(ASIOChannelInfo) * (deviceInfo->maxInputChannels
                         + deviceInfo->maxOutputChannels) );
@@ -1254,7 +1254,7 @@ PaError PaAsio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
 
         /* allocate enough space for all drivers, even if some aren't installed */
 
-        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
                 asioHostApi->allocations, sizeof(PaDeviceInfo*) * driverCount );
         if( !(*hostApi)->deviceInfos )
         {
@@ -1263,7 +1263,7 @@ PaError PaAsio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
         }
 
         /* allocate all device info structs in a contiguous block */
-        deviceInfoArray = (PaAsioDeviceInfo*)PaUtil_GroupAllocateMemory(
+        deviceInfoArray = (PaAsioDeviceInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
                 asioHostApi->allocations, sizeof(PaAsioDeviceInfo) * driverCount );
         if( !deviceInfoArray )
         {

--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -1171,7 +1171,8 @@ PaError PaAsio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
         goto error;
     }
 
-    memset( asioHostApi, 0, sizeof(PaAsioHostApiRepresentation) ); /* ensure all fields are zeroed. especially asioHostApi->allocations */
+    /* NOTE: we depend on PaUtil_AllocateZeroInitializedMemory() ensuring that all
+       fields are set to zero. especially asioHostApi->allocations */
 
     /*
         We initialize COM ourselves here and uninitialize it in Terminate().

--- a/src/hostapi/audioio/pa_unix_audioio.c
+++ b/src/hostapi/audioio/pa_unix_audioio.c
@@ -29,13 +29,13 @@
  */
 
 /*
- * The text above constitutes the entire PortAudio license; however, 
+ * The text above constitutes the entire PortAudio license; however,
  * the PortAudio community also makes the following non-binding requests:
  *
  * Any person wishing to distribute modifications to the Software is
  * requested to send the modifications to the original developer so that
- * they can be incorporated into the canonical version. It is also 
- * requested that these non-binding requests be included along with the 
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
  * license above.
  */
 
@@ -168,7 +168,7 @@ PaError PaAudioIO_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIn
 
     PA_UNLESS( audioIOHostApi->allocations = PaUtil_CreateAllocationGroup(), paInsufficientMemory );
 
-    if( (common->deviceInfos = PaUtil_GroupAllocateMemory(
+    if( (common->deviceInfos = PaUtil_GroupAllocateZeroInitializedMemory(
          audioIOHostApi->allocations, sizeof(PaDeviceInfo *) * AUDIOIO_MAX_DEVICES)) == NULL )
     {
         result = paInsufficientMemory;
@@ -193,12 +193,12 @@ PaError PaAudioIO_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIn
         if (fd < 0)
             continue;
 
-        PA_UNLESS(dev = PaUtil_GroupAllocateMemory(audioIOHostApi->allocations, sizeof(PaDeviceInfo)), paInsufficientMemory);
+        PA_UNLESS(dev = PaUtil_GroupAllocateZeroInitializedMemory(audioIOHostApi->allocations, sizeof(PaDeviceInfo)), paInsufficientMemory);
 
         dev->structVersion = 2;
         dev->hostApi = hostApiIndex;
 
-        PA_UNLESS(dev->name = PaUtil_GroupAllocateMemory(audioIOHostApi->allocations, sizeof(path)), paInsufficientMemory);
+        PA_UNLESS(dev->name = PaUtil_GroupAllocateZeroInitializedMemory(audioIOHostApi->allocations, sizeof(path)), paInsufficientMemory);
 
         memcpy((char *)dev->name, path, sizeof(path));
 

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -1777,13 +1777,12 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         goto error;
     }
 
-    /* If we fail after this point, we my be left in a bad state, with
-       some data structures setup and others not. So, first thing we
-       do is initialize everything so that if we fail, we know what hasn't
-       been touched.
+    /* NOTE: If we fail after this point, we my be left in a bad state, with
+       some data structures setup and others not. So, we critically depend on all
+       stream fields being zero-initialized so that if we fail, we know what
+       hasn't been touched. Zero-initialization is guaranteed by
+       PaUtil_AllocateZeroInitializedMemory().
      */
-    bzero( stream, sizeof( PaMacCoreStream ) );
-
     /*
     stream->blio.inputRingBuffer.buffer = NULL;
     stream->blio.outputRingBuffer.buffer = NULL;

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -596,7 +596,7 @@ static PaError GetChannelInfo( PaMacAUHAL *auhalHostApi,
     if (err)
         return err;
 
-    buflist = PaUtil_AllocateMemory(propSize);
+    buflist = PaUtil_AllocateZeroInitializedMemory(propSize);
     if( !buflist )
         return paInsufficientMemory;
     err = ERR(PaMacCore_AudioDeviceGetProperty(macCoreDeviceId, 0, isInput, kAudioDevicePropertyStreamConfiguration, &propSize, buflist));
@@ -740,7 +740,7 @@ PaError PaMacCore_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIn
         return UNIX_ERR(unixErr);
     }
 
-    auhalHostApi = (PaMacAUHAL*)PaUtil_AllocateMemory( sizeof(PaMacAUHAL) );
+    auhalHostApi = (PaMacAUHAL*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaMacAUHAL) );
     if( !auhalHostApi )
     {
         result = paInsufficientMemory;
@@ -1770,7 +1770,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( (streamFlags & paPlatformSpecificFlags) != 0 )
         return paInvalidFlag; /* unexpected platform specific flag */
 
-    stream = (PaMacCoreStream*)PaUtil_AllocateMemory( sizeof(PaMacCoreStream) );
+    stream = (PaMacCoreStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaMacCoreStream) );
     if( !stream )
     {
         result = paInsufficientMemory;

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -357,7 +357,7 @@ static PaError gatherDeviceInfo(PaMacAUHAL *auhalHostApi)
     VDBUG( ( "Found %ld device(s).\n", auhalHostApi->devCount ) );
 
     /* -- copy the device IDs -- */
-    auhalHostApi->devIds = (AudioDeviceID *)PaUtil_GroupAllocateMemory(
+    auhalHostApi->devIds = (AudioDeviceID *)PaUtil_GroupAllocateZeroInitializedMemory(
                                auhalHostApi->allocations,
                                propsize );
     if( !auhalHostApi->devIds )
@@ -675,7 +675,7 @@ static PaError InitializeDeviceInfo( PaMacAUHAL *auhalHostApi,
         if (err)
             return err;
 
-        name = PaUtil_GroupAllocateMemory(auhalHostApi->allocations,propSize+1);
+        name = PaUtil_GroupAllocateZeroInitializedMemory(auhalHostApi->allocations,propSize+1);
         if ( !name )
             return paInsufficientMemory;
         err = ERR(PaMacCore_AudioDeviceGetProperty(macCoreDeviceId, 0, 0, kAudioDevicePropertyDeviceName, &propSize, name));
@@ -686,7 +686,7 @@ static PaError InitializeDeviceInfo( PaMacAUHAL *auhalHostApi,
     {
         /* valid CFString so we just allocate a c string big enough to contain the data */
         propSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(nameRef), kCFStringEncodingUTF8);
-        name = PaUtil_GroupAllocateMemory(auhalHostApi->allocations, propSize+1);
+        name = PaUtil_GroupAllocateZeroInitializedMemory(auhalHostApi->allocations, propSize+1);
         if ( !name )
         {
             CFRelease(nameRef);
@@ -774,7 +774,7 @@ PaError PaMacCore_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIn
 
     if( auhalHostApi->devCount > 0 )
     {
-        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
                 auhalHostApi->allocations, sizeof(PaDeviceInfo*) * auhalHostApi->devCount);
         if( !(*hostApi)->deviceInfos )
         {
@@ -783,7 +783,7 @@ PaError PaMacCore_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIn
         }
 
         /* allocate all device info structs in a contiguous block */
-        deviceInfoArray = (PaDeviceInfo*)PaUtil_GroupAllocateMemory(
+        deviceInfoArray = (PaDeviceInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
                 auhalHostApi->allocations, sizeof(PaDeviceInfo) * auhalHostApi->devCount );
         if( !deviceInfoArray )
         {

--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -1207,7 +1207,8 @@ PaError PaWinDs_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInde
         goto error;
     }
 
-    memset( winDsHostApi, 0, sizeof(PaWinDsHostApiRepresentation) ); /* ensure all fields are zeroed. especially winDsHostApi->allocations */
+    /* NOTE: we depend on PaUtil_AllocateZeroInitializedMemory() ensuring that all
+       fields are set to zero. especially winDsHostApi->allocations */
 
     result = PaWinUtil_CoInitialize( paDirectSound, &winDsHostApi->comInitializationResult );
     if( result != paNoError )
@@ -2024,7 +2025,8 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         goto error;
     }
 
-    memset( stream, 0, sizeof(PaWinDsStream) ); /* initialize all stream variables to 0 */
+    /* NOTE: we depend on PaUtil_AllocateZeroInitializedMemory() ensuring that all
+       stream fields are set to zero. */
 
     if( streamCallback )
     {

--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -1199,7 +1199,8 @@ PaError PaWinDs_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInde
     deviceNamesAndGUIDs.inputNamesAndGUIDs.items = NULL;
     deviceNamesAndGUIDs.outputNamesAndGUIDs.items = NULL;
 
-    winDsHostApi = (PaWinDsHostApiRepresentation*)PaUtil_AllocateMemory( sizeof(PaWinDsHostApiRepresentation) );
+    winDsHostApi = (PaWinDsHostApiRepresentation*)
+            PaUtil_AllocateZeroInitializedMemory(sizeof(PaWinDsHostApiRepresentation) );
     if( !winDsHostApi )
     {
         result = paInsufficientMemory;
@@ -2016,7 +2017,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         return paInvalidFlag; /* unexpected platform specific flag */
 
 
-    stream = (PaWinDsStream*)PaUtil_AllocateMemory( sizeof(PaWinDsStream) );
+    stream = (PaWinDsStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinDsStream) );
     if( !stream )
     {
         result = paInsufficientMemory;

--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -420,7 +420,7 @@ static char *DuplicateDeviceNameString( PaUtilAllocationGroup *allocations, cons
     {
         size_t len = WideCharToMultiByte(CP_UTF8, 0, src, -1, NULL, 0, NULL, NULL);
 
-        result = (char*)PaUtil_GroupAllocateMemory( allocations, (long)(len + 1) );
+        result = (char*)PaUtil_GroupAllocateZeroInitializedMemory( allocations, (long)(len + 1) );
         if( result ) {
             if (WideCharToMultiByte(CP_UTF8, 0, src, -1, result, (int)len, NULL, NULL) == 0) {
                 result = 0;
@@ -429,7 +429,7 @@ static char *DuplicateDeviceNameString( PaUtilAllocationGroup *allocations, cons
     }
     else
     {
-        result = (char*)PaUtil_GroupAllocateMemory( allocations, 1 );
+        result = (char*)PaUtil_GroupAllocateZeroInitializedMemory( allocations, 1 );
         if( result )
             result[0] = '\0';
     }
@@ -598,7 +598,7 @@ static void *DuplicateWCharString( PaUtilAllocationGroup *allocations, wchar_t *
     wchar_t *result;
 
     len = wcslen( source );
-    result = (wchar_t*)PaUtil_GroupAllocateMemory( allocations, (long) ((len+1) * sizeof(wchar_t)) );
+    result = (wchar_t*)PaUtil_GroupAllocateZeroInitializedMemory( allocations, (long) ((len+1) * sizeof(wchar_t)) );
     wcscpy( result, source );
     return result;
 }
@@ -1271,7 +1271,7 @@ PaError PaWinDs_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInde
     if( deviceCount > 0 )
     {
         /* allocate array for pointers to PaDeviceInfo structs */
-        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
                 winDsHostApi->allocations, sizeof(PaDeviceInfo*) * deviceCount );
         if( !(*hostApi)->deviceInfos )
         {
@@ -1280,7 +1280,7 @@ PaError PaWinDs_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInde
         }
 
         /* allocate all PaDeviceInfo structs in a contiguous block */
-        deviceInfoArray = (PaWinDsDeviceInfo*)PaUtil_GroupAllocateMemory(
+        deviceInfoArray = (PaWinDsDeviceInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
                 winDsHostApi->allocations, sizeof(PaWinDsDeviceInfo) * deviceCount );
         if( !deviceInfoArray )
         {

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -983,22 +983,22 @@ static PaError InitializeStream( PaJackStream *stream, PaJackHostApiRepresentati
         UNLESS( stream->local_input_ports =
                 (jack_port_t**) PaUtil_GroupAllocateZeroInitializedMemory( stream->stream_memory, sizeof(jack_port_t*) * numInputChannels ),
                 paInsufficientMemory );
-        memset( stream->local_input_ports, 0, sizeof(jack_port_t*) * numInputChannels );
+        /* NOTE: we depend on stream->local_input_ports being zero-initialized */
         UNLESS( stream->remote_output_ports =
                 (jack_port_t**) PaUtil_GroupAllocateZeroInitializedMemory( stream->stream_memory, sizeof(jack_port_t*) * numInputChannels ),
                 paInsufficientMemory );
-        memset( stream->remote_output_ports, 0, sizeof(jack_port_t*) * numInputChannels );
+        /* NOTE: we depend on stream->remote_output_ports being zero-initialized */
     }
     if( numOutputChannels > 0 )
     {
         UNLESS( stream->local_output_ports =
                 (jack_port_t**) PaUtil_GroupAllocateZeroInitializedMemory( stream->stream_memory, sizeof(jack_port_t*) * numOutputChannels ),
                 paInsufficientMemory );
-        memset( stream->local_output_ports, 0, sizeof(jack_port_t*) * numOutputChannels );
+        /* NOTE: we depend on stream->local_output_ports being zero-initialized */
         UNLESS( stream->remote_input_ports =
                 (jack_port_t**) PaUtil_GroupAllocateZeroInitializedMemory( stream->stream_memory, sizeof(jack_port_t*) * numOutputChannels ),
                 paInsufficientMemory );
-        memset( stream->remote_input_ports, 0, sizeof(jack_port_t*) * numOutputChannels );
+        /* NOTE: we depend on stream->remote_input_ports being zero-initialized */
     }
 
     stream->num_incoming_connections = numInputChannels;

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -760,7 +760,7 @@ PaError PaJack_Initialize( PaUtilHostApiRepresentation **hostApi,
     *hostApi = NULL;    /* Initialize to NULL */
 
     UNLESS( jackHostApi = (PaJackHostApiRepresentation*)
-        PaUtil_AllocateMemory( sizeof(PaJackHostApiRepresentation) ), paInsufficientMemory );
+        PaUtil_AllocateZeroInitializedMemory( sizeof(PaJackHostApiRepresentation) ), paInsufficientMemory );
     UNLESS( jackHostApi->deviceInfoMemory = PaUtil_CreateAllocationGroup(), paInsufficientMemory );
 
     mainThread_ = pthread_self();
@@ -1209,7 +1209,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         return paInvalidSampleRate;
 #undef ABS
 
-    UNLESS( stream = (PaJackStream*)PaUtil_AllocateMemory( sizeof(PaJackStream) ), paInsufficientMemory );
+    UNLESS( stream = (PaJackStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaJackStream) ), paInsufficientMemory );
     ENSURE_PA( InitializeStream( stream, jackHostApi, inputChannelCount, outputChannelCount ) );
 
     /* the blocking emulation, if necessary */

--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -243,7 +243,7 @@ PaError PaOSS_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex 
     PaError result = paNoError;
     PaOSSHostApiRepresentation *ossHostApi = NULL;
 
-    PA_UNLESS( ossHostApi = (PaOSSHostApiRepresentation*)PaUtil_AllocateMemory( sizeof(PaOSSHostApiRepresentation) ),
+    PA_UNLESS( ossHostApi = (PaOSSHostApiRepresentation*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaOSSHostApiRepresentation) ),
             paInsufficientMemory );
     PA_UNLESS( ossHostApi->allocations = PaUtil_CreateAllocationGroup(), paInsufficientMemory );
     ossHostApi->hostApiIndex = hostApiIndex;
@@ -761,7 +761,7 @@ static PaError PaOssStreamComponent_Initialize( PaOssStreamComponent *component,
     if( !callbackMode && !component->userInterleaved )
     {
         /* Pre-allocate non-interleaved user provided buffers */
-        PA_UNLESS( component->userBuffers = PaUtil_AllocateMemory( sizeof (void *) * component->userChannelCount ),
+        PA_UNLESS( component->userBuffers = PaUtil_AllocateZeroInitializedMemory( sizeof (void *) * component->userChannelCount ),
                 paInsufficientMemory );
     }
 
@@ -877,12 +877,12 @@ static PaError PaOssStream_Initialize( PaOssStream *stream, const PaStreamParame
     PA_ENSURE( OpenDevices( idevName, odevName, &idev, &odev ) );
     if( inputParameters )
     {
-        PA_UNLESS( stream->capture = PaUtil_AllocateMemory( sizeof (PaOssStreamComponent) ), paInsufficientMemory );
+        PA_UNLESS( stream->capture = PaUtil_AllocateZeroInitializedMemory( sizeof (PaOssStreamComponent) ), paInsufficientMemory );
         PA_ENSURE( PaOssStreamComponent_Initialize( stream->capture, inputParameters, callback != NULL, idev, idevName ) );
     }
     if( outputParameters )
     {
-        PA_UNLESS( stream->playback = PaUtil_AllocateMemory( sizeof (PaOssStreamComponent) ), paInsufficientMemory );
+        PA_UNLESS( stream->playback = PaUtil_AllocateZeroInitializedMemory( sizeof (PaOssStreamComponent) ), paInsufficientMemory );
         PA_ENSURE( PaOssStreamComponent_Initialize( stream->playback, outputParameters, callback != NULL, odev, odevName ) );
     }
 
@@ -1084,7 +1084,7 @@ static PaError PaOssStreamComponent_Configure( PaOssStreamComponent *component, 
         component->numBufs = master->numBufs;
     }
 
-    PA_UNLESS( component->buffer = PaUtil_AllocateMemory( PaOssStreamComponent_BufferSize( component ) ),
+    PA_UNLESS( component->buffer = PaUtil_AllocateZeroInitializedMemory( PaOssStreamComponent_BufferSize( component ) ),
             paInsufficientMemory );
 
 error:
@@ -1253,7 +1253,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     }
 
     /* allocate and do basic initialization of the stream structure */
-    PA_UNLESS( stream = (PaOssStream*)PaUtil_AllocateMemory( sizeof(PaOssStream) ), paInsufficientMemory );
+    PA_UNLESS( stream = (PaOssStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaOssStream) ), paInsufficientMemory );
     PA_ENSURE( PaOssStream_Initialize( stream, inputParameters, outputParameters, streamCallback, userData, streamFlags, ossHostApi ) );
 
     PA_ENSURE( PaOssStream_Configure( stream, sampleRate, framesPerBuffer, &inLatency, &outLatency ) );

--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -299,7 +299,7 @@ PaError PaUtil_InitializeDeviceInfo( PaDeviceInfo *deviceInfo, const char *name,
     if( allocations )
     {
         size_t len = strlen( name ) + 1;
-        PA_UNLESS( deviceInfo->name = PaUtil_GroupAllocateMemory( allocations, len ), paInsufficientMemory );
+        PA_UNLESS( deviceInfo->name = PaUtil_GroupAllocateZeroInitializedMemory( allocations, len ), paInsufficientMemory );
         strncpy( (char *)deviceInfo->name, name, len );
     }
     else
@@ -502,7 +502,7 @@ static PaError QueryDevice( char *deviceName, PaOSSHostApiRepresentation *ossApi
         goto error;
     }
 
-    PA_UNLESS( *deviceInfo = PaUtil_GroupAllocateMemory( ossApi->allocations, sizeof (PaDeviceInfo) ), paInsufficientMemory );
+    PA_UNLESS( *deviceInfo = PaUtil_GroupAllocateZeroInitializedMemory( ossApi->allocations, sizeof (PaDeviceInfo) ), paInsufficientMemory );
     PA_ENSURE( PaUtil_InitializeDeviceInfo( *deviceInfo, deviceName, ossApi->hostApiIndex, maxInputChannels, maxOutputChannels,
                 defaultLowInputLatency, defaultLowOutputLatency, defaultHighInputLatency, defaultHighOutputLatency, sampleRate,
                 ossApi->allocations ) );
@@ -577,7 +577,7 @@ static PaError BuildDeviceList( PaOSSHostApiRepresentation *ossApi )
 
     PA_DEBUG(("PaOSS %s: Total number of devices found: %d\n", __FUNCTION__, numDevices));
 
-    commonApi->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+    commonApi->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
         ossApi->allocations, sizeof(PaDeviceInfo*) * numDevices );
     memcpy( commonApi->deviceInfos, deviceInfos, numDevices * sizeof (PaDeviceInfo *) );
 

--- a/src/hostapi/skeleton/pa_hostapi_skeleton.c
+++ b/src/hostapi/skeleton/pa_hostapi_skeleton.c
@@ -158,7 +158,7 @@ PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiI
 
     if( deviceCount > 0 )
     {
-        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
                 skeletonHostApi->allocations, sizeof(PaDeviceInfo*) * deviceCount );
         if( !(*hostApi)->deviceInfos )
         {
@@ -167,7 +167,7 @@ PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiI
         }
 
         /* allocate all device info structs in a contiguous block */
-        deviceInfoArray = (PaDeviceInfo*)PaUtil_GroupAllocateMemory(
+        deviceInfoArray = (PaDeviceInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
                 skeletonHostApi->allocations, sizeof(PaDeviceInfo) * deviceCount );
         if( !deviceInfoArray )
         {
@@ -181,7 +181,7 @@ PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiI
             deviceInfo->structVersion = 2;
             deviceInfo->hostApi = hostApiIndex;
             deviceInfo->name = 0; /* IMPLEMENT ME: allocate block and copy name eg:
-                deviceName = (char*)PaUtil_GroupAllocateMemory( skeletonHostApi->allocations, strlen(srcName) + 1 );
+                deviceName = (char*)PaUtil_GroupAllocateZeroInitializedMemory( skeletonHostApi->allocations, strlen(srcName) + 1 );
                 if( !deviceName )
                 {
                     result = paInsufficientMemory;

--- a/src/hostapi/skeleton/pa_hostapi_skeleton.c
+++ b/src/hostapi/skeleton/pa_hostapi_skeleton.c
@@ -130,7 +130,7 @@ PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiI
     PaSkeletonHostApiRepresentation *skeletonHostApi;
     PaDeviceInfo *deviceInfoArray;
 
-    skeletonHostApi = (PaSkeletonHostApiRepresentation*)PaUtil_AllocateMemory( sizeof(PaSkeletonHostApiRepresentation) );
+    skeletonHostApi = (PaSkeletonHostApiRepresentation*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaSkeletonHostApiRepresentation) );
     if( !skeletonHostApi )
     {
         result = paInsufficientMemory;
@@ -477,7 +477,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         return paInvalidFlag; /* unexpected platform specific flag */
 
 
-    stream = (PaSkeletonStream*)PaUtil_AllocateMemory( sizeof(PaSkeletonStream) );
+    stream = (PaSkeletonStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaSkeletonStream) );
     if( !stream )
     {
         result = paInsufficientMemory;

--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -2085,7 +2085,7 @@ static PaDeviceInfo *AllocateDeviceListMemory(PaWasapiHostApiRepresentation *paW
     {
         return NULL;
     }
-    memset(paWasapi->devInfo, 0, sizeof(PaWasapiDeviceInfo) * deviceCount);
+    /* NOTE: we depend on all paWasapi->devInfo elements being zero-initialized */
 
     if (deviceCount != 0)
     {
@@ -2109,7 +2109,7 @@ static PaDeviceInfo *AllocateDeviceListMemory(PaWasapiHostApiRepresentation *paW
         {
             return NULL;
         }
-        memset(deviceInfoArray, 0, sizeof(PaDeviceInfo) * deviceCount);
+        /* NOTE: we depend on all deviceInfoArray elements being zero-initialized */
     }
 
     return deviceInfoArray;
@@ -2461,7 +2461,9 @@ PaError PaWasapi_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
         result = paInsufficientMemory;
         goto error;
     }
-    memset(paWasapi, 0, sizeof(PaWasapiHostApiRepresentation)); /* ensure all fields are zeroed. especially paWasapi->allocations */
+
+    /* NOTE: we depend on PaUtil_AllocateZeroInitializedMemory() ensuring that all
+       fields are set to zero. especially paWasapi->allocations */
 
     // Initialize COM subsystem
     result = PaWinUtil_CoInitialize(paWASAPI, &paWasapi->comInitializationResult);
@@ -4061,7 +4063,6 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
                 LogPaError(result = paInsufficientMemory);
                 goto error;
             }
-            memset(stream->in.tailBuffer, 0, sizeof(PaUtilRingBuffer));
 
             // buffer memory region
             stream->in.tailBufferMemory = PaUtil_AllocateZeroInitializedMemory(frameSize * bufferFrames);

--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -1825,7 +1825,7 @@ static void FillBaseDeviceInfo(PaDeviceInfo *deviceInfo, PaHostApiIndex hostApiI
 static PaError FillInactiveDeviceInfo(PaWasapiHostApiRepresentation *paWasapi, PaDeviceInfo *deviceInfo)
 {
     if (deviceInfo->name == NULL)
-        deviceInfo->name = (char *)PaUtil_GroupAllocateMemory(paWasapi->allocations, 1);
+        deviceInfo->name = (char *)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations, 1);
 
     if (deviceInfo->name != NULL)
     {
@@ -1894,7 +1894,7 @@ static PaError FillDeviceInfo(PaWasapiHostApiRepresentation *paWasapi, void *pEn
             hr = IPropertyStore_GetValue(pProperty, &PKEY_Device_FriendlyName, &value);
             IF_FAILED_INTERNAL_ERROR_JUMP(hr, result, error);
 
-            if ((deviceInfo->name = (char *)PaUtil_GroupAllocateMemory(paWasapi->allocations, PA_WASAPI_DEVICE_NAME_LEN)) == NULL)
+            if ((deviceInfo->name = (char *)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations, PA_WASAPI_DEVICE_NAME_LEN)) == NULL)
             {
                 result = paInsufficientMemory;
                 PropVariantClear(&value);
@@ -1959,7 +1959,7 @@ static PaError FillDeviceInfo(PaWasapiHostApiRepresentation *paWasapi, void *pEn
     wcsncpy(wasapiDeviceInfo->deviceId, listEntry->info->id, PA_WASAPI_DEVICE_ID_LEN - 1);
 
     // Set device name
-    if ((deviceInfo->name = (char *)PaUtil_GroupAllocateMemory(paWasapi->allocations, PA_WASAPI_DEVICE_NAME_LEN)) == NULL)
+    if ((deviceInfo->name = (char *)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations, PA_WASAPI_DEVICE_NAME_LEN)) == NULL)
     {
         result = paInsufficientMemory;
         goto error;
@@ -2080,7 +2080,7 @@ static PaDeviceInfo *AllocateDeviceListMemory(PaWasapiHostApiRepresentation *paW
     PaUtilHostApiRepresentation *hostApi = (PaUtilHostApiRepresentation *)paWasapi;
     PaDeviceInfo *deviceInfoArray = NULL;
 
-    if ((paWasapi->devInfo = (PaWasapiDeviceInfo *)PaUtil_GroupAllocateMemory(paWasapi->allocations,
+    if ((paWasapi->devInfo = (PaWasapiDeviceInfo *)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations,
         sizeof(PaWasapiDeviceInfo) * deviceCount)) == NULL)
     {
         return NULL;
@@ -2095,7 +2095,7 @@ static PaDeviceInfo *AllocateDeviceListMemory(PaWasapiHostApiRepresentation *paW
             deviceCount = PA_WASAPI_MAX_CONST_DEVICE_COUNT;
     #endif
 
-        if ((hostApi->deviceInfos = (PaDeviceInfo **)PaUtil_GroupAllocateMemory(paWasapi->allocations,
+        if ((hostApi->deviceInfos = (PaDeviceInfo **)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations,
             sizeof(PaDeviceInfo *) * deviceCount)) == NULL)
         {
             return NULL;
@@ -2104,7 +2104,7 @@ static PaDeviceInfo *AllocateDeviceListMemory(PaWasapiHostApiRepresentation *paW
             hostApi->deviceInfos[i] = NULL;
 
         // Allocate all device info structs in a contiguous block
-        if ((deviceInfoArray = (PaDeviceInfo *)PaUtil_GroupAllocateMemory(paWasapi->allocations,
+        if ((deviceInfoArray = (PaDeviceInfo *)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations,
             sizeof(PaDeviceInfo) * deviceCount)) == NULL)
         {
             return NULL;
@@ -2177,7 +2177,7 @@ static BOOL FillLooopbackDeviceInfo(PaWasapiHostApiRepresentation *paWasapi, PaD
 
     // Append loopback device name identificator to the device name to provide possibility to find
     // loopback device by its name for some external projects
-    loopbackDeviceInfo->name = (char *)PaUtil_GroupAllocateMemory(paWasapi->allocations, PA_WASAPI_DEVICE_NAME_LEN + 1);
+    loopbackDeviceInfo->name = (char *)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations, PA_WASAPI_DEVICE_NAME_LEN + 1);
     if (loopbackDeviceInfo->name == NULL)
         return FALSE;
     _snprintf((char *)loopbackDeviceInfo->name, PA_WASAPI_DEVICE_NAME_LEN - 1,

--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -1242,7 +1242,7 @@ static EWindowsVersion GetWindowsVersion()
                 dwMinorVersion = ver.dwMinorVersion;
                 dwBuild        = ver.dwBuildNumber;
             }
-            
+
             PRINT(("WASAPI: getting Windows version with RtlGetVersion(): major=%d, minor=%d, build=%d\n", dwMajorVersion, dwMinorVersion, dwBuild));
         }
 
@@ -1263,7 +1263,7 @@ static EWindowsVersion GetWindowsVersion()
 
                 if (dwVersion < 0x80000000)
                     dwBuild = (DWORD)(HIWORD(dwVersion));
-                
+
                 PRINT(("WASAPI: getting Windows version with GetVersion(): major=%d, minor=%d, build=%d\n", dwMajorVersion, dwMinorVersion, dwBuild));
             }
         }
@@ -1662,11 +1662,11 @@ static HRESULT (STDMETHODCALLTYPE PaActivateAudioInterfaceCompletionHandler_Acti
 
 static IActivateAudioInterfaceCompletionHandler *CreateActivateAudioInterfaceCompletionHandler(const IID *iid, void **client)
 {
-    PaActivateAudioInterfaceCompletionHandler *handler = PaUtil_AllocateMemory(sizeof(PaActivateAudioInterfaceCompletionHandler));
+    PaActivateAudioInterfaceCompletionHandler *handler = PaUtil_AllocateZeroInitializedMemory(sizeof(PaActivateAudioInterfaceCompletionHandler));
 
     memset(handler, 0, sizeof(*handler));
 
-    handler->parent.lpVtbl = PaUtil_AllocateMemory(sizeof(*handler->parent.lpVtbl));
+    handler->parent.lpVtbl = PaUtil_AllocateZeroInitializedMemory(sizeof(*handler->parent.lpVtbl));
     handler->parent.lpVtbl->QueryInterface    = &PaActivateAudioInterfaceCompletionHandler_QueryInterface;
     handler->parent.lpVtbl->AddRef            = &PaActivateAudioInterfaceCompletionHandler_AddRef;
     handler->parent.lpVtbl->Release           = &PaActivateAudioInterfaceCompletionHandler_Release;
@@ -2152,7 +2152,7 @@ error:
     return 0;
 }
 #else
-static UINT32 GetDeviceListDeviceCount(const PaWasapiHostApiRepresentation *paWasapi, 
+static UINT32 GetDeviceListDeviceCount(const PaWasapiHostApiRepresentation *paWasapi,
     const PaWasapiWinrtDeviceListContext *deviceListContext, EDataFlow filterFlow)
 {
     UINT32 i, ret = 0;
@@ -2455,7 +2455,7 @@ PaError PaWasapi_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
     }
 #endif
 
-    paWasapi = (PaWasapiHostApiRepresentation *)PaUtil_AllocateMemory(sizeof(PaWasapiHostApiRepresentation));
+    paWasapi = (PaWasapiHostApiRepresentation *)PaUtil_AllocateZeroInitializedMemory(sizeof(PaWasapiHostApiRepresentation));
     if (paWasapi == NULL)
     {
         result = paInsufficientMemory;
@@ -3913,7 +3913,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     }
 
     // Allocate memory for PaWasapiStream
-    if ((stream = (PaWasapiStream *)PaUtil_AllocateMemory(sizeof(PaWasapiStream))) == NULL)
+    if ((stream = (PaWasapiStream *)PaUtil_AllocateZeroInitializedMemory(sizeof(PaWasapiStream))) == NULL)
     {
         LogPaError(result = paInsufficientMemory);
         goto error;
@@ -4056,7 +4056,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             UINT32 frameSize    = stream->in.wavex.Format.nBlockAlign;
 
             // buffer
-            if ((stream->in.tailBuffer = PaUtil_AllocateMemory(sizeof(PaUtilRingBuffer))) == NULL)
+            if ((stream->in.tailBuffer = PaUtil_AllocateZeroInitializedMemory(sizeof(PaUtilRingBuffer))) == NULL)
             {
                 LogPaError(result = paInsufficientMemory);
                 goto error;
@@ -4064,7 +4064,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             memset(stream->in.tailBuffer, 0, sizeof(PaUtilRingBuffer));
 
             // buffer memory region
-            stream->in.tailBufferMemory = PaUtil_AllocateMemory(frameSize * bufferFrames);
+            stream->in.tailBufferMemory = PaUtil_AllocateZeroInitializedMemory(frameSize * bufferFrames);
             if (stream->in.tailBufferMemory == NULL)
             {
                 LogPaError(result = paInsufficientMemory);

--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -3364,7 +3364,7 @@ static PaError CreateHashEntry(PaNameHashObject* obj, const wchar_t* name, const
     }
     if (p == NULL)
     {
-        p = (PaNameHashIndex*)PaUtil_GroupAllocateMemory(obj->allocGroup, sizeof(PaNameHashIndex));
+        p = (PaNameHashIndex*)PaUtil_GroupAllocateZeroInitializedMemory(obj->allocGroup, sizeof(PaNameHashIndex));
         if (p == NULL)
         {
             return paInsufficientMemory;
@@ -3495,7 +3495,7 @@ static PaError ScanDeviceInfos( struct PaUtilHostApiRepresentation *hostApi, PaH
         unsigned devIsDefaultIn = 0, devIsDefaultOut = 0;
 
         /* Allocate the out param for all the info we need */
-        outArgument = (PaWinWDMScanDeviceInfosResults *) PaUtil_GroupAllocateMemory(
+        outArgument = (PaWinWDMScanDeviceInfosResults *) PaUtil_GroupAllocateZeroInitializedMemory(
             wdmHostApi->allocations, sizeof(PaWinWDMScanDeviceInfosResults) );
         if( !outArgument )
         {
@@ -3506,7 +3506,7 @@ static PaError ScanDeviceInfos( struct PaUtilHostApiRepresentation *hostApi, PaH
         outArgument->defaultInputDevice  = paNoDevice;
         outArgument->defaultOutputDevice = paNoDevice;
 
-        outArgument->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+        outArgument->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
             wdmHostApi->allocations, sizeof(PaDeviceInfo*) * totalDeviceCount );
         if( !outArgument->deviceInfos )
         {
@@ -3515,7 +3515,7 @@ static PaError ScanDeviceInfos( struct PaUtilHostApiRepresentation *hostApi, PaH
         }
 
         /* allocate all device info structs in a contiguous block */
-        deviceInfoArray = (PaWinWdmDeviceInfo*)PaUtil_GroupAllocateMemory(
+        deviceInfoArray = (PaWinWdmDeviceInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
             wdmHostApi->allocations, sizeof(PaWinWdmDeviceInfo) * totalDeviceCount );
         if( !deviceInfoArray )
         {
@@ -3723,7 +3723,7 @@ static PaError CommitDeviceInfos( struct PaUtilHostApiRepresentation *hostApi, P
     /* Free any old memory which might be in the device info */
     if( hostApi->deviceInfos )
     {
-        PaWinWDMScanDeviceInfosResults* localScanResults = (PaWinWDMScanDeviceInfosResults*)PaUtil_GroupAllocateMemory(
+        PaWinWDMScanDeviceInfosResults* localScanResults = (PaWinWDMScanDeviceInfosResults*)PaUtil_GroupAllocateZeroInitializedMemory(
             wdmHostApi->allocations, sizeof(PaWinWDMScanDeviceInfosResults));
         localScanResults->deviceInfos = hostApi->deviceInfos;
 
@@ -3910,7 +3910,7 @@ static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
 
     if( wdmHostApi)
     {
-        PaWinWDMScanDeviceInfosResults* localScanResults = (PaWinWDMScanDeviceInfosResults*)PaUtil_GroupAllocateMemory(
+        PaWinWDMScanDeviceInfosResults* localScanResults = (PaWinWDMScanDeviceInfosResults*)PaUtil_GroupAllocateZeroInitializedMemory(
             wdmHostApi->allocations, sizeof(PaWinWDMScanDeviceInfosResults));
         localScanResults->deviceInfos = hostApi->deviceInfos;
         DisposeDeviceInfos(hostApi, localScanResults, hostApi->info.deviceCount);
@@ -4818,7 +4818,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             {
                 unsigned size = stream->capture.noOfPackets * stream->capture.framesPerBuffer * stream->capture.bytesPerFrame;
                 /* Allocate input host buffer */
-                stream->capture.hostBuffer = (char*)PaUtil_GroupAllocateMemory(stream->allocGroup, size);
+                stream->capture.hostBuffer = (char*)PaUtil_GroupAllocateZeroInitializedMemory(stream->allocGroup, size);
                 PA_DEBUG(("Input buffer allocated (size = %u)\n", size));
                 if( !stream->capture.hostBuffer )
                 {
@@ -4912,7 +4912,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
             {
                 unsigned size = stream->render.noOfPackets * stream->render.framesPerBuffer * stream->render.bytesPerFrame;
                 /* Allocate output device buffer */
-                stream->render.hostBuffer = (char*)PaUtil_GroupAllocateMemory(stream->allocGroup, size);
+                stream->render.hostBuffer = (char*)PaUtil_GroupAllocateZeroInitializedMemory(stream->allocGroup, size);
                 PA_DEBUG(("Output buffer allocated (size = %u)\n", size));
                 if( !stream->render.hostBuffer )
                 {
@@ -5029,14 +5029,14 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         const unsigned bufferSizeInBytes = stream->capture.framesPerBuffer * stream->capture.bytesPerFrame;
         const unsigned ringBufferFrameSize = NextPowerOf2( 1024 + 2 * max(stream->capture.framesPerBuffer, stream->render.framesPerBuffer) );
 
-        stream->capture.events = (HANDLE*)PaUtil_GroupAllocateMemory(stream->allocGroup, stream->capture.noOfPackets * sizeof(HANDLE));
+        stream->capture.events = (HANDLE*)PaUtil_GroupAllocateZeroInitializedMemory(stream->allocGroup, stream->capture.noOfPackets * sizeof(HANDLE));
         if (stream->capture.events == NULL)
         {
             result = paInsufficientMemory;
             goto error;
         }
 
-        stream->capture.packets = (DATAPACKET*)PaUtil_GroupAllocateMemory(stream->allocGroup, stream->capture.noOfPackets * sizeof(DATAPACKET));
+        stream->capture.packets = (DATAPACKET*)PaUtil_GroupAllocateZeroInitializedMemory(stream->allocGroup, stream->capture.noOfPackets * sizeof(DATAPACKET));
         if (stream->capture.packets == NULL)
         {
             result = paInsufficientMemory;
@@ -5135,7 +5135,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         }
 
         /* Setup the input ring buffer here */
-        stream->ringBufferData = (char*)PaUtil_GroupAllocateMemory(stream->allocGroup, ringBufferFrameSize * stream->capture.bytesPerFrame);
+        stream->ringBufferData = (char*)PaUtil_GroupAllocateZeroInitializedMemory(stream->allocGroup, ringBufferFrameSize * stream->capture.bytesPerFrame);
         if (stream->ringBufferData == NULL)
         {
             result = paInsufficientMemory;
@@ -5147,14 +5147,14 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     {
         const unsigned bufferSizeInBytes = stream->render.framesPerBuffer * stream->render.bytesPerFrame;
 
-        stream->render.events = (HANDLE*)PaUtil_GroupAllocateMemory(stream->allocGroup, stream->render.noOfPackets * sizeof(HANDLE));
+        stream->render.events = (HANDLE*)PaUtil_GroupAllocateZeroInitializedMemory(stream->allocGroup, stream->render.noOfPackets * sizeof(HANDLE));
         if (stream->render.events == NULL)
         {
             result = paInsufficientMemory;
             goto error;
         }
 
-        stream->render.packets = (DATAPACKET*)PaUtil_GroupAllocateMemory(stream->allocGroup, stream->render.noOfPackets * sizeof(DATAPACKET));
+        stream->render.packets = (DATAPACKET*)PaUtil_GroupAllocateZeroInitializedMemory(stream->allocGroup, stream->render.noOfPackets * sizeof(DATAPACKET));
         if (stream->render.packets == NULL)
         {
             result = paInsufficientMemory;

--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -882,7 +882,7 @@ static PaError WdmGetPinPropertyMulti(
         return result;
     }
 
-    *ksMultipleItem = (KSMULTIPLE_ITEM*)PaUtil_AllocateMemory( multipleItemSize );
+    *ksMultipleItem = (KSMULTIPLE_ITEM*)PaUtil_AllocateZeroInitializedMemory( multipleItemSize );
     if( !*ksMultipleItem )
     {
         return paInsufficientMemory;
@@ -931,7 +931,7 @@ static PaError WdmGetPropertyMulti(HANDLE handle,
         return result;
     }
 
-    *ksMultipleItem = (KSMULTIPLE_ITEM*)PaUtil_AllocateMemory( multipleItemSize );
+    *ksMultipleItem = (KSMULTIPLE_ITEM*)PaUtil_AllocateZeroInitializedMemory( multipleItemSize );
     if( !*ksMultipleItem )
     {
         return paInsufficientMemory;
@@ -1337,7 +1337,7 @@ static PaWinWdmPin* PinNew(PaWinWdmFilter* parentFilter, unsigned long pinId, Pa
     PA_DEBUG(("PinNew: Creating pin %d:\n",pinId));
 
     /* Allocate the new PIN object */
-    pin = (PaWinWdmPin*)PaUtil_AllocateMemory( sizeof(PaWinWdmPin) );
+    pin = (PaWinWdmPin*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinWdmPin) );
     if( !pin )
     {
         result = paInsufficientMemory;
@@ -1352,7 +1352,7 @@ static PaWinWdmPin* PinNew(PaWinWdmFilter* parentFilter, unsigned long pinId, Pa
 
     /* Allocate a connect structure */
     pin->pinConnectSize = sizeof(KSPIN_CONNECT) + sizeof(KSDATAFORMAT_WAVEFORMATEX);
-    pin->pinConnect = (KSPIN_CONNECT*)PaUtil_AllocateMemory( pin->pinConnectSize );
+    pin->pinConnect = (KSPIN_CONNECT*)PaUtil_AllocateZeroInitializedMemory( pin->pinConnectSize );
     if( !pin->pinConnect )
     {
         result = paInsufficientMemory;
@@ -1671,7 +1671,7 @@ static PaWinWdmPin* PinNew(PaWinWdmFilter* parentFilter, unsigned long pinId, Pa
             }
             else
             {
-                KSPIN_PHYSICALCONNECTION* pc = (KSPIN_PHYSICALCONNECTION*)PaUtil_AllocateMemory(cbBytes + 2);
+                KSPIN_PHYSICALCONNECTION* pc = (KSPIN_PHYSICALCONNECTION*)PaUtil_AllocateZeroInitializedMemory(cbBytes + 2);
                 ULONG pcPin;
                 wchar_t symbLinkName[MAX_PATH];
                 PA_DEBUG(("PinNew: Physical connection found!\n"));
@@ -1899,7 +1899,7 @@ static PaWinWdmPin* PinNew(PaWinWdmFilter* parentFilter, unsigned long pinId, Pa
                             PA_DEBUG(("PinNew: Setting up %u inputs\n", muxCount));
 
                             /* Now we redo the operation once known how many multiplexer positions there are */
-                            pin->inputs = (PaWinWdmMuxedInput**)PaUtil_AllocateMemory(muxCount * sizeof(PaWinWdmMuxedInput*));
+                            pin->inputs = (PaWinWdmMuxedInput**)PaUtil_AllocateZeroInitializedMemory(muxCount * sizeof(PaWinWdmMuxedInput*));
                             if (pin->inputs == NULL)
                             {
                                 FilterRelease(pin->parentFilter->topologyFilter);
@@ -1914,7 +1914,7 @@ static PaWinWdmPin* PinNew(PaWinWdmFilter* parentFilter, unsigned long pinId, Pa
 
                                 if (pin->inputs[i] == NULL)
                                 {
-                                    pin->inputs[i] = (PaWinWdmMuxedInput*)PaUtil_AllocateMemory(sizeof(PaWinWdmMuxedInput));
+                                    pin->inputs[i] = (PaWinWdmMuxedInput*)PaUtil_AllocateZeroInitializedMemory(sizeof(PaWinWdmMuxedInput));
                                     if (pin->inputs[i] == NULL)
                                     {
                                         FilterRelease(pin->parentFilter->topologyFilter);
@@ -2196,7 +2196,7 @@ static PaError PinSetFormat(PaWinWdmPin* pin, const WAVEFORMATEX* format)
 
     if( pin->pinConnectSize != size )
     {
-        newConnect = PaUtil_AllocateMemory( size );
+        newConnect = PaUtil_AllocateZeroInitializedMemory( size );
         if( newConnect == NULL )
             return paInsufficientMemory;
         memcpy( newConnect, (void*)pin->pinConnect, min(pin->pinConnectSize,size) );
@@ -2689,7 +2689,7 @@ static PaWinWdmFilter* FilterNew( PaWDMKSType type, DWORD devNode, const wchar_t
     PaError result;
 
     /* Allocate the new filter object */
-    filter = (PaWinWdmFilter*)PaUtil_AllocateMemory( sizeof(PaWinWdmFilter) );
+    filter = (PaWinWdmFilter*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinWdmFilter) );
     if( !filter )
     {
         result = paInsufficientMemory;
@@ -2831,7 +2831,7 @@ PaError FilterInitializePins( PaWinWdmFilter* filter )
         return paNoError;
 
     /* Allocate pointer array to hold the pins */
-    filter->pins = (PaWinWdmPin**)PaUtil_AllocateMemory( sizeof(PaWinWdmPin*) * filter->pinCount );
+    filter->pins = (PaWinWdmPin**)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinWdmPin*) * filter->pinCount );
     if( !filter->pins )
     {
         result = paInsufficientMemory;
@@ -3156,7 +3156,7 @@ PaWinWdmFilter** BuildFilterList( int* pFilterCount, int* pNoOfPaDevices, PaErro
     PA_DEBUG(("Interfaces found: %d\n",device-invalidDevices));
 
     /* Now allocate the list of pointers to devices */
-    ppFilters  = (PaWinWdmFilter**)PaUtil_AllocateMemory( sizeof(PaWinWdmFilter*) * filterCount);
+    ppFilters  = (PaWinWdmFilter**)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinWdmFilter*) * filterCount);
     if( ppFilters == 0 )
     {
         if(handle != NULL)
@@ -3478,12 +3478,12 @@ static PaError ScanDeviceInfos( struct PaUtilHostApiRepresentation *hostApi, PaH
     // Get hold of default device paths for capture & playback
     if( waveInMessage(0, DRV_QUERYDEVICEINTERFACESIZE, (DWORD_PTR)&defaultInDevPathSize, 0 ) == MMSYSERR_NOERROR )
     {
-        defaultInDevPath = (wchar_t *)PaUtil_AllocateMemory((defaultInDevPathSize + 1) * sizeof(wchar_t));
+        defaultInDevPath = (wchar_t *)PaUtil_AllocateZeroInitializedMemory((defaultInDevPathSize + 1) * sizeof(wchar_t));
         waveInMessage(0, DRV_QUERYDEVICEINTERFACE, (DWORD_PTR)defaultInDevPath, defaultInDevPathSize);
     }
     if( waveOutMessage(0, DRV_QUERYDEVICEINTERFACESIZE, (DWORD_PTR)&defaultOutDevPathSize, 0 ) == MMSYSERR_NOERROR )
     {
-        defaultOutDevPath = (wchar_t *)PaUtil_AllocateMemory((defaultOutDevPathSize + 1) * sizeof(wchar_t));
+        defaultOutDevPath = (wchar_t *)PaUtil_AllocateZeroInitializedMemory((defaultOutDevPathSize + 1) * sizeof(wchar_t));
         waveOutMessage(0, DRV_QUERYDEVICEINTERFACE, (DWORD_PTR)defaultOutDevPath, defaultOutDevPathSize);
     }
 
@@ -3827,7 +3827,7 @@ PaError PaWinWdm_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
         }
     }
 
-    wdmHostApi = (PaWinWdmHostApiRepresentation*)PaUtil_AllocateMemory( sizeof(PaWinWdmHostApiRepresentation) );
+    wdmHostApi = (PaWinWdmHostApiRepresentation*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinWdmHostApiRepresentation) );
     if( !wdmHostApi )
     {
         result = paInsufficientMemory;
@@ -4422,7 +4422,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         return paInvalidFlag; /* unexpected platform specific flag */
     }
 
-    stream = (PaWinWdmStream*)PaUtil_AllocateMemory( sizeof(PaWinWdmStream) );
+    stream = (PaWinWdmStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinWdmStream) );
     if( !stream )
     {
         result = paInsufficientMemory;
@@ -5913,7 +5913,7 @@ PA_THREAD_FUNC ProcessingThread(void* pParam)
     PA_DEBUG(("Timeout = %ld ms\n",info.timeout));
 
     /* Allocate handle array */
-    handleArray = (HANDLE*)PaUtil_AllocateMemory((info.stream->capture.noOfPackets + info.stream->render.noOfPackets + 1) * sizeof(HANDLE));
+    handleArray = (HANDLE*)PaUtil_AllocateZeroInitializedMemory((info.stream->capture.noOfPackets + info.stream->render.noOfPackets + 1) * sizeof(HANDLE));
 
     /* Setup handle array for WFMO */
     if (info.stream->capture.pPin != 0)

--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -1344,9 +1344,6 @@ static PaWinWdmPin* PinNew(PaWinWdmFilter* parentFilter, unsigned long pinId, Pa
         goto error;
     }
 
-    /* Zero the pin object */
-    /* memset( (void*)pin, 0, sizeof(PaWinWdmPin) ); */
-
     pin->parentFilter = parentFilter;
     pin->pinId = pinId;
 
@@ -2703,9 +2700,6 @@ static PaWinWdmFilter* FilterNew( PaWDMKSType type, DWORD devNode, const wchar_t
 
     /* Store device node */
     filter->deviceNode = devNode;
-
-    /* Zero the filter object - done by AllocateMemory */
-    /* memset( (void*)filter, 0, sizeof(PaWinWdmFilter) ); */
 
     /* Copy the filter name */
     wcsncpy(filter->devInfo.filterPath, filterName, MAX_PATH);
@@ -4437,9 +4431,6 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         goto error;
     }
 
-    /* Zero the stream object */
-    /* memset((void*)stream,0,sizeof(PaWinWdmStream)); */
-
     if( streamCallback )
     {
         PaUtil_InitializeStreamRepresentation( &stream->streamRepresentation,
@@ -5001,8 +4992,6 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 
     PA_DEBUG(("BytesPerInputFrame = %d\n",stream->capture.bytesPerFrame));
     PA_DEBUG(("BytesPerOutputFrame = %d\n",stream->render.bytesPerFrame));
-
-    /* memset(stream->hostBuffer,0,size); */
 
     /* Abort */
     stream->eventAbort          = CreateEvent(NULL, TRUE, FALSE, NULL);

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -642,7 +642,7 @@ static int QueryWaveInKSFilterMaxChannels( UINT waveInDeviceId, int *maxChannels
             (DWORD_PTR)&devicePathSize, 0 ) != MMSYSERR_NOERROR )
         return 0;
 
-    devicePath = PaUtil_AllocateMemory( devicePathSize );
+    devicePath = PaUtil_AllocateZeroInitializedMemory( devicePathSize );
     if( !devicePath )
         return 0;
 
@@ -775,7 +775,7 @@ static int QueryWaveOutKSFilterMaxChannels( UINT waveOutDeviceId, int *maxChanne
             (DWORD_PTR)&devicePathSize, 0 ) != MMSYSERR_NOERROR )
         return 0;
 
-    devicePath = PaUtil_AllocateMemory( devicePathSize );
+    devicePath = PaUtil_AllocateZeroInitializedMemory( devicePathSize );
     if( !devicePath )
         return 0;
 
@@ -947,7 +947,7 @@ PaError PaWinMme_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
     DWORD waveInPreferredDevice, waveOutPreferredDevice;
     DWORD preferredDeviceStatusFlags;
 
-    winMmeHostApi = (PaWinMmeHostApiRepresentation*)PaUtil_AllocateMemory( sizeof(PaWinMmeHostApiRepresentation) );
+    winMmeHostApi = (PaWinMmeHostApiRepresentation*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinMmeHostApiRepresentation) );
     if( !winMmeHostApi )
     {
         result = paInsufficientMemory;
@@ -1813,9 +1813,9 @@ static PaError InitializeWaveHandles( PaWinMmeHostApiRepresentation *winMmeHostA
     if( result != paNoError ) goto error;
 
     if( isInput )
-        handlesAndBuffers->waveHandles = (void*)PaUtil_AllocateMemory( sizeof(HWAVEIN) * deviceCount );
+        handlesAndBuffers->waveHandles = (void*)PaUtil_AllocateZeroInitializedMemory( sizeof(HWAVEIN) * deviceCount );
     else
-        handlesAndBuffers->waveHandles = (void*)PaUtil_AllocateMemory( sizeof(HWAVEOUT) * deviceCount );
+        handlesAndBuffers->waveHandles = (void*)PaUtil_AllocateZeroInitializedMemory( sizeof(HWAVEOUT) * deviceCount );
     if( !handlesAndBuffers->waveHandles )
     {
         result = paInsufficientMemory;
@@ -2009,7 +2009,7 @@ static PaError InitializeWaveHeaders( PaWinMmeSingleDirectionHandlesAndBuffers *
 
     /* allocate an array of pointers to arrays of wave headers, one array of
         wave headers per device */
-    handlesAndBuffers->waveHeaders = (WAVEHDR**)PaUtil_AllocateMemory( sizeof(WAVEHDR*) * handlesAndBuffers->deviceCount );
+    handlesAndBuffers->waveHeaders = (WAVEHDR**)PaUtil_AllocateZeroInitializedMemory( sizeof(WAVEHDR*) * handlesAndBuffers->deviceCount );
     if( !handlesAndBuffers->waveHeaders )
     {
         result = paInsufficientMemory;
@@ -2032,7 +2032,7 @@ static PaError InitializeWaveHeaders( PaWinMmeSingleDirectionHandlesAndBuffers *
         }
 
         /* Allocate an array of wave headers for device i */
-        deviceWaveHeaders = (WAVEHDR *) PaUtil_AllocateMemory( sizeof(WAVEHDR)*hostBufferCount );
+        deviceWaveHeaders = (WAVEHDR *) PaUtil_AllocateZeroInitializedMemory( sizeof(WAVEHDR)*hostBufferCount );
         if( !deviceWaveHeaders )
         {
             result = paInsufficientMemory;
@@ -2047,7 +2047,7 @@ static PaError InitializeWaveHeaders( PaWinMmeSingleDirectionHandlesAndBuffers *
         /* Allocate a buffer for each wave header */
         for( j=0; j < (signed int)hostBufferCount; ++j )
         {
-            deviceWaveHeaders[j].lpData = (char *)PaUtil_AllocateMemory( bufferBytes );
+            deviceWaveHeaders[j].lpData = (char *)PaUtil_AllocateZeroInitializedMemory( bufferBytes );
             if( !deviceWaveHeaders[j].lpData )
             {
                 result = paInsufficientMemory;
@@ -2457,7 +2457,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( result != paNoError ) goto error;
 
 
-    stream = (PaWinMmeStream*)PaUtil_AllocateMemory( sizeof(PaWinMmeStream) );
+    stream = (PaWinMmeStream*)PaUtil_AllocateZeroInitializedMemory( sizeof(PaWinMmeStream) );
     if( !stream )
     {
         result = paInsufficientMemory;

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -699,7 +699,7 @@ static PaError InitializeInputDeviceInfo( PaWinMmeHostApiRepresentation *winMmeH
     {
         len = WCharStringLen( wic.szPname ) + 1 + sizeof(constInputMapperSuffix_);
         /* Append I/O suffix to WAVE_MAPPER device. */
-        deviceName = (char*)PaUtil_GroupAllocateMemory(
+        deviceName = (char*)PaUtil_GroupAllocateZeroInitializedMemory(
                     winMmeHostApi->allocations,
                     (long)len );
         if( !deviceName )
@@ -713,7 +713,7 @@ static PaError InitializeInputDeviceInfo( PaWinMmeHostApiRepresentation *winMmeH
     else
     {
         len = WCharStringLen( wic.szPname ) + 1;
-        deviceName = (char*)PaUtil_GroupAllocateMemory(
+        deviceName = (char*)PaUtil_GroupAllocateZeroInitializedMemory(
                     winMmeHostApi->allocations,
                     (long)len );
         if( !deviceName )
@@ -835,7 +835,7 @@ static PaError InitializeOutputDeviceInfo( PaWinMmeHostApiRepresentation *winMme
     {
         /* Append I/O suffix to WAVE_MAPPER device. */
         len = WCharStringLen( woc.szPname ) + 1 + sizeof(constOutputMapperSuffix_);
-        deviceName = (char*)PaUtil_GroupAllocateMemory(
+        deviceName = (char*)PaUtil_GroupAllocateZeroInitializedMemory(
                     winMmeHostApi->allocations,
                     (long)len );
         if( !deviceName )
@@ -849,7 +849,7 @@ static PaError InitializeOutputDeviceInfo( PaWinMmeHostApiRepresentation *winMme
     else
     {
         len = WCharStringLen( woc.szPname ) + 1;
-        deviceName = (char*)PaUtil_GroupAllocateMemory(
+        deviceName = (char*)PaUtil_GroupAllocateZeroInitializedMemory(
                     winMmeHostApi->allocations,
                     (long)len );
         if( !deviceName )
@@ -1004,7 +1004,7 @@ PaError PaWinMme_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
 
     if( maximumPossibleDeviceCount > 0 ){
 
-        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateZeroInitializedMemory(
                 winMmeHostApi->allocations, sizeof(PaDeviceInfo*) * maximumPossibleDeviceCount );
         if( !(*hostApi)->deviceInfos )
         {
@@ -1013,7 +1013,7 @@ PaError PaWinMme_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
         }
 
         /* allocate all device info structs in a contiguous block */
-        deviceInfoArray = (PaWinMmeDeviceInfo*)PaUtil_GroupAllocateMemory(
+        deviceInfoArray = (PaWinMmeDeviceInfo*)PaUtil_GroupAllocateZeroInitializedMemory(
                 winMmeHostApi->allocations, sizeof(PaWinMmeDeviceInfo) * maximumPossibleDeviceCount );
         if( !deviceInfoArray )
         {
@@ -1021,7 +1021,7 @@ PaError PaWinMme_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiInd
             goto error;
         }
 
-        winMmeHostApi->winMmeDeviceIds = (UINT*)PaUtil_GroupAllocateMemory(
+        winMmeHostApi->winMmeDeviceIds = (UINT*)PaUtil_GroupAllocateZeroInitializedMemory(
                 winMmeHostApi->allocations, sizeof(int) * maximumPossibleDeviceCount );
         if( !winMmeHostApi->winMmeDeviceIds )
         {

--- a/src/os/unix/pa_unix_util.c
+++ b/src/os/unix/pa_unix_util.c
@@ -71,7 +71,7 @@ static int numAllocations_ = 0;
 #endif
 
 
-void *PaUtil_AllocateMemory( long size )
+void *PaUtil_AllocateZeroInitializedMemory( long size )
 {
     /* use { malloc(); memset() } instead of calloc() so that we get
        the same alignment guarantee as malloc(). */

--- a/src/os/unix/pa_unix_util.c
+++ b/src/os/unix/pa_unix_util.c
@@ -73,7 +73,11 @@ static int numAllocations_ = 0;
 
 void *PaUtil_AllocateMemory( long size )
 {
+    /* use { malloc(); memset() } instead of calloc() so that we get
+       the same alignment guarantee as malloc(). */
     void *result = malloc( size );
+    if ( result )
+        memset( result, 0, size );
 
 #if PA_TRACK_MEMORY
     if( result != NULL ) numAllocations_ += 1;

--- a/src/os/win/pa_win_util.c
+++ b/src/os/win/pa_win_util.c
@@ -65,7 +65,7 @@ static int numAllocations_ = 0;
 #endif
 
 
-void *PaUtil_AllocateMemory( long size )
+void *PaUtil_AllocateZeroInitializedMemory( long size )
 {
     void *result = GlobalAlloc( GMEM_FIXED | GMEM_ZEROINIT, size );
 

--- a/src/os/win/pa_win_util.c
+++ b/src/os/win/pa_win_util.c
@@ -67,7 +67,7 @@ static int numAllocations_ = 0;
 
 void *PaUtil_AllocateMemory( long size )
 {
-    void *result = GlobalAlloc( GPTR, size );
+    void *result = GlobalAlloc( GMEM_FIXED | GMEM_ZEROINIT, size );
 
 #if PA_TRACK_MEMORY
     if( result != NULL ) numAllocations_ += 1;

--- a/src/os/win/pa_win_wdmks_utils.c
+++ b/src/os/win/pa_win_wdmks_utils.c
@@ -145,7 +145,7 @@ static PaError WdmGetPinPropertyMulti(
         return paUnanticipatedHostError;
     }
 
-    *ksMultipleItem = (KSMULTIPLE_ITEM*)PaUtil_AllocateMemory( multipleItemSize );
+    *ksMultipleItem = (KSMULTIPLE_ITEM*)PaUtil_AllocateZeroInitializedMemory( multipleItemSize );
     if( !*ksMultipleItem )
     {
         return paInsufficientMemory;


### PR DESCRIPTION
Make internal memory allocation utility functions allocate zero-initialized memory, and make this a documented guarantee. (Previously these allocations were not zero-initialized on Unix, but were zero-initialized on Windows). Rename `PaUtil_AllocateMemory` to `PaUtil_AllocateZeroInitializedMemory`. Rename `PaUtil_GroupAllocateMemory` to `PaUtil_GroupAllocateZeroInitializedMemory`. Remove redundant zero-initialization from dependent code. 

Note that it is possible that there are now allocations where zero-initialization is inappropriate for performance reasons. I intend to review the code for this as a separate issue.

Please consider rebase-and-merge (not squashing) to retain separation of critical changes to independent commits.

Fixes 396.