### PR TITLE
Increase max supported sample rate to 768000 Hz to address existence of the capable hardware

### DIFF
--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -862,7 +862,7 @@ static int SampleFormatIsValid( PaSampleFormat format )
         - if supplied its hostApi field matches the output device's host Api
 
     double sampleRate
-        - is not an 'absurd' rate (less than 1000. or greater than 384000.)
+        - is not an 'absurd' rate (less than 1000. or greater than 768000.)
         - sampleRate is NOT validated against device capabilities
 
     PaStreamFlags streamFlags
@@ -1003,7 +1003,7 @@ static PaError ValidateOpenStreamParameters(
 
 
     /* Check for absurd sample rates. */
-    if( (sampleRate < 1000.0) || (sampleRate > 384000.0) )
+    if( (sampleRate < 1000.0) || (sampleRate > 768000.0) )
         return paInvalidSampleRate;
 
     if( ((streamFlags & ~paPlatformSpecificFlags) & ~(paClipOff | paDitherOff | paNeverDropInput | paPrimeOutputBuffersUsingStreamCallback ) ) != 0 )


### PR DESCRIPTION
Increase max supported sample rate to 768000 Hz to address existence of the capable hardware such as USB DACs and DAPs. 

Closes #737 