### PR TITLE
Fix for WDM KS WaveRT low-latency microphone capture quality

### DIFF
--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -6587,12 +6587,11 @@ static PaError PaPinCaptureEventHandler_WaveRTEvent(PaProcessThreadInfo* pInfo, 
     PaWinWdmIOInfo* pCapture = &pInfo->stream->capture;
     const unsigned halfInputBuffer = pCapture->hostBufferSize >> 1;
     PaWinWdmPin* pin = pCapture->pPin;
-    DATAPACKET* packet = 0;
 
     /* Get hold of current ADC position */
     pin->fnAudioPosition(pin, &pos);
     pos %= pCapture->hostBufferSize;
-    pos &= ~(pCapture->bytesPerFrame - 1);
+    pos -= pos % pCapture->bytesPerFrame;
 
     /* Call barrier (or dummy) */
     pin->fnMemBarrier();

--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -6617,7 +6617,7 @@ static PaError PaPinCaptureEventHandler_WaveRTEvent(PaProcessThreadInfo* pInfo, 
             frameCount += frameCount_Step2;
         }
     }
-    
+
     PA_HP_TRACE((pInfo->stream->hLog, "Capture event (WaveRT): idx=%u head=%u (pos = %4.1lf%%, frames=%u)", realInBuf, pInfo->captureHead, (pos * 100.0 / pCapture->hostBufferSize), frameCount));
 
     ++pInfo->captureHead;


### PR DESCRIPTION
In my tests with latency < 40 ms on Win10 with embeded Realtek sound card, WDM KS capture resulted in sound with lots of cracks. 
I digged into the code and found out 1) there is a wrong assumption that host buffer position should be either 0 or 1/2 of buffer size when event is handled, 2) ensured that host ring buffer is read both from the end and the beginning if necessary (the exisiting code might resulted in reading non-initialized data beyond the end of the host buffer)