### PR TITLE
use PROJECT_SOURCE_DIR to set the CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(PA_USE_SKELETON)
 endif()
 
 include(CMakeDependentOption)
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake/modules")
 
 # JACK is most commonly used on Linux, but it is cross platform, so allow building it on any OS
 # if the FindJACK.cmake module finds POSIX headers.


### PR DESCRIPTION
This allows using the source tree inside another project with add_subdirectory().

See https://cmake.org/cmake/help/v3.26/variable/PROJECT_SOURCE_DIR.html which is available in 3.1, the minimum required by portaudio.