### PR TITLE
Treat warnings as errors on CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -114,6 +114,7 @@ jobs:
            -DPA_USE_SKELETON=ON
            -DPA_BUILD_TESTS=ON
            -DPA_BUILD_EXAMPLES=ON
+           -DPA_WARNINGS_ARE_ERRORS=ON
            -S .
            -B build
     - name: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,43 @@ else()
   set(LIBRARY_BUILD_TYPE STATIC)
 endif()
 
+option(PA_WARNINGS_ARE_ERRORS "Turn compiler warnings into errors" OFF)
+if(PA_WARNINGS_ARE_ERRORS)
+    if(MSVC)
+        add_compile_options(/WX
+            # "Grandfathered" warnings that existed before we started enforcement.
+            # Do *NOT* add warnings to this list. Instead, fix your code so that it doesn't produce the warning.
+            # TODO: fix the offending code so that we don't have to exclude specific warnings anymore.
+            /wd4018 # W3 signed/unsigned mismatch
+            /wd4024 # W1 different types for formal and actual parameter
+            /wd4047 # W1 differs in levels of indirection
+            /wd4101 # W3 unreferenced local variable
+            /wd4133 # W3 incompatible types
+            /wd4146 # W2 unary minus operator applied to unsigned type, result still unsigned
+            /wd4244 # W2 conversion possible loss of data
+            /wd4267 # W3 conversion possible loss of data
+            /wd4305 # W1 truncation
+            /wd4477 # W1 format string requires an argument of type, but variadic argument number has type
+            /wd4996 # W3 unsafe/deprecated
+        )
+    else()
+        add_compile_options(-Werror
+            # "Grandfathered" warnings that existed before we started enforcement.
+            # Do *NOT* add warnings to this list. Instead, fix your code so that it doesn't produce the warning.
+            # TODO: fix the offending code so that we don't have to exclude specific warnings anymore.
+            -Wno-error=deprecated-declarations  # https://github.com/PortAudio/portaudio/issues/213 https://github.com/PortAudio/portaudio/issues/641
+            -Wno-error=incompatible-pointer-types
+            -Wno-error=int-conversion
+            -Wno-error=stringop-overflow
+        )
+        if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+             # Don't fail on older clang versions that don't recognize the latest warnings in the list above.
+             # Note that unrecognized warning options are not a fatal error on GCC, and in fact, GCC will choke on this option. Hence the conditional.
+            add_compile_options(-Wno-error=unknown-warning-option)
+        endif()
+    endif()
+endif()
+
 add_library(PortAudio
   ${LIBRARY_BUILD_TYPE}
   src/common/pa_allocation.c


### PR DESCRIPTION
This pull request adds a new CMake option that makes it easy and convenient for PortAudio developers to turn warnings into errors, making it easier to find problems while iterating on code.

The option is then enabled on CI, ensuring that any future PortAudio changes are warning-free.

The option is not enabled by default because that would run the risk of breaking the build for people who don't have the same build setup as the CI (in particular, compiler type and version), and might trigger different warnings as a result. In particular, we don't want to break people who are merely interested in building PortAudio, but not interested in making changes to PortAudio.

Unfortunately the current code is not free of warnings. We should clean up the codebase to remove all warnings, but that will require some work. If we block enforcement on this work being done, we would not get immediate benefits and we could end up with even more warnings to clean up. So instead, this PR proposes the following approach:

1. We "grandfather" the specific warning types that are already produced by the existing code, i.e. we explicitly stop them from being turned into errors to avoid breaking CI.
2. We turn on enforcement in CI, thus preventing backsliding.
3. We progressively clean up the codebase, removing warning types from the exception list as we go.
4. Once everything is cleaned up we might want to consider increasing the warning level as much as possible.

This PR handles (1) and (2), with (3) and (4) relegated to future PRs.

This PR supersedes #636, which appears to have stalled.