### PR TITLE
paloopback: fix wrong test duration

### DIFF
--- a/qa/loopback/src/paqa.c
+++ b/qa/loopback/src/paqa.c
@@ -1017,7 +1017,7 @@ static int PaQa_AnalyzeLoopbackConnection( UserOptions *userOptions, PaDeviceInd
                 // SAMPLE RATE
                 TestParameters srTestParams = flagTestParams;
                 srTestParams.sampleRate = sampleRates[iRate];
-                srTestParams.maxFrames = (int) (PAQA_TEST_DURATION * testParams.sampleRate);
+                srTestParams.maxFrames = (int) (PAQA_TEST_DURATION * srTestParams.sampleRate);
 
                 numBadChannels = PaQa_SingleLoopBackTest( userOptions, &srTestParams );
                 totalBadChannels += numBadChannels;


### PR DESCRIPTION
This fixes a regression introduced in 5b5feb3 where, during sample rate testing, the test duration would be computed based on the global sample rate instead of the chosen sample rate, resulting in the test running for too long or not long enough depending on the sample rate being tested. The main symptom is that paloopback would complain about timeouts when testing sample rates 8000, 11000 and 16000.