### PR TITLE
Pa_Initialize(): Guard against recursive calls.

### DIFF
--- a/include/portaudio.h
+++ b/include/portaudio.h
@@ -151,7 +151,8 @@ typedef enum PaErrorCode
     paCanNotReadFromAnOutputOnlyStream,
     paCanNotWriteToAnInputOnlyStream,
     paIncompatibleStreamHostApi,
-    paBadBufferPtr
+    paBadBufferPtr,
+    paCanNotInitializeRecursively
 } PaErrorCode;
 
 

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -365,7 +365,7 @@ PaError Pa_Initialize( void )
     {
         // a concurrent initialization is already running
         PA_DEBUG(("Attempting to re-enter Pa_Initialize(), aborting!\n"));
-        result = paInternalError;
+        result = paCanNotInitializeRecursively;
     }
     else
     {
@@ -469,6 +469,7 @@ const char *Pa_GetErrorText( PaError errorCode )
     case paCanNotWriteToAnInputOnlyStream:      result = "Can't write to an input only stream"; break;
     case paIncompatibleStreamHostApi: result = "Incompatible stream host API"; break;
     case paBadBufferPtr:             result = "Bad buffer pointer"; break;
+    case paCanNotInitializeRecursively: result = "PortAudio can not initialized recursively"; break;
     default:
         if( errorCode > 0 )
             result = "Invalid error code (value greater than zero)";

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -374,6 +374,7 @@ PaError Pa_Initialize( void )
         // let recursive calls execute the if branch above.
         // This can happen if a driver like FlexAsio itself uses portaudio
         // and avoids a stack overflow in the user application.
+        // https://github.com/PortAudio/portaudio/issues/766
         initializing_ = true;
 
         PA_VALIDATE_TYPE_SIZES;

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -469,7 +469,7 @@ const char *Pa_GetErrorText( PaError errorCode )
     case paCanNotWriteToAnInputOnlyStream:      result = "Can't write to an input only stream"; break;
     case paIncompatibleStreamHostApi: result = "Incompatible stream host API"; break;
     case paBadBufferPtr:             result = "Bad buffer pointer"; break;
-    case paCanNotInitializeRecursively: result = "PortAudio can not initialized recursively"; break;
+    case paCanNotInitializeRecursively: result = "PortAudio can not be initialized recursively"; break;
     default:
         if( errorCode > 0 )
             result = "Invalid error code (value greater than zero)";

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -365,6 +365,7 @@ PaError Pa_Initialize( void )
     else if( initializing_ )
     {
         // a concurrent initialization is already running
+        PA_DEBUG(("Attempting to re-enter Pa_Initialize(), aborting!\n"));
         result = paInternalError;
     }
     else

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -67,7 +67,6 @@
 #include <string.h>
 #include <stdlib.h> /* needed for strtol() */
 #include <assert.h> /* needed by PA_VALIDATE_ENDIANNESS */
-#include <stdbool.h>
 
 #include "portaudio.h"
 #include "pa_util.h"
@@ -155,7 +154,7 @@ static PaUtilHostApiRepresentation **hostApis_ = 0;
 static int hostApisCount_ = 0;
 static int defaultHostApiIndex_ = 0;
 static int initializationCount_ = 0;
-static bool initializing_ = false;
+static int initializing_ = 0;
 static int deviceCount_ = 0;
 
 PaUtilStreamRepresentation *firstOpenStream_ = NULL;
@@ -375,7 +374,7 @@ PaError Pa_Initialize( void )
         // This can happen if a driver like FlexAsio itself uses portaudio
         // and avoids a stack overflow in the user application.
         // https://github.com/PortAudio/portaudio/issues/766
-        initializing_ = true;
+        initializing_ = 1;
 
         PA_VALIDATE_TYPE_SIZES;
         PA_VALIDATE_ENDIANNESS;
@@ -387,7 +386,7 @@ PaError Pa_Initialize( void )
         if( result == paNoError )
             ++initializationCount_;
 
-        initializing_ = false;
+        initializing_ = 0;
     }
 
     PA_LOGAPI_EXIT_PAERROR( "Pa_Initialize", result );


### PR DESCRIPTION
This fixes a stack overflow when a diver uses portaudio as well like FlexAsio

Fixes: https://github.com/PortAudio/portaudio/issues/766