### PR TITLE
Issue #35 - implemented missing Int32_to_Int24_Dither function

### DIFF
--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -943,6 +943,7 @@ static void Int32_To_Int24_Dither(
 
     while ( count-- )
     {
+        /* REVIEW */
         dither = PaUtil_Generate16BitTriangularDither(ditherGenerator);
         *dest = (signed char) ((((*src) >> 1) + dither) >> 7);
         

--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -935,13 +935,20 @@ static void Int32_To_Int24_Dither(
     void *sourceBuffer, signed int sourceStride,
     unsigned int count, struct PaUtilTriangularDitherGenerator *ditherGenerator )
 {
-    (void) destinationBuffer; /* unused parameters */
-    (void) destinationStride; /* unused parameters */
-    (void) sourceBuffer; /* unused parameters */
-    (void) sourceStride; /* unused parameters */
-    (void) count; /* unused parameters */
     (void) ditherGenerator; /* unused parameters */
-    /* IMPLEMENT ME */
+
+    PaInt32 *src = (PaInt32*)sourceBuffer;
+    signed char *dest = (signed char*)destinationBuffer;
+    PaInt32 dither;
+
+    while ( count-- )
+    {
+        dither = PaUtil_Generate16BitTriangularDither(ditherGenerator);
+        *dest = (signed char) ((((*src) >> 1) + dither) >> 7);
+        
+        src += sourceStride;
+        dest += destinationStride;
+    }
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Title. Implemented the missing function "Int32_To_Int24_Dither" in "pa_converters.c" using the specified coding guidelines.

I had a few questions:
1. Is doing conversions differently for Little Endian vs Big Endian machines required for all conversion functions? I noticed that some functions did make the distinction while some did not, and I cannot figure out why that is the case.
2. What is the purpose of the sourceStride and the destinationStride variables in the conversion functions? Based off of how the other functions were implemented I gather that they're used for navigating across the bits of the binary numbers (I think?) but I am not sure. If that is the case, then why is it so that some strides are directly added onto src while others (such as the sourceStride in the function Int24_To_Float32) are multiplied by a certain number before adding them onto src?