### PR TITLE
Fix some low-hanging C warnings

### DIFF
--- a/examples/paex_read_write_wire.c
+++ b/examples/paex_read_write_wire.c
@@ -98,8 +98,8 @@ int main(void)
     int numChannels;
 
     printf("patest_read_write_wire.c\n"); fflush(stdout);
-    printf("sizeof(int) = %lu\n", sizeof(int)); fflush(stdout);
-    printf("sizeof(long) = %lu\n", sizeof(long)); fflush(stdout);
+    printf("sizeof(int) = %lu\n", (unsigned long) sizeof(int)); fflush(stdout);
+    printf("sizeof(long) = %lu\n", (unsigned long) sizeof(long)); fflush(stdout);
 
     err = Pa_Initialize();
     if( err != paNoError ) goto error2;

--- a/qa/loopback/src/paqa.c
+++ b/qa/loopback/src/paqa.c
@@ -968,7 +968,6 @@ static int PaQa_AnalyzeLoopbackConnection( UserOptions *userOptions, PaDeviceInd
     int iRate;
     int iSize;
     int iFormat;
-    int savedValue;
     TestParameters testParams;
     const PaDeviceInfo *inputDeviceInfo = Pa_GetDeviceInfo( inputDevice );
     const PaDeviceInfo *outputDeviceInfo = Pa_GetDeviceInfo( outputDevice );

--- a/qa/paqa_devs.c
+++ b/qa/paqa_devs.c
@@ -118,7 +118,7 @@ static int gNumFailed = 0;
 static float NextSineSample( PaQaData *data )
 {
     float phase = data->phase + PHASE_INCREMENT;
-    if( phase > M_PI ) phase -= 2.0 * M_PI;
+    if( phase > M_PI ) phase -= (float) (2.0 * M_PI);
     data->phase = phase;
     return sinf(phase) * SINE_AMPLITUDE;
 }

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -1216,7 +1216,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     stream->isBlockingStream = !streamCallback;
     if( stream->isBlockingStream )
     {
-        float latency = 0.001; /* 1ms is the absolute minimum we support */
+        float latency = 0.001f; /* 1ms is the absolute minimum we support */
         int   minimum_buffer_frames = 0;
 
         if( inputParameters && inputParameters->suggestedLatency > latency )

--- a/test/patest_dsound_find_best_latency_params.c
+++ b/test/patest_dsound_find_best_latency_params.c
@@ -46,7 +46,7 @@
 //#include <mmsystem.h>   /* required when using pa_win_wmme.h */
 
 #include <conio.h>      /* for _getch */
-
+#include <tchar.h>
 
 #include "portaudio.h"
 #include "pa_win_ds.h"
@@ -202,7 +202,7 @@ static void printWindowsVersionInfo( FILE *fp )
 
 
     fprintf( fp, "OS name and edition: %s %s\n", osName, osProductType );
-    fprintf( fp, "OS version: %d.%d.%d %S\n",
+    _ftprintf( fp, TEXT("OS version: %d.%d.%d %s\n"),
                 osVersionInfoEx.dwMajorVersion, osVersionInfoEx.dwMinorVersion,
                 osVersionInfoEx.dwBuildNumber, osVersionInfoEx.szCSDVersion );
     fprintf( fp, "Processor architecture: %s\n", processorArchitecture );

--- a/test/patest_dsound_find_best_latency_params.c
+++ b/test/patest_dsound_find_best_latency_params.c
@@ -406,9 +406,9 @@ int main(int argc, char* argv[])
     if( argc >= 2 ){
         deviceIndex = -1;
         if( sscanf( argv[1], "%d", &deviceIndex ) != 1 )
-            usage(dsoundHostApiInfo);
+            usage(dsoundHostApiIndex);
         if( deviceIndex < 0 || deviceIndex >= Pa_GetDeviceCount() || Pa_GetDeviceInfo(deviceIndex)->hostApi != dsoundHostApiIndex ){
-            usage(dsoundHostApiInfo);
+            usage(dsoundHostApiIndex);
         }
     }
 

--- a/test/patest_dsound_find_best_latency_params.c
+++ b/test/patest_dsound_find_best_latency_params.c
@@ -36,11 +36,12 @@
  * license above.
  */
 
+#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */
+
 #include <stdio.h>
 #include <time.h>
 #include <math.h>
 
-#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */
 #include <windows.h>
 //#include <mmsystem.h>   /* required when using pa_win_wmme.h */
 

--- a/test/patest_dsound_find_best_latency_params.c
+++ b/test/patest_dsound_find_best_latency_params.c
@@ -101,7 +101,7 @@ static void printWindowsVersionInfo( FILE *fp )
 
     memset( &osVersionInfoEx, 0, sizeof(OSVERSIONINFOEX) );
     osVersionInfoEx.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-    GetVersionEx( &osVersionInfoEx );
+    GetVersionEx( (LPOSVERSIONINFO) &osVersionInfoEx );
 
 
     if( osVersionInfoEx.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS ){

--- a/test/patest_leftright.c
+++ b/test/patest_leftright.c
@@ -57,7 +57,7 @@
 #define M_PI  (3.14159265)
 #endif
 #define TABLE_SIZE   (200)
-#define BALANCE_DELTA  (0.001)
+#define BALANCE_DELTA  (0.001f)
 
 typedef struct
 {
@@ -161,11 +161,11 @@ int main(void)
     for( i=0; i<4; i++ )
     {
         printf("Hear low sound on left side.\n");
-        data.targetBalance = 0.01;
+        data.targetBalance = 0.01f;
         Pa_Sleep( 1000 );
 
         printf("Hear high sound on right side.\n");
-        data.targetBalance = 0.99;
+        data.targetBalance = 0.99f;
         Pa_Sleep( 1000 );
     }
 

--- a/test/patest_wmme_find_best_latency_params.c
+++ b/test/patest_wmme_find_best_latency_params.c
@@ -36,11 +36,12 @@
  * license above.
  */
 
+#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */
+
 #include <stdio.h>
 #include <time.h>
 #include <math.h>
 
-#define  _WIN32_WINNT 0x0501 /* for GetNativeSystemInfo */
 #include <windows.h>    /* required when using pa_win_wmme.h */
 #include <mmsystem.h>   /* required when using pa_win_wmme.h */
 

--- a/test/patest_wmme_find_best_latency_params.c
+++ b/test/patest_wmme_find_best_latency_params.c
@@ -46,7 +46,7 @@
 #include <mmsystem.h>   /* required when using pa_win_wmme.h */
 
 #include <conio.h>      /* for _getch */
-
+#include <tchar.h>
 
 #include "portaudio.h"
 #include "pa_win_wmme.h"
@@ -207,7 +207,7 @@ static void printWindowsVersionInfo( FILE *fp )
 
 
     fprintf( fp, "OS name and edition: %s %s\n", osName, osProductType );
-    fprintf( fp, "OS version: %d.%d.%d %S\n",
+    _ftprintf( fp, TEXT("OS version: %d.%d.%d %s\n"),
                 osVersionInfoEx.dwMajorVersion, osVersionInfoEx.dwMinorVersion,
                 osVersionInfoEx.dwBuildNumber, osVersionInfoEx.szCSDVersion );
     fprintf( fp, "Processor architecture: %s\n", processorArchitecture );

--- a/test/patest_wmme_find_best_latency_params.c
+++ b/test/patest_wmme_find_best_latency_params.c
@@ -106,7 +106,7 @@ static void printWindowsVersionInfo( FILE *fp )
 
     memset( &osVersionInfoEx, 0, sizeof(OSVERSIONINFOEX) );
     osVersionInfoEx.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-    GetVersionEx( &osVersionInfoEx );
+    GetVersionEx( (LPOSVERSIONINFO) &osVersionInfoEx );
 
 
     if( osVersionInfoEx.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS ){


### PR DESCRIPTION
This PR is a spin-off of #780 that focuses on fixing a number of trivial low-hanging fruit warnings.

Note that this PR only fixes a few classes of warnings, not all of them. It's a step in the right direction, though.