### PR TITLE
Remove -Werror from autotools darwin build

### DIFF
--- a/configure
+++ b/configure
@@ -15866,7 +15866,7 @@ case "${host_os}" in
         $as_echo "#define PA_USE_COREAUDIO 1" >>confdefs.h
 
 
-        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated -Werror"
+        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated"
         LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices"
 
         if test "x$enable_mac_universal" = "xyes" ; then

--- a/configure.in
+++ b/configure.in
@@ -221,7 +221,7 @@ case "${host_os}" in
 
         AC_DEFINE(PA_USE_COREAUDIO,1)
 
-        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated -Werror"
+        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix -Wno-deprecated"
         LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit -framework CoreFoundation -framework CoreServices"
 
         if test "x$enable_mac_universal" = "xyes" ; then


### PR DESCRIPTION
Warnings should not be turned into errors by default as that can cause difficulties for people who just want to build PortAudio, not work on it. Also this is inconsistent with other platforms.

This PR is a spin-off of #780.