### PR TITLE
oss: Clean up header handling

### DIFF
--- a/cmake/modules/FindOSS.cmake
+++ b/cmake/modules/FindOSS.cmake
@@ -10,11 +10,9 @@ Imported Targets
 This module provides the following imported targets, if found:
 
 ``OSS::oss``
-  Target for the OSS header include directory. One of the following
-  compile definitions is added to the target:
-  HAVE_SYS_SOUNDCARD_H if the header is sys/soundcard.h
-  HAVE_LINUX_SOUNDCARD_H if the header is linux/soundcard.h
-  HAVE_MACHINE_SOUNDCARD_H if the header is machine/soundcard.h
+  Target for the OSS header include directory. The following compile
+  definition is added to the target:
+  HAVE_SYS_SOUNDCARD_H for the header sys/soundcard.h
 
 #]=======================================================================]
 
@@ -23,20 +21,6 @@ find_path(OSS_INCLUDE_DIR
   DOC "OSS include directory")
 if(OSS_INCLUDE_DIR)
   set(OSS_DEFINITIONS HAVE_SYS_SOUNDCARD_H)
-else()
-  find_path(OSS_INCLUDE_DIR
-    NAMES linux/soundcard.h
-    DOC "OSS include directory")
-  if(OSS_INCLUDE_DIR)
-    set(OSS_DEFINITIONS HAVE_LINUX_SOUNDCARD_H)
-  else()
-    find_path(OSS_INCLUDE_DIR
-      NAMES machine/soundcard.h
-      DOC "OSS include directory")
-    if(OSS_INCLUDE_DIR)
-      set(OSS_DEFINITIONS HAVE_MACHINE_SOUNDCARD_H)
-    endif()
-  endif()
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/configure
+++ b/configure
@@ -15405,13 +15405,12 @@ fi
 have_libossaudio=no
 have_oss=no
 if test "x$with_oss" != "xno"; then
-    for ac_header in sys/soundcard.h linux/soundcard.h machine/soundcard.h
+    for ac_header in sys/soundcard.h
 do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
-ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  ac_fn_c_check_header_mongrel "$LINENO" "sys/soundcard.h" "ac_cv_header_sys_soundcard_h" "$ac_includes_default"
+if test "x$ac_cv_header_sys_soundcard_h" = xyes; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+#define HAVE_SYS_SOUNDCARD_H 1
 _ACEOF
  have_oss=yes
 fi

--- a/configure.in
+++ b/configure.in
@@ -144,7 +144,7 @@ fi
 have_libossaudio=no
 have_oss=no
 if test "x$with_oss" != "xno"; then
-    AC_CHECK_HEADERS([sys/soundcard.h linux/soundcard.h machine/soundcard.h], [have_oss=yes])
+    AC_CHECK_HEADERS([sys/soundcard.h], [have_oss=yes])
     if test "x$have_oss" = "xyes"; then
         AC_CHECK_LIB(ossaudio, _oss_ioctl, have_libossaudio=yes, have_libossaudio=no)
     fi

--- a/src/hostapi/oss/pa_unix_oss.c
+++ b/src/hostapi/oss/pa_unix_oss.c
@@ -63,21 +63,11 @@
 #include <limits.h>
 #include <semaphore.h>
 
-#ifdef HAVE_SYS_SOUNDCARD_H
-# include <sys/soundcard.h>
-# ifdef __NetBSD__
-#  define DEVICE_NAME_BASE           "/dev/audio"
-# else
-#  define DEVICE_NAME_BASE           "/dev/dsp"
-# endif
-#elif defined(HAVE_LINUX_SOUNDCARD_H)
-# include <linux/soundcard.h>
-# define DEVICE_NAME_BASE            "/dev/dsp"
-#elif defined(HAVE_MACHINE_SOUNDCARD_H)
-# include <machine/soundcard.h> /* JH20010905 */
-# define DEVICE_NAME_BASE            "/dev/audio"
+#include <sys/soundcard.h>
+#ifdef __NetBSD__
+# define DEVICE_NAME_BASE           "/dev/audio"
 #else
-# error No sound card header file
+# define DEVICE_NAME_BASE           "/dev/dsp"
 #endif
 
 #include "portaudio.h"


### PR DESCRIPTION
Clean up some of the OSS header handling. machine/soundcard.h is from FreeBSD releases that are over 20 years old and linux/soundcard.h is used by ancient Linux. Modern FreeBSD / NetBSD and Linux with OSSv4 is good with sys/soundcard.h.