### PR TITLE
[DRAFT] example of setting -Werror in autotools ./configure CI script

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: configure
-      run: ./configure
+      run: ./configure CFLAGS=-Werror
     - name: make
-      run: make
+      run: make CFLAGS=-Werror


### PR DESCRIPTION
Either include in #800 or follow up from 800

I don't intend to use both options. Choose one option, either

1. configure step, OR
2. make step

See discussion at https://stackoverflow.com/questions/32792692/cflags-in-configure-script