### PR TITLE
Remove some warnings from allowlist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,9 @@ if(PA_WARNINGS_ARE_ERRORS)
             # Do *NOT* add warnings to this list. Instead, fix your code so that it doesn't produce the warning.
             # TODO: fix the offending code so that we don't have to exclude specific warnings anymore.
             /wd4018 # W3 signed/unsigned mismatch
-            /wd4024 # W1 different types for formal and actual parameter
-            /wd4047 # W1 differs in levels of indirection
-            /wd4101 # W3 unreferenced local variable
-            /wd4133 # W3 incompatible types
             /wd4146 # W2 unary minus operator applied to unsigned type, result still unsigned
             /wd4244 # W2 conversion possible loss of data
             /wd4267 # W3 conversion possible loss of data
-            /wd4305 # W1 truncation
-            /wd4477 # W1 format string requires an argument of type, but variadic argument number has type
             /wd4996 # W3 unsafe/deprecated
         )
     else()
@@ -40,8 +34,6 @@ if(PA_WARNINGS_ARE_ERRORS)
             # Do *NOT* add warnings to this list. Instead, fix your code so that it doesn't produce the warning.
             # TODO: fix the offending code so that we don't have to exclude specific warnings anymore.
             -Wno-error=deprecated-declarations  # https://github.com/PortAudio/portaudio/issues/213 https://github.com/PortAudio/portaudio/issues/641
-            -Wno-error=incompatible-pointer-types
-            -Wno-error=int-conversion
             -Wno-error=stringop-overflow
         )
         if (CMAKE_C_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
These warnings are not currently being triggered. Their presence is probably the result of merge confusion between #780 and #799.