### PR TITLE
Fix MSVC warning wd4146 unary minus operator applied to unsigned type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ if(PA_WARNINGS_ARE_ERRORS)
             # Do *NOT* add warnings to this list. Instead, fix your code so that it doesn't produce the warning.
             # TODO: fix the offending code so that we don't have to exclude specific warnings anymore.
             /wd4018 # W3 signed/unsigned mismatch
-            # TEST /wd4146 # W2 unary minus operator applied to unsigned type, result still unsigned
             /wd4244 # W2 conversion possible loss of data
             /wd4267 # W3 conversion possible loss of data
             /wd4996 # W3 unsafe/deprecated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(PA_WARNINGS_ARE_ERRORS)
             # Do *NOT* add warnings to this list. Instead, fix your code so that it doesn't produce the warning.
             # TODO: fix the offending code so that we don't have to exclude specific warnings anymore.
             /wd4018 # W3 signed/unsigned mismatch
-            /wd4146 # W2 unary minus operator applied to unsigned type, result still unsigned
+            # TEST /wd4146 # W2 unary minus operator applied to unsigned type, result still unsigned
             /wd4244 # W2 conversion possible loss of data
             /wd4267 # W3 conversion possible loss of data
             /wd4996 # W3 unsafe/deprecated

--- a/qa/loopback/src/paqa.c
+++ b/qa/loopback/src/paqa.c
@@ -1351,7 +1351,8 @@ int TestSampleFormatConversion( void )
     const char charInput[] = { 127, 64, -64, -128 };
     const unsigned char ucharInput[] = { 255, 128+64, 64, 0 };
     const short shortInput[] = { 32767, 32768/2, -32768/2, -32768 };
-    const int intInput[] = { 2147483647, 2147483647/2, /*-2147483648/2:*/(-2147483647 - 1)/2, /*"-2147483648":*/(-2147483647 - 1) }; /*see PR #814*/
+    const int int_minus_2147483648 = (-2147483647 - 1); /*"-2147483648" as a signed integer. See PR #814*/
+    const int intInput[] = { 2147483647, 2147483647/2, int_minus_2147483648/2, int_minus_2147483648 }; /*see PR #814*/
 
     float floatOutput[4];
     short shortOutput[4];

--- a/qa/loopback/src/paqa.c
+++ b/qa/loopback/src/paqa.c
@@ -1352,7 +1352,7 @@ int TestSampleFormatConversion( void )
     const unsigned char ucharInput[] = { 255, 128+64, 64, 0 };
     const short shortInput[] = { 32767, 32768/2, -32768/2, -32768 };
     const int int_minus_2147483648 = (-2147483647 - 1); /*"-2147483648" as a signed integer. See PR #814*/
-    const int intInput[] = { 2147483647, 2147483647/2, int_minus_2147483648/2, int_minus_2147483648 }; /*see PR #814*/
+    const int intInput[] = { 2147483647, 2147483647/2, int_minus_2147483648/2, int_minus_2147483648 };
 
     float floatOutput[4];
     short shortOutput[4];

--- a/qa/loopback/src/paqa.c
+++ b/qa/loopback/src/paqa.c
@@ -1351,7 +1351,7 @@ int TestSampleFormatConversion( void )
     const char charInput[] = { 127, 64, -64, -128 };
     const unsigned char ucharInput[] = { 255, 128+64, 64, 0 };
     const short shortInput[] = { 32767, 32768/2, -32768/2, -32768 };
-    const int intInput[] = { 2147483647, 2147483647/2, -1073741824 /*-2147483648/2 doesn't work in msvc*/, -2147483648 };
+    const int intInput[] = { 2147483647, 2147483647/2, /*-2147483648/2:*/(-2147483647 - 1)/2, /*"-2147483648":*/(-2147483647 - 1) }; /*see PR #814*/
 
     float floatOutput[4];
     short shortOutput[4];


### PR DESCRIPTION
Fixes:

> wd4146: W2 unary minus operator applied to unsigned type, result still unsigned

See next comment for details.