### PR TITLE
bindings/cpp: CMake: support pkgconfig with RelWithDebInfo

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -118,5 +118,5 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/PortAudioCppConfig.cmake"
 set(PC_PREFIX "\${pcfiledir}/../..")  
 configure_file(cmake/portaudiocpp.pc.in "${CMAKE_CURRENT_BINARY_DIR}/portaudiocpp.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/portaudiocpp.pc"
-        CONFIGURATIONS Release
+        CONFIGURATIONS Release RelWithDebInfo
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
I suggest to add this quick fix that adds also `RelWithDebInfo` to the configurations allowed to install portaudiocpp.pc, otherwise you won't have support for pkg-config when building a release package with separate debugging information.
Actually, besides that, `RelWithDebInfo` is identical to Release.