### PR TITLE
Improve float to int truncation precision

### DIFF
--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -330,7 +330,7 @@ static const double const_1_div_2147483648_ = 1.0 / 2147483648.0; /* 32 bit mult
 
 /* -------------------------------------------------------------------------- */
 
-static inline int SetRoundingMode()
+static int SetRoundingMode()
 {
     int prev = fegetround();
 
@@ -342,24 +342,10 @@ static inline int SetRoundingMode()
 
 /* -------------------------------------------------------------------------- */
 
-static inline void ResetRoundingMode(int prev)
+static void ResetRoundingMode(int prev)
 {
     if (prev != -1)
         fesetround(prev);
-}
-
-/* -------------------------------------------------------------------------- */
-
-static inline PaInt32 TruncateFloatToInt32(float v)
-{
-    return (PaInt32)v;
-}
-
-/* -------------------------------------------------------------------------- */
-
-static inline PaInt32 TruncateDoubleToInt32(double v)
-{
-    return (PaInt32)v;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -379,7 +365,7 @@ static void Float32_To_Int32(
     {
         /* REVIEW */
         double scaled = *src * 0x7FFFFFFF;
-        *dest = TruncateDoubleToInt32(scaled);
+        *dest = (PaInt32)scaled;
 
         src += sourceStride;
         dest += destinationStride;
@@ -405,7 +391,7 @@ static void Float32_To_Int32_Dither(
         double dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         double dithered = ((double)*src * (2147483646.0)) + dither;
-        *dest = TruncateDoubleToInt32(dithered);
+        *dest = (PaInt32)dithered;
 
         src += sourceStride;
         dest += destinationStride;
@@ -432,7 +418,7 @@ static void Float32_To_Int32_Clip(
         /* REVIEW */
         double scaled = *src * 0x7FFFFFFF;
         PA_CLIP_( scaled, -2147483648., 2147483647.  );
-        *dest = TruncateDoubleToInt32(scaled);
+        *dest = (PaInt32)scaled;
 
         src += sourceStride;
         dest += destinationStride;
@@ -459,7 +445,7 @@ static void Float32_To_Int32_DitherClip(
         /* use smaller scaler to prevent overflow when we add the dither */
         double dithered = ((double)*src * (2147483646.0)) + dither;
         PA_CLIP_( dithered, -2147483648., 2147483647.  );
-        *dest = TruncateDoubleToInt32(dithered);
+        *dest = (PaInt32)dithered;
 
         src += sourceStride;
         dest += destinationStride;
@@ -486,7 +472,7 @@ static void Float32_To_Int24(
     {
         /* convert to 32 bit and drop the low 8 bits */
         double scaled = (double)(*src) * 2147483647.0;
-        temp = TruncateDoubleToInt32(scaled);
+        temp = (PaInt32)scaled;
 
 #if defined(PA_LITTLE_ENDIAN)
         dest[0] = (unsigned char)(temp >> 8);
@@ -525,7 +511,7 @@ static void Float32_To_Int24_Dither(
         /* use smaller scaler to prevent overflow when we add the dither */
         double dithered = ((double)*src * (2147483646.0)) + dither;
 
-        temp = TruncateDoubleToInt32(dithered);
+        temp = (PaInt32)dithered;
 
 #if defined(PA_LITTLE_ENDIAN)
         dest[0] = (unsigned char)(temp >> 8);
@@ -563,7 +549,7 @@ static void Float32_To_Int24_Clip(
         /* convert to 32 bit and drop the low 8 bits */
         double scaled = *src * 0x7FFFFFFF;
         PA_CLIP_( scaled, -2147483648., 2147483647.  );
-        temp = TruncateDoubleToInt32(scaled);
+        temp = (PaInt32)scaled;
 
 #if defined(PA_LITTLE_ENDIAN)
         dest[0] = (unsigned char)(temp >> 8);
@@ -603,7 +589,7 @@ static void Float32_To_Int24_DitherClip(
         double dithered = ((double)*src * (2147483646.0)) + dither;
         PA_CLIP_( dithered, -2147483648., 2147483647.  );
 
-        temp = TruncateDoubleToInt32(dithered);
+        temp = (PaInt32)dithered;
 
 #if defined(PA_LITTLE_ENDIAN)
         dest[0] = (unsigned char)(temp >> 8);
@@ -638,7 +624,7 @@ static void Float32_To_Int16(
     while( count-- )
     {
         float scaled = *src * (32767.0f);
-        *dest = (PaInt16)TruncateFloatToInt32(scaled);
+        *dest = (PaInt16)scaled;
 
         src += sourceStride;
         dest += destinationStride;
@@ -665,7 +651,7 @@ static void Float32_To_Int16_Dither(
         /* use smaller scaler to prevent overflow when we add the dither */
         float dithered = (*src * (32766.0f)) + dither;
 
-        *dest = (PaInt16)TruncateFloatToInt32(dithered);
+        *dest = (PaInt16)dithered;
 
         src += sourceStride;
         dest += destinationStride;
@@ -691,7 +677,7 @@ static void Float32_To_Int16_Clip(
     {
         float scaled = *src * (32767.0f);
         PA_CLIP_( scaled, -0x8000, 0x7FFF );
-        *dest = (PaInt16)TruncateFloatToInt32(scaled);
+        *dest = (PaInt16)scaled;
 
         src += sourceStride;
         dest += destinationStride;
@@ -719,7 +705,7 @@ static void Float32_To_Int16_DitherClip(
         float dither = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         float dithered = (*src * (32766.0f)) + dither;
-        PaInt32 samp = TruncateFloatToInt32(dithered);
+        PaInt32 samp = (PaInt32)dithered;
         PA_CLIP_( samp, -0x8000, 0x7FFF );
         *dest = (PaInt16) samp;
 
@@ -746,7 +732,7 @@ static void Float32_To_Int8(
     while( count-- )
     {
         float scaled = *src * (127.0f);
-        *dest = (signed char)TruncateFloatToInt32(scaled);
+        *dest = (signed char)scaled;
 
         src += sourceStride;
         dest += destinationStride;
@@ -771,7 +757,7 @@ static void Float32_To_Int8_Dither(
         float dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         float dithered = (*src * (126.0f)) + dither;
-        *dest = (signed char)TruncateFloatToInt32(dithered);
+        *dest = (signed char)dithered;
 
         src += sourceStride;
         dest += destinationStride;
@@ -796,7 +782,7 @@ static void Float32_To_Int8_Clip(
     while( count-- )
     {
         float scaled = *src * (127.0f);
-        PaInt32 samp = TruncateFloatToInt32(scaled);
+        PaInt32 samp = (PaInt32)scaled;
         PA_CLIP_( samp, -0x80, 0x7F );
         *dest = (signed char) samp;
 
@@ -825,7 +811,7 @@ static void Float32_To_Int8_DitherClip(
         float dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         float dithered = (*src * (126.0f)) + dither;
-        PaInt32 samp = TruncateFloatToInt32(dithered);
+        PaInt32 samp = (PaInt32)dithered;
         PA_CLIP_( samp, -0x80, 0x7F );
         *dest = (signed char) samp;
 
@@ -851,7 +837,7 @@ static void Float32_To_UInt8(
 
     while( count-- )
     {
-        unsigned char samp = (unsigned char)(128 + ((unsigned char)TruncateFloatToInt32(*src * (127.0f))));
+        unsigned char samp = (unsigned char)(128 + ((unsigned char)(PaInt32)(*src * (127.0f))));
         *dest = samp;
 
         src += sourceStride;
@@ -877,7 +863,7 @@ static void Float32_To_UInt8_Dither(
         float dither = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         float dithered = (*src * (126.0f)) + dither;
-        PaInt32 samp = TruncateFloatToInt32(dithered);
+        PaInt32 samp = (PaInt32)dithered;
         *dest = (unsigned char) (128 + samp);
 
         src += sourceStride;
@@ -902,7 +888,7 @@ static void Float32_To_UInt8_Clip(
 
     while( count-- )
     {
-        PaInt32 samp = 128 + TruncateFloatToInt32(*src * (127.0f));
+        PaInt32 samp = 128 + (PaInt32)(*src * (127.0f));
         PA_CLIP_( samp, 0x00, 0xFF );
         *dest = (unsigned char) samp;
 
@@ -931,7 +917,7 @@ static void Float32_To_UInt8_DitherClip(
         float dither  = PaUtil_GenerateFloatTriangularDither( ditherGenerator );
         /* use smaller scaler to prevent overflow when we add the dither */
         float dithered = (*src * (126.0f)) + dither;
-        PaInt32 samp = 128 + TruncateFloatToInt32(dithered);
+        PaInt32 samp = 128 + (PaInt32)dithered;
         PA_CLIP_( samp, 0x00, 0xFF );
         *dest = (unsigned char) samp;
 

--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -330,7 +330,7 @@ static const double const_1_div_2147483648_ = 1.0 / 2147483648.0; /* 32 bit mult
 
 /* -------------------------------------------------------------------------- */
 
-static int SetRoundingMode()
+static int SetRoundingModeToNearest()
 {
     int prev = fegetround();
 
@@ -357,7 +357,7 @@ static void Float32_To_Int32(
 {
     float *src = (float*)sourceBuffer;
     PaInt32 *dest =  (PaInt32*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -383,7 +383,7 @@ static void Float32_To_Int32_Dither(
 {
     float *src = (float*)sourceBuffer;
     PaInt32 *dest =  (PaInt32*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     while( count-- )
     {
@@ -409,7 +409,7 @@ static void Float32_To_Int32_Clip(
 {
     float *src = (float*)sourceBuffer;
     PaInt32 *dest =  (PaInt32*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -436,7 +436,7 @@ static void Float32_To_Int32_DitherClip(
 {
     float *src = (float*)sourceBuffer;
     PaInt32 *dest = (PaInt32*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     while( count-- )
     {
@@ -463,7 +463,7 @@ static void Float32_To_Int24(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
     PaInt32 temp;
 
     (void)ditherGenerator; /* unused parameter */
@@ -500,7 +500,7 @@ static void Float32_To_Int24_Dither(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
     PaInt32 temp;
 
     while( count-- )
@@ -539,7 +539,7 @@ static void Float32_To_Int24_Clip(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
     PaInt32 temp;
 
     (void)ditherGenerator; /* unused parameter */
@@ -577,7 +577,7 @@ static void Float32_To_Int24_DitherClip(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest = (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
     PaInt32 temp;
 
     while( count-- )
@@ -617,7 +617,7 @@ static void Float32_To_Int16(
 {
     float *src = (float*)sourceBuffer;
     PaInt16 *dest =  (PaInt16*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -642,7 +642,7 @@ static void Float32_To_Int16_Dither(
 {
     float *src = (float*)sourceBuffer;
     PaInt16 *dest = (PaInt16*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     while( count-- )
     {
@@ -669,7 +669,7 @@ static void Float32_To_Int16_Clip(
 {
     float *src = (float*)sourceBuffer;
     PaInt16 *dest =  (PaInt16*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -695,7 +695,7 @@ static void Float32_To_Int16_DitherClip(
 {
     float *src = (float*)sourceBuffer;
     PaInt16 *dest =  (PaInt16*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -725,7 +725,7 @@ static void Float32_To_Int8(
 {
     float *src = (float*)sourceBuffer;
     signed char *dest =  (signed char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -750,7 +750,7 @@ static void Float32_To_Int8_Dither(
 {
     float *src = (float*)sourceBuffer;
     signed char *dest =  (signed char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     while( count-- )
     {
@@ -775,7 +775,7 @@ static void Float32_To_Int8_Clip(
 {
     float *src = (float*)sourceBuffer;
     signed char *dest =  (signed char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -802,7 +802,7 @@ static void Float32_To_Int8_DitherClip(
 {
     float *src = (float*)sourceBuffer;
     signed char *dest =  (signed char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -831,7 +831,7 @@ static void Float32_To_UInt8(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest =  (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -856,7 +856,7 @@ static void Float32_To_UInt8_Dither(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest =  (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     while( count-- )
     {
@@ -882,7 +882,7 @@ static void Float32_To_UInt8_Clip(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest =  (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 
@@ -908,7 +908,7 @@ static void Float32_To_UInt8_DitherClip(
 {
     float *src = (float*)sourceBuffer;
     unsigned char *dest =  (unsigned char*)destinationBuffer;
-    int prevMode = SetRoundingMode();
+    int prevMode = SetRoundingModeToNearest();
 
     (void)ditherGenerator; /* unused parameter */
 


### PR DESCRIPTION
Improve float to int truncation precision by forcing floating-point rounding mode to rounding ~~towards zero or by using CPU SIMD which truncates by rounding towards zero~~ to nearest.

This PR addresses issues discussed in #390 and PR #403 which removed `lrint` in favor of C-style cast of floating point value to integer.

Currently, conversion via C-style cast works as expected, i.e. truncates floating point value to integer with rounding ~~towards zero~~ to nearest, only if CPU is set to rounding ~~towards zero~~ to nearest mode. But, if user code or compilation flags set some other rounding mode the conversion via C-style cast ~~becomes erroneous~~ results in unexpected result.

To circumvent it this PR proposes to set ~~needed~~ required rounding mode via `fesetround` API and reset it back to previous user-set rounding mode when conversion operation completes.

~~Besides `fesetround` API it is also possible to use specialized CPU SIMD which truncates with rounding towards zero, for example it can be x86 SSE and SSE2, ARMv8. By using CPU SIMD it is possible to avoid calling `fesetround` API completely that improves run-time performance.~~

This PR implements ~~these 2 approaches~~:
1. Use `fesetround` to set required rounding mode when no CPU SIMD is present for the truncation of float and double to int for the required rounding mode
2. ~~Use CPU SIMD for truncation of float and double to int and in this case code related `fesetround` is optimized away by the compiler in Release build, so no overhead happens during run-time~~