### PR TITLE
pulseaudio: Move Pulseaudio include in correct place when using autoconf

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -404,10 +404,10 @@ case "${host_os}" in
 
         if [[ "$have_pulse" = "yes" ] || [ "$have_jack" = "yes" ]] ; then
            OTHER_OBJS="$OTHER_OBJS src/common/pa_ringbuffer.o"
-           INCLUDES="$INCLUDES pa_linux_pulseaudio.h"
         fi
 
         if [[ "$have_pulse" = "yes" ] && [ "$with_pulse" != "no" ]] ; then
+           INCLUDES="$INCLUDES pa_linux_pulseaudio.h"
            DLL_LIBS="$DLL_LIBS $PULSE_LIBS"
            CFLAGS="$CFLAGS $PULSE_CFLAGS"
            OTHER_OBJS="$OTHER_OBJS src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.o"


### PR DESCRIPTION
As Jack and Pulseaudio both needs Ringbuffer that include can be done in same place. In configure.in also Pulseaudio header file was included before it was sure that it was really needed.

Commit makes sure that Pulseaudio include is available only if it's needed as it can cause failing in build if Pulseaudio develoment files are not available.