### PR TITLE
Fix 'pulseaudioHostApi' use-after-free in PaPulseAudio_Initialize

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio.c
@@ -758,7 +758,6 @@ PaError PaPulseAudio_Initialize( PaUtilHostApiRepresentation ** hostApi,
         pulseaudioHostApi = NULL;
     }
 
-    PaPulseAudio_UnLock( pulseaudioHostApi->mainloop );
     return result;
 }
 


### PR DESCRIPTION
The call to PaPulseAudio_UnLock( pulseaudioHostApi->mainloop ) in error-label is performed on 'pulseaudioHostApi' after 'pulseaudioHostApi' has been freed by PaPulseAudio_Free