### PR TITLE
pulseaudio: Make use of suggestedLatency stream parameter.

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio.c
@@ -1115,6 +1115,16 @@ PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 
         stream->inputDevice = inputParameters->device;
 
+        /* Convert positive suggestedLatency from seconds to microseconds, otherwise default to zero. */
+        if (inputParameters->suggestedLatency >= 0)
+        {
+            stream->suggestedLatencyUSecs = (unsigned int) (inputParameters->suggestedLatency * 1e6 + 1.0f);
+        }
+        else
+        {
+            stream->suggestedLatencyUSecs = 0;
+        }
+
         /*
          * This is too much as most of the time there is not much
          * stuff in buffer but it's enough if we are doing blocked
@@ -1227,6 +1237,16 @@ PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
         }
 
         stream->outputDevice = outputParameters->device;
+
+        /* Convert positive suggestedLatency from seconds to microseconds, otherwise default to zero. */
+        if (outputParameters->suggestedLatency >= 0)
+        {
+            stream->suggestedLatencyUSecs = (unsigned int) (outputParameters->suggestedLatency * 1e6 + 1.0f);
+        }
+        else
+        {
+            stream->suggestedLatencyUSecs = 0;
+        }
     }
 
     else

--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -633,7 +633,7 @@ PaError PaPulseAudio_StartStreamCb( PaStream * s )
     const char *pulseaudioName = NULL;
     pa_operation *pulseaudioOperation = NULL;
     int waitLoop = 0;
-    unsigned int pulseaudioReqFrameSize = (1024 * 2);
+    unsigned int pulseaudioReqFrameSize = stream->suggestedLatencyUSecs;
 
     stream->isActive = 0;
     stream->isStopped = 1;

--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_internal.h
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_internal.h
@@ -125,6 +125,7 @@ typedef struct PaPulseAudio_Stream
     pa_stream *inputStream;
     pa_buffer_attr outputBufferAttr;
     pa_buffer_attr inputBufferAttr;
+    unsigned int suggestedLatencyUSecs;
     int outputUnderflows;
     int outputChannelCount;
     int inputChannelCount;


### PR DESCRIPTION
This will translate the client provided suggestedLatency in seconds into microseconds and pass them to Pulseaudio, so the client has some control over required latency.

Invalid values < 1 microseconds get mapped to the default minimum latency, currently 10 msecs.

This replaces the previous hard-coded latency of ~2 msecs, which turned out to be too low on some tested mid-range systems and caused audio buffer underruns and audio artifacts.