### PR TITLE
wasapi: Fix wrong sign in timeInfo.inputBufferAdcTime calculation.

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -4986,7 +4986,7 @@ static void WaspiHostProcessingLoop( void *inputBuffer,  long inputFrames,
         else
             pending_time = (PaTime)stream->in.latencySeconds;
 
-        timeInfo.inputBufferAdcTime = timeInfo.currentTime + pending_time;
+        timeInfo.inputBufferAdcTime = timeInfo.currentTime - pending_time;
     }
     // Query output current latency
     if (stream->out.clientProc != NULL)


### PR DESCRIPTION
ADC capture time must be earlier than currentTime, as the capture time of any received samples in a buffer must be in the past.

Fix the wrong sign in calculation to fix this.