### PR TITLE
pulseaudio: fix inadvertent assignment in PaPulseAudio_StartStreamCb

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -853,7 +853,7 @@ PaError PaPulseAudio_StartStreamCb( PaStream * s )
                     pulseaudioState = pa_stream_get_state( stream->outputStream );
                     PaPulseAudio_UnLock( pulseaudioHostApi->mainloop );
 
-                    if( pulseaudioState = PA_STREAM_READY )
+                    if( pulseaudioState == PA_STREAM_READY )
                     {
                         break;
                     }


### PR DESCRIPTION
This bug was introduced by a fairly late commit in #336 (https://github.com/PortAudio/portaudio/pull/336/commits/c454c37f738f1dff0f6a8330daa3131e841a3d36).

I don't know how to induce this failure mode, so the code after the if statement is untested.