### PR TITLE
workflows: Add Pulseaudio to Github workflow build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -82,7 +82,7 @@ jobs:
     - name: "[Ubuntu] install dependencies"
       run: |
         sudo apt-get update
-        sudo apt-get install libasound2-dev ${{ matrix.dependencies_extras }}
+        sudo apt-get install libasound2-dev libpulse-dev ${{ matrix.dependencies_extras }}
       if: matrix.os == 'ubuntu-latest'
     - name: "[macOS] install dependencies"
       # https://github.com/PortAudio/portaudio/issues/767


### PR DESCRIPTION
As Pulseaudio is not currently build on Github workflow build. PR Adds it at least for CMake build