### PR TITLE
cmake: Silence configuration warning when MSVC is selected as generator.

### DIFF
--- a/cmake/modules/FindJACK.cmake
+++ b/cmake/modules/FindJACK.cmake
@@ -40,8 +40,10 @@ list(APPEND JACK_LINK_LIBRARIES Regex::regex)
 
 if(NOT CMAKE_USE_PTHREADS_INIT)
     # This CMake find module is provided by the pthreads port in vcpkg.
-    find_package(pthreads)
-    list(APPEND JACK_LINK_LIBRARIES PThreads4W::PThreads4W)
+    find_package(pthreads QUIET)
+    if(pthreads_FOUND)
+        list(APPEND JACK_LINK_LIBRARIES PThreads4W::PThreads4W)
+    endif()
 endif()
 
 if(CMAKE_USE_PTHREADS_INIT OR TARGET PThreads4W::PThreads4W)


### PR DESCRIPTION
Silences CMake warning when MSVC is selected as generator:

```
CMake Warning at cmake/modules/FindJACK.cmake:43 (find_package):
  By not providing "Findpthreads.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "pthreads",
  but CMake did not find one.

  Could not find a package configuration file provided by "pthreads" with any
  of the following names:

    pthreadsConfig.cmake
    pthreads-config.cmake

  Add the installation prefix of "pthreads" to CMAKE_PREFIX_PATH or set
  "pthreads_DIR" to a directory containing one of the above files.  If
  "pthreads" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:138 (find_package)
``` 