### PR TITLE
centralize clock handling for pthread_cond_timedwait

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,13 @@ find_package(JACK)
 cmake_dependent_option(PA_USE_JACK "Enable support for JACK Audio Connection Kit" ON JACK_FOUND OFF)
 if(PA_USE_JACK)
   target_link_libraries(PortAudio PRIVATE JACK::jack)
-  target_sources(PortAudio PRIVATE src/hostapi/jack/pa_jack.c)
+  target_sources(PortAudio PRIVATE
+    src/hostapi/jack/pa_jack.c
+    src/os/unix/pa_pthread_util.c
+    src/os/unix/pa_pthread_util.h
+  )
   set(PORTAUDIO_PUBLIC_HEADERS "${PORTAUDIO_PUBLIC_HEADERS}" include/pa_jack.h)
+  target_include_directories(PortAudio PRIVATE src/os/unix) # for pa_pthread_util.h
   target_compile_definitions(PortAudio PUBLIC PA_USE_JACK=1)
   set(PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS} -DPA_USE_JACK=1")
   set(PKGCONFIG_REQUIRES_PRIVATE "${PKGCONFIG_REQUIRES_PRIVATE} jack")
@@ -288,6 +293,8 @@ elseif(UNIX)
     src/os/unix/pa_unix_hostapis.c
     src/os/unix/pa_unix_util.c
     src/os/unix/pa_unix_util.h
+    src/os/unix/pa_pthread_util.c
+    src/os/unix/pa_pthread_util.h
   )
   target_include_directories(PortAudio PRIVATE src/os/unix)
   target_link_libraries(PortAudio PRIVATE m)

--- a/configure
+++ b/configure
@@ -15936,7 +15936,7 @@ else
 fi
 
         CFLAGS="$CFLAGS $mac_arches $mac_sysroot $mac_version_min"
-        OTHER_OBJS="src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o src/hostapi/coreaudio/pa_mac_core.o src/hostapi/coreaudio/pa_mac_core_utilities.o src/hostapi/coreaudio/pa_mac_core_blocking.o src/common/pa_ringbuffer.o"
+        OTHER_OBJS="src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o src/os/unix/pa_pthread_util.o src/hostapi/coreaudio/pa_mac_core.o src/hostapi/coreaudio/pa_mac_core_utilities.o src/hostapi/coreaudio/pa_mac_core_blocking.o src/common/pa_ringbuffer.o"
         PADLL="libportaudio.dylib"
         ;;
 
@@ -16272,7 +16272,7 @@ fi
               ;;
         esac
 
-        OTHER_OBJS="$OTHER_OBJS src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o"
+        OTHER_OBJS="$OTHER_OBJS src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o src/os/unix/pa_pthread_util.o"
 esac
 CFLAGS="$CFLAGS $THREAD_CFLAGS"
 

--- a/configure.in
+++ b/configure.in
@@ -265,7 +265,7 @@ case "${host_os}" in
         SHARED_FLAGS="$LIBS -dynamiclib $mac_arches $mac_sysroot $mac_version_min"
         AX_CHECK_COMPILE_FLAG([-std=c11], [CFLAGS="-std=c11 $CFLAGS"], [CFLAGS="-std=c99 $CFLAGS"])
         CFLAGS="$CFLAGS $mac_arches $mac_sysroot $mac_version_min"
-        OTHER_OBJS="src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o src/hostapi/coreaudio/pa_mac_core.o src/hostapi/coreaudio/pa_mac_core_utilities.o src/hostapi/coreaudio/pa_mac_core_blocking.o src/common/pa_ringbuffer.o"
+        OTHER_OBJS="src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o src/os/unix/pa_pthread_util.o src/hostapi/coreaudio/pa_mac_core.o src/hostapi/coreaudio/pa_mac_core_utilities.o src/hostapi/coreaudio/pa_mac_core_blocking.o src/common/pa_ringbuffer.o"
         PADLL="libportaudio.dylib"
         ;;
 
@@ -449,7 +449,7 @@ case "${host_os}" in
               ;;
         esac
 
-        OTHER_OBJS="$OTHER_OBJS src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o"
+        OTHER_OBJS="$OTHER_OBJS src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o src/os/unix/pa_pthread_util.o"
 esac
 CFLAGS="$CFLAGS $THREAD_CFLAGS"
 

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -1057,11 +1057,18 @@ static PaError WaitCondition( PaJackHostApiRepresentation *hostApi )
     int err = 0;
     struct timespec ts;
 
-    PaPthreadUtil_GetTime( hostApi->condClockId, &ts );
-    ts.tv_sec += 10 * 60; /* 10 minutes */
+    if( PaPthreadUtil_GetTime( hostApi->condClockId, &ts ) == 0 )
+    {
+        ts.tv_sec += 10 * 60; /* 10 minutes */
 
-    /* XXX: Best enclose in loop, in case of spurious wakeups? */
-    err = pthread_cond_timedwait( &hostApi->cond, &hostApi->mtx, &ts );
+        /* XXX: Best enclose in loop, in case of spurious wakeups? */
+        err = pthread_cond_timedwait( &hostApi->cond, &hostApi->mtx, &ts );
+    }
+    else
+    {
+        /* XXX: Best enclose in loop, in case of spurious wakeups? */
+        err = pthread_cond_wait( &hostApi->cond, &hostApi->mtx );
+    }
 
     /* Make sure we didn't time out */
     UNLESS( err != ETIMEDOUT, paTimedOut );

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -63,6 +63,7 @@
 #include <jack/jack.h>
 
 #include "pa_util.h"
+#include "pa_pthread_util.h"
 #include "pa_hostapi.h"
 #include "pa_stream.h"
 #include "pa_process.h"
@@ -168,6 +169,7 @@ typedef struct
 
     pthread_mutex_t mtx;
     pthread_cond_t cond;
+    PaUtilClockId condClockId;
     unsigned long inputBase, outputBase;
 
     /* For dealing with the process thread */
@@ -758,6 +760,7 @@ PaError PaJack_Initialize( PaUtilHostApiRepresentation **hostApi,
     int activated = 0;
     jack_status_t jackStatus = 0;
     *hostApi = NULL;    /* Initialize to NULL */
+    pthread_condattr_t cattr;
 
     UNLESS( jackHostApi = (PaJackHostApiRepresentation*)
         PaUtil_AllocateZeroInitializedMemory( sizeof(PaJackHostApiRepresentation) ), paInsufficientMemory );
@@ -765,7 +768,10 @@ PaError PaJack_Initialize( PaUtilHostApiRepresentation **hostApi,
 
     mainThread_ = pthread_self();
     ASSERT_CALL( pthread_mutex_init( &jackHostApi->mtx, NULL ), 0 );
-    ASSERT_CALL( pthread_cond_init( &jackHostApi->cond, NULL ), 0 );
+
+    ASSERT_CALL( pthread_condattr_init( &cattr ), 0 );
+    jackHostApi->condClockId = PaPthreadUtil_NegotiateCondAttrClock( &cattr );
+    ASSERT_CALL( pthread_cond_init( &jackHostApi->cond, &cattr), 0 );
 
     /* Try to become a client of the JACK server.  If we cannot do
      * this, then this API cannot be used.
@@ -1049,11 +1055,11 @@ static PaError WaitCondition( PaJackHostApiRepresentation *hostApi )
 {
     PaError result = paNoError;
     int err = 0;
-    PaTime pt = PaUtil_GetTime();
     struct timespec ts;
 
-    ts.tv_sec = (time_t) floor( pt + 10 * 60 /* 10 minutes */ );
-    ts.tv_nsec = (long) ((pt - floor( pt )) * 1000000000);
+    PaPthreadUtil_GetTime( hostApi->condClockId, &ts );
+    ts.tv_sec += 10 * 60; /* 10 minutes */
+
     /* XXX: Best enclose in loop, in case of spurious wakeups? */
     err = pthread_cond_timedwait( &hostApi->cond, &hostApi->mtx, &ts );
 

--- a/src/os/unix/pa_pthread_util.c
+++ b/src/os/unix/pa_pthread_util.c
@@ -114,7 +114,7 @@ int PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts )
     t1970 = t1601 - SYSTEM_TIME_TO_UNIX_TIME_OFFSET;
 
     ts->tv_sec = (time_t) (t1970 / (UINT64)10000000UL);
-    ts->tv_nsec = (long long) ((t1970 - ((UINT64)ts->tv_sec * (UINT64)10000000UL)) * (UINT64)100UL);
+    ts->tv_nsec = (long) ((t1970 - ((UINT64)ts->tv_sec * (UINT64)10000000UL)) * (UINT64)100UL);
     return 0; /* success */
 #else
     /* fall back to gettimeofday for Apple and when clock_gettime is unavailable */

--- a/src/os/unix/pa_pthread_util.c
+++ b/src/os/unix/pa_pthread_util.c
@@ -110,6 +110,7 @@ int PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts )
 
     GetSystemTimeAsFileTime( &ft );
     t1601 = ((UINT64)ft.dwHighDateTime << 32) + (UINT64)ft.dwLowDateTime;
+/* The following constant is 134774 days in 100ns ticks. i.e. 134774*24*3600*10000000 */
 #define SYSTEM_TIME_TO_UNIX_TIME_OFFSET (((UINT64)27111902UL << 32) + (UINT64)3577643008UL)
     t1970 = t1601 - SYSTEM_TIME_TO_UNIX_TIME_OFFSET;
 

--- a/src/os/unix/pa_pthread_util.c
+++ b/src/os/unix/pa_pthread_util.c
@@ -1,0 +1,116 @@
+/*
+ * $Id$
+ * PortAudio Portable Real-Time Audio Library
+ * Latest Version at: http://www.portaudio.com
+ *
+ * Based on the Open Source API proposed by Ross Bencina
+ * Copyright (c) 1999-2024 Ross Bencina, Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+#if !PAUTIL_USE_POSIX_ADVANCED_REALTIME && (defined(WIN32) || defined(_WIN32))
+#include <windows.h>
+#endif
+
+#include "pa_pthread_util.h"
+#include "pa_debugprint.h"
+
+PaUtilClockId PaPthreadUtil_NegotiateCondAttrClock( pthread_condattr_t *cattr )
+{
+#if PAUTIL_USE_POSIX_ADVANCED_REALTIME
+    /* Set most suitable timeout clock and return its id.
+       If a clock can't be set, return the default clock.
+    */
+    clockid_t clockId;
+
+/* try each potential clockid in order of preferences until one succeeds:*/
+#if defined(CLOCK_BOOTTIME )
+    if( pthread_condattr_setclock( cattr, CLOCK_BOOTTIME ) == 0 )
+        return CLOCK_BOOTTIME;
+#endif
+
+#if defined(CLOCK_MONOTONIC)
+    if( pthread_condattr_setclock( cattr, CLOCK_MONOTONIC ) == 0 )
+        return CLOCK_MONOTONIC;
+#endif
+
+#if defined(CLOCK_REALTIME)
+    if( pthread_condattr_setclock( cattr, CLOCK_REALTIME ) == 0 )
+        return CLOCK_REALTIME;
+#endif
+
+    /* fallback to returning the current clock id*/
+    if ( pthread_condattr_getclock( cattr, &clockId) == 0 )
+        return clockId;
+
+    /* fallback to returning the default expected clock id*/
+    PA_DEBUG(( "%s: could not configure condattr clock\n", __FUNCTION__));
+    return CLOCK_REALTIME;
+#else /* not PAUTIL_USE_POSIX_ADVANCED_REALTIME */
+    return 0; /* dummy value */
+#endif
+}
+
+void PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts )
+{
+#if PAUTIL_USE_POSIX_ADVANCED_REALTIME
+    clock_gettime(clockId, ts);
+#else /* not PAUTIL_USE_POSIX_ADVANCED_REALTIME */
+
+#if defined(WIN32) || defined(_WIN32)
+    /* On Windows, assume pthreads4w, which uses Unix time derived from SystemTime as timeout reference.
+       The conversion is based on this code: https://stackoverflow.com/a/26085827
+       With reference to the pthreads4w code: https://sourceforge.net/p/pthreads4w/code/ci/master/tree/ptw32_timespec.c
+    */
+    SYSTEMTIME st;
+    FILETIME ft;
+    __int64 t1601;
+
+    GetSystemTime( &st );
+    SystemTimeToFileTime( &st, &ft );
+    t1601 = ((__int64)ft.dwLowDateTime );
+    t1601 += ((__int64)ft.dwHighDateTime) << 32;
+
+#define WIN32SYSTEM_TIME_TO_UNIX_TIME_OFFSET ( ((__int64)27111902UL << 32) + (__int64)3577643008UL )
+    ts->tv_sec  = (time_t) ((t1601 - WIN32SYSTEM_TIME_TO_UNIX_TIME_OFFSET) / 10000000L);
+    ts->tv_nsec = (long long) (st.wMilliseconds * 1000000);
+
+#else
+    /* fallback to gettimeofday for Apple and when clock_gettime is unavailable */
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    ts->tv_sec  = tv.tv_sec;
+    ts->tv_nsec = tv.tv_usec * 1000;
+#endif
+
+#endif
+}

--- a/src/os/unix/pa_pthread_util.c
+++ b/src/os/unix/pa_pthread_util.c
@@ -49,12 +49,12 @@
 PaUtilClockId PaPthreadUtil_NegotiateCondAttrClock( pthread_condattr_t *cattr )
 {
 #if PAUTIL_USE_POSIX_ADVANCED_REALTIME
-    /* Set most suitable timeout clock and return its id.
-       If a clock can't be set, return the default clock.
+    /* Set most suitable timeout clock on the condattr and return its clock id.
+       If a clock can't be set, return the default clock id.
     */
     clockid_t clockId;
 
-/* try each potential clockid in order of preferences until one succeeds:*/
+/* try each potential clockid in order of preference until one succeeds: */
 #if defined(CLOCK_BOOTTIME )
     if( pthread_condattr_setclock( cattr, CLOCK_BOOTTIME ) == 0 )
         return CLOCK_BOOTTIME;
@@ -70,11 +70,11 @@ PaUtilClockId PaPthreadUtil_NegotiateCondAttrClock( pthread_condattr_t *cattr )
         return CLOCK_REALTIME;
 #endif
 
-    /* fallback to returning the current clock id*/
+    /* fall back to returning the current clock id */
     if ( pthread_condattr_getclock( cattr, &clockId) == 0 )
         return clockId;
 
-    /* fallback to returning the default expected clock id*/
+    /* fall back to returning the default expected clock id */
     PA_DEBUG(( "%s: could not configure condattr clock\n", __FUNCTION__));
     return CLOCK_REALTIME;
 #else /* not PAUTIL_USE_POSIX_ADVANCED_REALTIME */
@@ -111,10 +111,10 @@ void PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts )
 #define SYSTEM_TIME_TO_UNIX_TIME_OFFSET (((UINT64)27111902UL << 32) + (UINT64)3577643008UL)
     t1970 = t1601 - SYSTEM_TIME_TO_UNIX_TIME_OFFSET;
 
-    ts->tv_sec  = (time_t) (t1970 / (UINT64)10000000UL);
+    ts->tv_sec = (time_t) (t1970 / (UINT64)10000000UL);
     ts->tv_nsec = (long long) ((t1970 - ((UINT64)ts->tv_sec * (UINT64)10000000UL)) * (UINT64)100UL);
 #else
-    /* fallback to gettimeofday for Apple and when clock_gettime is unavailable */
+    /* fall back to gettimeofday for Apple and when clock_gettime is unavailable */
     struct timeval tv;
     if ( gettimeofday(&tv, NULL) == 0 )
     {

--- a/src/os/unix/pa_pthread_util.c
+++ b/src/os/unix/pa_pthread_util.c
@@ -87,9 +87,12 @@ void PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts )
 #else /* not PAUTIL_USE_POSIX_ADVANCED_REALTIME */
 
 #if defined(WIN32) || defined(_WIN32)
-    /* On Windows, assume pthreads4w, which uses Unix time derived from SystemTime as timeout reference.
-       The conversion is based on this code: https://stackoverflow.com/a/26085827
-       With reference to the pthreads4w code: https://sourceforge.net/p/pthreads4w/code/ci/master/tree/ptw32_timespec.c
+    /* On Windows, the most likely pthreads implementations are pthreads4w,
+       and winpthread via mingw-w64. Both use Unix time derived from Win32 SystemTime as the time base:
+         https://sourceforge.net/p/pthreads4w/code/ci/master/tree/ptw32_timespec.c
+         https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-libraries/winpthreads/src/misc.c
+       The conversion from SystemTime to Unix time is based on this code: https://stackoverflow.com/a/26085827
+       with reference to the pthreads4w code linked above.
     */
     SYSTEMTIME st;
     FILETIME ft;

--- a/src/os/unix/pa_pthread_util.h
+++ b/src/os/unix/pa_pthread_util.h
@@ -93,8 +93,10 @@ PaUtilClockId PaPthreadUtil_NegotiateCondAttrClock( pthread_condattr_t *cattr );
 
 /** Get the current time according to the clock referred to by clockId, as
  * previously returned by PaPthreadUtil_NegotiateCondAttrTimeoutClock().
+ *
+ * Returns 0 upon success, -1 otherwise.
 */
-void PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts );
+int PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts );
 
 #ifdef __cplusplus
 }

--- a/src/os/unix/pa_pthread_util.h
+++ b/src/os/unix/pa_pthread_util.h
@@ -1,0 +1,102 @@
+/*
+ * $Id$
+ * PortAudio Portable Real-Time Audio Library
+ * Latest Version at: http://www.portaudio.com
+ *
+ * Based on the Open Source API proposed by Ross Bencina
+ * Copyright (c) 1999-2024 Ross Bencina, Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/** @file
+ @ingroup unix_src
+*/
+
+#ifndef PA_PTHREAD_UTIL_H
+#define PA_PTHREAD_UTIL_H
+
+#include <time.h> /* timespec, clock_gettime */
+#include <sys/types.h> /* clockid_t */
+#if !(defined(WIN32) || defined(_WIN32))
+#include <sys/time.h> /* gettimeofday on macos */
+#endif
+#include <pthread.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+/*
+  Use the presence of CLOCK_REALTIME as a proxy for the availability of
+  pthread_condattr_setclock, pthread_condattr_getclock and clock_gettime.
+
+  Otherewise use a fallback path.
+
+  On Apple, stick with default unix time using gettimeofday,
+  since CLOCK_MONOTONIC is known to be buggy:
+    https://discussions.apple.com/thread/253778121?sortBy=best
+
+  And clock_gettime is not available pre-Sierra:
+    https://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x
+    https://stackoverflow.com/a/21352348
+*/
+#if defined(CLOCK_REALTIME) && !defined(__APPLE__)
+#define PAUTIL_USE_POSIX_ADVANCED_REALTIME  1
+#else
+#define PAUTIL_USE_POSIX_ADVANCED_REALTIME  0
+#endif
+
+#if PAUTIL_USE_POSIX_ADVANCED_REALTIME
+
+#define PaUtilClockId clockid_t
+
+#else
+
+#define PaUtilClockId int /* dummy type */
+
+#endif
+
+/** Negotiate the most suitable clock for condvar timeouts, set the clock
+ * on cattr and return the clock's id.
+ */
+PaUtilClockId PaPthreadUtil_NegotiateCondAttrClock( pthread_condattr_t *cattr );
+
+/** Get the current time according to the clock referred to by clockId, as
+ * previously returned by PaPthreadUtil_NegotiateCondAttrTimeoutClock().
+*/
+void PaPthreadUtil_GetTime( PaUtilClockId clockId, struct timespec *ts );
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif

--- a/src/os/unix/pa_unix_util.c
+++ b/src/os/unix/pa_unix_util.c
@@ -367,6 +367,9 @@ PaError PaUnixThread_New( PaUnixThread* self, void* (*threadFunc)( void* ), void
         struct timespec ts;
         int waitForDeadline = 0;
         int res = 0;
+#ifdef PA_ENABLE_DEBUG_OUTPUT
+        double startTime = PaUtil_GetTime();
+#endif
 
         PA_ENSURE( PaUnixMutex_Lock( &self->mtx ) );
 
@@ -393,8 +396,8 @@ PaError PaUnixThread_New( PaUnixThread* self, void* (*threadFunc)( void* ), void
 
         PA_ENSURE( PaUnixMutex_Unlock( &self->mtx ) );
 
-        PA_UNLESS( !res || ETIMEDOUT == res, paInternalError ); /* FIXME: add separate check for timeout and return paTimedOut */
-        PA_DEBUG(( "%s: Waited for %g seconds for stream to start\n", __FUNCTION__, PaUtil_GetTime() - now ));
+        PA_UNLESS( !res || ETIMEDOUT == res, paInternalError );
+        PA_DEBUG(( "%s: Waited for %g seconds for stream to start\n", __FUNCTION__, PaUtil_GetTime() - startTime ));
         if( ETIMEDOUT == res )
         {
             PA_ENSURE( paTimedOut );

--- a/src/os/unix/pa_unix_util.c
+++ b/src/os/unix/pa_unix_util.c
@@ -372,7 +372,7 @@ PaError PaUnixThread_New( PaUnixThread* self, void* (*threadFunc)( void* ), void
 
         /* Wait for stream to be started */
         PaPthreadUtil_GetTime( self->condClockId, &ts );
-        now = ts.tv_sec + ts.tv_nsec * 1e9;
+        now = ts.tv_sec + ts.tv_nsec * 1e-9;
         deadline = now + waitForChild;
 
         while( self->parentWaiting && !res )

--- a/src/os/unix/pa_unix_util.h
+++ b/src/os/unix/pa_unix_util.h
@@ -45,6 +45,7 @@
 #define PA_UNIX_UTIL_H
 
 #include "pa_util.h"
+#include "pa_pthread_util.h"
 #include "pa_cpuload.h"
 #include <assert.h>
 #include <pthread.h>
@@ -150,6 +151,7 @@ typedef struct
     int locked;
     PaUnixMutex mtx;
     pthread_cond_t cond;
+    PaUtilClockId condClockId;
     volatile sig_atomic_t stopRequest;
 } PaUnixThread;
 


### PR DESCRIPTION
- Ensure that the clock that is configured on the cond object is the one that is used to compute the wait deadline
- Ensure that the most appropriate clock is selected on each platform based on availability `CLOCK_BOOTTIME` > `CLOCK_MONOTONIC` > `CLOCK_REALTIME` (on Mac use gettimeofday because other clock interfaces are either not available or broken).

Used directly or indirectly by pa_jack, pa_alsa, pa_asihpi

Resolves #795, #807.