### PR TITLE
pa_whitelint.py: escape backslashes in regex strings (fixes warning in CI)

### DIFF
--- a/pa_whitelint.py
+++ b/pa_whitelint.py
@@ -189,7 +189,7 @@ for dir in dirs:
 
             # 3. Correct leading whitespace / bad indenting
             if checkBadIndenting:
-                leadingWhitespaceRe = re.compile(b"^\s*")
+                leadingWhitespaceRe = re.compile(b"^\\s*")
                 commentIsOpen = False
                 previousLine = b""
                 previousIndent = 0
@@ -218,7 +218,7 @@ for dir in dirs:
                     lineNo += 1
 
             # 4. No trailing whitespace
-            trailingWhitespaceRe = re.compile(b"\s*$")
+            trailingWhitespaceRe = re.compile(b"\\s*$")
             lineNo = 1
             for line in lines:
                 m = trailingWhitespaceRe.search(line)


### PR DESCRIPTION
Fixes the following warnings when running the whitespace checker CI script:

```
/home/runner/work/portaudio/portaudio/./pa_whitelint.py:192: SyntaxWarning: invalid escape sequence '\s'
  leadingWhitespaceRe = re.compile(b"^\s*")
/home/runner/work/portaudio/portaudio/./pa_whitelint.py:221: SyntaxWarning: invalid escape sequence '\s'
  trailingWhitespaceRe = re.compile(b"\s*$")
```