### PR TITLE
Fix bug: Permit AsioStreamInfo without channel selectors

### DIFF
--- a/src/hostapi/asio/pa_asio.cpp
+++ b/src/hostapi/asio/pa_asio.cpp
@@ -1878,15 +1878,17 @@ static PaError ValidateAsioSpecificStreamInfo(
         }
 
         if( streamInfo->flags & paAsioUseChannelSelectors )
+        {
             *channelSelectors = streamInfo->channelSelectors;
 
-        if( !(*channelSelectors) )
-            return paIncompatibleHostApiSpecificStreamInfo;
+            if( !(*channelSelectors) )
+                return paIncompatibleHostApiSpecificStreamInfo;
 
-        for( int i=0; i < streamParameters->channelCount; ++i ){
-            if( (*channelSelectors)[i] < 0
+            for( int i=0; i < streamParameters->channelCount; ++i ){
+                if( (*channelSelectors)[i] < 0
                     || (*channelSelectors)[i] >= deviceChannelCount ){
-                return paInvalidChannelCount;
+                    return paInvalidChannelCount;
+                }
             }
         }
     }


### PR DESCRIPTION
Validation for PaAsioStreamInfo currently fails if the channelSelectors field is null.  As of March 1, 2024 channelSelectors is the only feature enabled by this structure but PR #519 will add another.

This PR amends the check so channelSelectors is only validated if the paAsioUseChannelSelectors flag is set in PaAsioStreamInfo.