### PR TITLE
JACK: do not subtract buffer size from port latency

### DIFF
--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -1365,11 +1365,9 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
 
     if( stream->num_incoming_connections > 0 )
         stream->streamRepresentation.streamInfo.inputLatency = (jack_port_get_latency( stream->remote_output_ports[0] )
-                - jack_get_buffer_size( jackHostApi->jack_client )  /* One buffer is not counted as latency */
             + PaUtil_GetBufferProcessorInputLatencyFrames( &stream->bufferProcessor )) / sampleRate;
     if( stream->num_outgoing_connections > 0 )
         stream->streamRepresentation.streamInfo.outputLatency = (jack_port_get_latency( stream->remote_input_ports[0] )
-                - jack_get_buffer_size( jackHostApi->jack_client )  /* One buffer is not counted as latency */
             + PaUtil_GetBufferProcessorOutputLatencyFrames( &stream->bufferProcessor )) / sampleRate;
 
     stream->streamRepresentation.streamInfo.sampleRate = jackSr;


### PR DESCRIPTION
The latency calculation subtracts the size of one buffer from JACK's port latency value. I suspect this adjustment was made so that jackd's "asynchronous mode" appears to have the user's requested latency value even though jackd adds one extra buffer, thus increasing the real latency.

When jackd runs in "synchronous mode" or the more recent pipewire-jack implementation is used, PortAudio reports incorrect latency values of 0 seconds because the latency is exactly one buffer.

Fix the calculation to produce the real latency.