### PR TITLE
file() was removed in Python 3 in favor of open()

### DIFF
--- a/doc/utils/checkfiledocs.py
+++ b/doc/utils/checkfiledocs.py
@@ -72,7 +72,7 @@ for f in sourceFiles:
     if not doxygenHtmlDocFileName( os.path.basename(f) ) in docFiles:
         printError( f, "no doxygen generated doc page" )
 
-    s = file( f, 'rt' ).read()
+    s = open( f, 'rt' ).read()
 
     if not '/**' in s:
         printError( f, "no doxygen /** block" )  


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/builtins.html#removed-file

https://docs.python.org/3/whatsnew/3.0.html#builtins
> Removed the `file` type. Use [`open()`](https://docs.python.org/3/library/functions.html#open). There are now several different kinds of streams that open can return in the [`io`](https://docs.python.org/3/library/io.html#module-io) module.