### PR TITLE
Fix WDM-KS buffer position alignment

### DIFF
--- a/src/hostapi/wdmks/pa_win_wdmks.c
+++ b/src/hostapi/wdmks/pa_win_wdmks.c
@@ -6651,7 +6651,7 @@ static PaError PaPinCaptureEventHandler_WaveRTPolled(PaProcessThreadInfo* pInfo,
     pos += pin->hwLatency;
     pos %= pCapture->hostBufferSize;
     /* Need to align position on frame boundary */
-    pos &= ~(pCapture->bytesPerFrame - 1);
+    pos = (pos / pCapture->bytesPerFrame) * pCapture->bytesPerFrame;
 
     /* Call barrier (or dummy) */
     pin->fnMemBarrier();
@@ -6703,7 +6703,7 @@ static PaError PaPinRenderEventHandler_WaveRTEvent(PaProcessThreadInfo* pInfo, u
     /* Wrap it */
     pos %= pRender->hostBufferSize;
     /* And align it, not sure its really needed though */
-    pos &= ~(pRender->bytesPerFrame - 1);
+    pos = (pos / pRender->bytesPerFrame) * pRender->bytesPerFrame;
     /* Then realOutBuf will point to "other" half of double buffer */
     realOutBuf = pos < halfOutputBuffer ? 1U : 0U;
 
@@ -6740,7 +6740,7 @@ static PaError PaPinRenderEventHandler_WaveRTPolled(PaProcessThreadInfo* pInfo, 
     /* Wrap it */
     pos %= pRender->hostBufferSize;
     /* And align it, not sure its really needed though */
-    pos &= ~(pRender->bytesPerFrame - 1);
+    pos = (pos / pRender->bytesPerFrame) * pRender->bytesPerFrame;
 
     if (pInfo->priming)
     {


### PR DESCRIPTION
The previous code is only correct if `bytesPerFrame` is a power of two. If it's not (e.g. 2-channel 24-bit = 6 bytes per frame), then the computed buffer position is corrupted. This can lead the code to use the wrong buffer half, resulting in glitchy audio.

Fixes #763