### PR TITLE
JACK: support connecting to no device (only creating ports)

### DIFF
--- a/include/pa_jack.h
+++ b/include/pa_jack.h
@@ -50,6 +50,19 @@
 extern "C" {
 #endif
 
+typedef struct PaJackStreamInfo
+{
+    unsigned long size;
+    PaHostApiTypeId hostApiType;
+    unsigned long version;
+
+    PaDeviceIndex device;
+}
+PaJackStreamInfo;
+
+/** Initialize host API specific structure, to ask for no device connection. */
+void PaJack_InitializeNoDeviceStreamInfo( PaJackStreamInfo *info );
+
 /** Set the JACK client name.
  *
  * During Pa_Initialize, When PA JACK connects as a client of the JACK server, it requests a certain


### PR DESCRIPTION
Previously, using the JACK backend meant that for each port:
 - We call `jack_port_register()` to create the port,
 - And call `jack_connect()` to create a connection between the newly created port and a target (the `PaStreamParameters.device` argument).

In the JACK world, it is common for processes to spawn a node with ports and let somebody else do the routing. We therefore allow creating a stream that targets as input and/or output `paNoDevice`.

See the commit message for additional details.

I do have questions regarding this:

 - Would you be willing to take such a patch?
 - What should the public-facing API look like? I'm not familiar with PortAudio's API so there might be something better to do.