### PR TITLE
wasapi: Workaround for the Realtek driver "Mono" bug

### DIFF
--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -2992,7 +2992,7 @@ static PaError GetClosestFormat(IAudioClient *client, const PaDeviceInfo *baseDe
             // Limit this workaround to Realtek devices only
             if (strstr(baseDeviceInfo->name, "Realtek") != NULL)
             {
-                // Force internal Mono to Stereo mixer
+                // Force our Mono to Stereo mixer mechanism
                 outWavex->Format.nChannels = 2;
                 UpdateWaveFormatBlockAlign((WAVEFORMATEX *)outWavex);
             }


### PR DESCRIPTION
Workaround for the Realtek driver bug when driver mistakenly accepts Mono format with `IAudioClient_IsFormatSupported()` while subsequently fails in `IAudioClient_Initialize()`.

It is a long-lasting issue #875 which was resolved with a kind debugging help by @arkadijs.

Closes #875.