### PR TITLE
change MME-specific DLL ordinals to start at 100 in .def files.

### DIFF
--- a/cmake/portaudio.def.in
+++ b/cmake/portaudio.def.in
@@ -61,7 +61,7 @@ PaUtil_SetDebugPrintFunction        @55
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_PopulateDeviceList    @69
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetIMMDevice               @70
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_IsLoopback                 @71
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandleCount    @72
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandle         @73
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandleCount   @74
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandle        @75
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandleCount    @100
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandle         @101
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandleCount   @102
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandle        @103

--- a/msvc/portaudio.def
+++ b/msvc/portaudio.def
@@ -58,7 +58,7 @@ PaWasapiWinrt_SetDefaultDeviceId    @67
 PaWasapiWinrt_PopulateDeviceList    @69
 PaWasapi_GetIMMDevice               @70
 PaWasapi_IsLoopback                 @71
-PaWinMME_GetStreamInputHandleCount  @72
-PaWinMME_GetStreamInputHandle       @73
-PaWinMME_GetStreamOutputHandleCount @74
-PaWinMME_GetStreamOutputHandle      @75
+PaWinMME_GetStreamInputHandleCount  @100
+PaWinMME_GetStreamInputHandle       @101
+PaWinMME_GetStreamOutputHandleCount @102
+PaWinMME_GetStreamOutputHandle      @103


### PR DESCRIPTION
resolves #784