### PR TITLE
undo .def file ordinal change made in 605fc89. …

### DIFF
--- a/cmake/portaudio.def.in
+++ b/cmake/portaudio.def.in
@@ -39,6 +39,7 @@ Pa_GetStreamWriteAvailable          @32
 Pa_GetSampleSize                    @33
 Pa_Sleep                            @34
 Pa_GetVersionInfo                   @35
+; add new portable public API functions here. DO NOT CHANGE EXISTING ORDINALS!
 @DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_GetAvailableBufferSizes      @50
 @DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_ShowControlPanel             @51
 @DEF_EXCLUDE_X86_PLAIN_CONVERTERS@PaUtil_InitializeX86PlainConverters @52
@@ -60,8 +61,9 @@ PaUtil_SetDebugPrintFunction        @55
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_SetDefaultDeviceId    @67
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_PopulateDeviceList    @69
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetIMMDevice               @70
-@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_IsLoopback                 @71
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandleCount    @72
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandle         @73
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandleCount   @74
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandle        @75
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandleCount    @71
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandle         @72
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandleCount   @73
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandle        @74
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_IsLoopback                 @75
+; add new host-API-specific public functions here. DO NOT CHANGE EXISTING ORDINALS!

--- a/msvc/portaudio.def
+++ b/msvc/portaudio.def
@@ -36,6 +36,7 @@ Pa_GetStreamWriteAvailable          @32
 Pa_GetSampleSize                    @33
 Pa_Sleep                            @34
 Pa_GetVersionInfo                   @35
+; add new portable public API functions here. DO NOT CHANGE EXISTING ORDINALS!
 PaAsio_GetAvailableBufferSizes      @50
 PaAsio_ShowControlPanel             @51
 PaUtil_InitializeX86PlainConverters @52
@@ -57,8 +58,9 @@ PaWasapi_SetStreamStateHandler      @68
 PaWasapiWinrt_SetDefaultDeviceId    @67
 PaWasapiWinrt_PopulateDeviceList    @69
 PaWasapi_GetIMMDevice               @70
-PaWasapi_IsLoopback                 @71
-PaWinMME_GetStreamInputHandleCount  @72
-PaWinMME_GetStreamInputHandle       @73
-PaWinMME_GetStreamOutputHandleCount @74
-PaWinMME_GetStreamOutputHandle      @75
+PaWinMME_GetStreamInputHandleCount  @71
+PaWinMME_GetStreamInputHandle       @72
+PaWinMME_GetStreamOutputHandleCount @73
+PaWinMME_GetStreamOutputHandle      @74
+PaWasapi_IsLoopback                 @75
+; add new host-API-specific public functions here. DO NOT CHANGE EXISTING ORDINALS!


### PR DESCRIPTION
add comments about append-only policy for ordinal changes. resolves #784

here's the change that it undoes: 605fc89

Phil and I have decided that we prefer this to #941