### PR TITLE
add FIXME and TODO comments to compile_cmake.dox

### DIFF
--- a/cmake/portaudio.def.in
+++ b/cmake/portaudio.def.in
@@ -39,6 +39,7 @@ Pa_GetStreamWriteAvailable          @32
 Pa_GetSampleSize                    @33
 Pa_Sleep                            @34
 Pa_GetVersionInfo                   @35
+; add new portable public API functions here. DO NOT CHANGE EXISTING ORDINALS!
 @DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_GetAvailableBufferSizes      @50
 @DEF_EXCLUDE_ASIO_SYMBOLS@PaAsio_ShowControlPanel             @51
 @DEF_EXCLUDE_X86_PLAIN_CONVERTERS@PaUtil_InitializeX86PlainConverters @52
@@ -60,8 +61,9 @@ PaUtil_SetDebugPrintFunction        @55
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_SetDefaultDeviceId    @67
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapiWinrt_PopulateDeviceList    @69
 @DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_GetIMMDevice               @70
-@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_IsLoopback                 @71
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandleCount    @72
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandle         @73
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandleCount   @74
-@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandle        @75
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandleCount    @71
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamInputHandle         @72
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandleCount   @73
+@DEF_EXCLUDE_WMME_SYMBOLS@PaWinMME_GetStreamOutputHandle        @74
+@DEF_EXCLUDE_WASAPI_SYMBOLS@PaWasapi_IsLoopback                 @75
+; add new host-API-specific public functions here. DO NOT CHANGE EXISTING ORDINALS!

--- a/doc/src/tutorial/compile_cmake.dox
+++ b/doc/src/tutorial/compile_cmake.dox
@@ -5,7 +5,9 @@
 
 CMake can be used to generate Visual Studio solutions on Windows, Makefiles (on Linux and OS X) and build metadata for other build systems for PortAudio. You should obtain a recent version of CMake from [http://www.cmake.org] if you do not have one already. If you are unfamiliar with CMake, this section will provide some information on using CMake to build PortAudio.
 
-On Linux, CMake serves a very similar purpose to an autotools "configure" script - except it can generate build metadata apart from Makefiles. The equivalent of the following on POSIX'y systems:
+@section cmake_posix Building on Unix-like Systems
+
+On Unix-like systems such as Linux and macOS, CMake serves a very similar purpose to an autotools "configure" script - except it can generate build metadata apart from Makefiles. The equivalent of the following on POSIX'y systems:
 
     build_path> {portaudio path}/configure --prefix=/install_location
     build_path> make
@@ -23,6 +25,10 @@ The "-G" option specifies the type of build metadata which will be generated. Yo
 
 "make install" should install the same set of files that are installed using the usual configure script included with PortAudio along with a few extra files (similar to pkg-config metadata files) which make it easier for other CMake projects to use the installed libraries.
 
+FIXME: do these instructions still work? do they install static and dynamic libraries as with PortAudio V19.7? #468 implies not.
+
+@section cmake_windows Building on Windows
+
 On Windows, you can use CMake to generate Visual Studio project files which can be used to create the PortAudio libraries. The following serves as an example (and should be done from a directory outside the PortAudio tree) which will create Visual Studio 2015 project files targeting a 64-bit build:
 
     C:\PABUILD> cmake {portaudio path} -G "Visual Studio 14 2015 Win64"
@@ -31,14 +37,25 @@ After executing the above, you can either open the generated solution with Visua
 
     C:\PABUILD> cmake --build . --config Release
 
+FIXME: check whether these windows instructions are still valid
+
+TODO: mention that recent version of PortAudio can open the cmake file directly
+
+TODO: describe how to select between static and dynamic build outputs, and note that this is a change since V19.7
+
+
 If you want ASIO support you need to obtain the ASIO2 SDK from Steinberg and place it according to \ref compile_windows_asio_msvc. Both ASIO and the DirectX SDK are automatically searched for by the CMake script - if they are found, they will be enabled by default.
 
 @section cmake_using Using PortAudio in your CMake project
+
+ FIXME: this section is currently wrong (see ticket #486) not clear whether the cmakelists or documentation should be updated.
 
 PortAudio defines the following CMake targets:
 
  - "portaudio_static" for a static library and
  - "portaudio" for a dynamic library
+
+ TODO: describe how to select between static and dynamic build artifacts
 
 If you installed PortAudio as described above in \ref cmake_building and the install prefix you used (CMAKE_INSTALL_PREFIX) is in your system PATH or CMAKE_MODULE_PATH CMake variable, you should be able to use:
 

--- a/msvc/portaudio.def
+++ b/msvc/portaudio.def
@@ -36,6 +36,7 @@ Pa_GetStreamWriteAvailable          @32
 Pa_GetSampleSize                    @33
 Pa_Sleep                            @34
 Pa_GetVersionInfo                   @35
+; add new portable public API functions here. DO NOT CHANGE EXISTING ORDINALS!
 PaAsio_GetAvailableBufferSizes      @50
 PaAsio_ShowControlPanel             @51
 PaUtil_InitializeX86PlainConverters @52
@@ -57,8 +58,9 @@ PaWasapi_SetStreamStateHandler      @68
 PaWasapiWinrt_SetDefaultDeviceId    @67
 PaWasapiWinrt_PopulateDeviceList    @69
 PaWasapi_GetIMMDevice               @70
-PaWasapi_IsLoopback                 @71
-PaWinMME_GetStreamInputHandleCount  @72
-PaWinMME_GetStreamInputHandle       @73
-PaWinMME_GetStreamOutputHandleCount @74
-PaWinMME_GetStreamOutputHandle      @75
+PaWinMME_GetStreamInputHandleCount  @71
+PaWinMME_GetStreamInputHandle       @72
+PaWinMME_GetStreamOutputHandleCount @73
+PaWinMME_GetStreamOutputHandle      @74
+PaWasapi_IsLoopback                 @75
+; add new host-API-specific public functions here. DO NOT CHANGE EXISTING ORDINALS!


### PR DESCRIPTION
This is a starting point for fixing the CMake docs. I don't know CMake and have no way to move forward with this, yet it is blocking V19.8 release. Please help out by suggesting how to fix each broken section.

Related to #662, #486, #918

