### PR TITLE
ASIO: add `PaAsio_GetSampleRate()` function

### DIFF
--- a/examples/pa_devs.c
+++ b/examples/pa_devs.c
@@ -167,7 +167,11 @@ int main(void)
         {   /* Use wide char on windows, so we can show UTF-8 encoded device names */
             wchar_t wideName[MAX_PATH];
             MultiByteToWideChar(CP_UTF8, 0, deviceInfo->name, -1, wideName, MAX_PATH-1);
+        #if __USE_MINGW_ANSI_STDIO
+            wprintf( L"Name                        = %S\n", wideName );
+        #else
             wprintf( L"Name                        = %s\n", wideName );
+        #endif
         }
 #else
         printf( "Name                        = %s\n", deviceInfo->name );
@@ -186,6 +190,7 @@ int main(void)
 /* ASIO specific latency information */
         if( Pa_GetHostApiInfo( deviceInfo->hostApi )->type == paASIO ){
             long minLatency, maxLatency, preferredLatency, granularity;
+            double currentSampleRate;
 
             err = PaAsio_GetAvailableLatencyValues( i,
                     &minLatency, &maxLatency, &preferredLatency, &granularity );
@@ -198,6 +203,9 @@ int main(void)
                 printf( "ASIO buffer granularity     = power of 2\n" );
             else
                 printf( "ASIO buffer granularity     = %ld\n", granularity  );
+
+            err = PaAsio_GetSampleRate( i, &currentSampleRate );
+            printf( "ASIO current sample rate    = %8.2f\n", currentSampleRate);
         }
 #endif /* PA_USE_ASIO */
 #endif /* WIN32 */

--- a/include/pa_asio.h
+++ b/include/pa_asio.h
@@ -78,6 +78,18 @@ PaError PaAsio_GetAvailableBufferSizes( PaDeviceIndex device,
 #define PaAsio_GetAvailableLatencyValues PaAsio_GetAvailableBufferSizes
 
 
+/** Get the current sample rate of the specified device (at the time of PortAudio initialization).
+
+ @param device The global index of the device about which the query is being made.
+ @param sampleRate A pointer to the location which will receive the current sample rate.
+
+ If the current sample rate is unknown, sampleRate will be set to 0.
+
+ @see ASIOGetSampleRate in the ASIO SDK.
+*/
+PaError PaAsio_GetSampleRate( PaDeviceIndex device, double* sampleRate );
+
+
 /** Display the ASIO control panel for the specified device.
 
   @param device The global index of the device whose control panel is to be displayed.


### PR DESCRIPTION
`PaAsio_GetSampleRate()` returns the current sample rate of the specified device at the time of library initialization.
(If the current sample rate is unknown, a sample rate of 0 will be returned.)

For example, this is useful for people who want to use the current sample rate as the default sample rate (which PA's ASIO implementation does not do.)

Actually, I would rather prefer to change the definition of "defaultSampleRate" in the context of ASIO, see https://github.com/PortAudio/portaudio/issues/970, but if this is not desired, this PR would be an acceptable workaround.
