### PR TITLE
cmake: patch asiolist.cpp as issue #331 explains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,11 +215,6 @@ if(WIN32)
     endif()
   endif()
   if(PA_USE_ASIO AND TARGET ASIO::host)
-    #patch asiolist.cpp
-    file(READ "${ASIO_ROOT}/host/pc/asiolist.cpp" FILE_CONTENTS)
-    string(REPLACE "delete lpdrv" "delete[] lpdrv" FILE_CONTENTS "${FILE_CONTENTS}")
-    file(WRITE "${ASIO_ROOT}/host/pc/asiolist.cpp" "${FILE_CONTENTS}")
-
     target_link_libraries(portaudio PRIVATE "$<BUILD_INTERFACE:ASIO::host>")
     set(PORTAUDIO_PUBLIC_HEADERS "${PORTAUDIO_PUBLIC_HEADERS}" include/pa_asio.h)
     target_compile_definitions(portaudio PUBLIC PA_USE_ASIO=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,11 @@ if(WIN32)
     endif()
   endif()
   if(PA_USE_ASIO AND TARGET ASIO::host)
+    #patch asiolist.cpp
+    file(READ "${ASIO_ROOT}/host/pc/asiolist.cpp" FILE_CONTENTS)
+    string(REPLACE "delete lpdrv" "delete[] lpdrv" FILE_CONTENTS "${FILE_CONTENTS}")
+    file(WRITE "${ASIO_ROOT}/host/pc/asiolist.cpp" "${FILE_CONTENTS}")
+
     target_link_libraries(portaudio PRIVATE "$<BUILD_INTERFACE:ASIO::host>")
     set(PORTAUDIO_PUBLIC_HEADERS "${PORTAUDIO_PUBLIC_HEADERS}" include/pa_asio.h)
     target_compile_definitions(portaudio PUBLIC PA_USE_ASIO=1)

--- a/cmake/modules/FindASIO.cmake
+++ b/cmake/modules/FindASIO.cmake
@@ -66,7 +66,7 @@ if(ASIO_ROOT)
       file(READ "${ASIO_ROOT}/host/pc/asiolist.cpp" FILE_CONTENTS)
       string(REPLACE "delete lpdrv" "delete[] lpdrv" FILE_CONTENTS "${FILE_CONTENTS}")
       file(WRITE "${ASIO_ROOT}/host/pc/patched_asiolist.cpp" "${FILE_CONTENTS}")
-      message(STATUS "Done patching asiolist.cpp")
+      message(STATUS "Done patching asiolist.cpp into patched_asiolist.cpp")
     endif()
     add_library(ASIO::host INTERFACE IMPORTED)
     target_sources(ASIO::host INTERFACE

--- a/cmake/modules/FindASIO.cmake
+++ b/cmake/modules/FindASIO.cmake
@@ -61,11 +61,18 @@ if(ASIO_ROOT)
   message(STATUS "Found ASIO SDK: ${ASIO_ROOT}")
 
   if(ASIO_FOUND AND NOT TARGET ASIO::host)
+    #patch asiolist.cpp
+    if(NOT EXISTS "${ASIO_ROOT}/host/pc/patched_asiolist.cpp")
+      file(READ "${ASIO_ROOT}/host/pc/asiolist.cpp" FILE_CONTENTS)
+      string(REPLACE "delete lpdrv" "delete[] lpdrv" FILE_CONTENTS "${FILE_CONTENTS}")
+      file(WRITE "${ASIO_ROOT}/host/pc/patched_asiolist.cpp" "${FILE_CONTENTS}")
+      message(STATUS "Done patching asiolist.cpp")
+    endif()
     add_library(ASIO::host INTERFACE IMPORTED)
     target_sources(ASIO::host INTERFACE
       "${ASIO_ROOT}/common/asio.cpp"
       "${ASIO_ROOT}/host/asiodrivers.cpp"
-      "${ASIO_ROOT}/host/pc/asiolist.cpp"
+      "${ASIO_ROOT}/host/pc/patched_asiolist.cpp"
     )
     target_include_directories(ASIO::host INTERFACE
       "${ASIO_ROOT}/common"

--- a/src/hostapi/asio/ASIO-README.txt
+++ b/src/hostapi/asio/ASIO-README.txt
@@ -87,6 +87,8 @@ To fix this issue replace the line:
 with:
     delete [] lpdrv;
 
+In the cmake build of portaudio this is already done for you.
+
 Explanation: lpdrv is allocated as an array on the line:
     lpdrv = new ASIODRVSTRUCT[1];
 Hence it must also be deleted as an array as per standard C++ rules.


### PR DESCRIPTION
If download of ASIO api is complete, this performs the modification of "delete lpdrv" to "delete[] lpdrv".
Even in the case it was already done that would be harmless.