### PR TITLE
fix broken CI: upgrade cmake CI to actions/cache@v4 because v2 is no longer available

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,7 +73,7 @@ jobs:
         sudo apt-get install libasound2-dev libpulse-dev libsndio-dev ${{ matrix.dependencies_extras }}
       if: matrix.os == 'ubuntu-latest'
     - name: "Set up ASIO SDK cache [Windows/MinGW]"
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       if: matrix.asio_sdk_cache_path != null
       with:
         path: ${{ matrix.asio_sdk_cache_path }}


### PR DESCRIPTION
see: https://github.com/actions/toolkit/discussions/1890