### PR TITLE
[cmake] Increase minimum required version of CMake to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.5)
 project(PortAudio VERSION 19.8)
 
 #


### PR DESCRIPTION
CMake 4 refuses to accept a minimum required version below 3.5 without additional flags.