### PR TITLE
small fixups from PR #1021 with improved commit messages

### DIFF
--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -341,7 +341,7 @@ static void Float32_To_Int32(
     while( count-- )
     {
         /* REVIEW */
-        double scaled = *src * 0x7FFFFFFF;
+        double scaled = (double)*src * 0x7FFFFFFF;
         *dest = (PaInt32) scaled;
 
         src += sourceStride;
@@ -386,7 +386,7 @@ static void Float32_To_Int32_Clip(
     while( count-- )
     {
         /* REVIEW */
-        double scaled = *src * 0x7FFFFFFF;
+        double scaled = (double)*src * 0x7FFFFFFF;
         PA_CLIP_( scaled, -2147483648., 2147483647.  );
         *dest = (PaInt32) scaled;
 
@@ -505,7 +505,7 @@ static void Float32_To_Int24_Clip(
     while( count-- )
     {
         /* convert to 32 bit and drop the low 8 bits */
-        double scaled = *src * 0x7FFFFFFF;
+        double scaled = (double)*src * 0x7FFFFFFF;
         PA_CLIP_( scaled, -2147483648., 2147483647.  );
         temp = (PaInt32) scaled;
 

--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio.c
@@ -563,7 +563,6 @@ PaError PaPulseAudio_Initialize( PaUtilHostApiRepresentation ** hostApi,
 {
     PaError result = paNoError;
     int i;
-    int deviceCount;
     int ret = 0;
     int lockTaken = 0;
     PaPulseAudio_HostApiRepresentation *pulseaudioHostApi = NULL;

--- a/test/patest_ringmix.c
+++ b/test/patest_ringmix.c
@@ -41,7 +41,7 @@
  */
 
 
-#include "stdio.h"
+#include <stdio.h>
 #include "portaudio.h"
 /* This will be called asynchronously by the PortAudio engine. */
 static int myCallback( const void *inputBuffer, void *outputBuffer,


### PR DESCRIPTION
These are the commits from PR #1021 that have already been approved by Phil and I. I just updated the commit messages to be clearer.

I dropped the patch changing `sin` -> `sinf` since that is not C89. I will revert the other uses of sinf.