### PR TITLE
Implement 8-bit converters with Dither

### DIFF
--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -1012,16 +1012,18 @@ static void Int32_To_UInt8_Dither(
     void *sourceBuffer, signed int sourceStride,
     unsigned int count, struct PaUtilTriangularDitherGenerator *ditherGenerator )
 {
-    /* PaInt32 *src = (PaInt32*)sourceBuffer;
-    unsigned char *dest =  (unsigned char*)destinationBuffer; */
-    (void)ditherGenerator; /* unused parameter */
+    PaInt32 *src = (PaInt32*)sourceBuffer;
+    unsigned char *dest = (unsigned char*)destinationBuffer;
+
+    PaInt32 dither;
 
     while( count-- )
     {
-        /* IMPLEMENT ME */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        *dest = (unsigned char) ((((src[0] >> 1) + dither) >> 23) + 128);
 
-        /* src += sourceStride;
-        dest += destinationStride; */
+        src += sourceStride;
+        dest += destinationStride;
     }
 }
 
@@ -1260,13 +1262,30 @@ static void Int24_To_UInt8_Dither(
     void *sourceBuffer, signed int sourceStride,
     unsigned int count, struct PaUtilTriangularDitherGenerator *ditherGenerator )
 {
-    (void) destinationBuffer; /* unused parameters */
-    (void) destinationStride; /* unused parameters */
-    (void) sourceBuffer; /* unused parameters */
-    (void) sourceStride; /* unused parameters */
-    (void) count; /* unused parameters */
-    (void) ditherGenerator; /* unused parameters */
-    /* IMPLEMENT ME */
+    unsigned char *src = (unsigned char*)sourceBuffer;
+    unsigned char  *dest = (unsigned char*)destinationBuffer;
+
+    PaInt32 temp, dither;
+
+    while( count-- )
+    {
+
+#if defined(PA_LITTLE_ENDIAN)
+        temp = (((PaInt32)src[0]) << 8);
+        temp = temp | (((PaInt32)src[1]) << 16);
+        temp = temp | (((PaInt32)src[2]) << 24);
+#elif defined(PA_BIG_ENDIAN)
+        temp = (((PaInt32)src[0]) << 24);
+        temp = temp | (((PaInt32)src[1]) << 16);
+        temp = temp | (((PaInt32)src[2]) << 8);
+#endif
+
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        *dest = (unsigned char) ((((temp >> 1) + dither) >> 23) + 128);
+
+        src += sourceStride * 3;
+        dest += destinationStride;
+    }
 }
 
 /* -------------------------------------------------------------------------- */
@@ -1373,16 +1392,20 @@ static void Int16_To_Int8_Dither(
     void *sourceBuffer, signed int sourceStride,
     unsigned int count, struct PaUtilTriangularDitherGenerator *ditherGenerator )
 {
-    /* PaInt16 *src = (PaInt16*)sourceBuffer;
-    signed char *dest =  (signed char*)destinationBuffer; */
-    (void)ditherGenerator; /* unused parameter */
+    PaInt16 *src = (PaInt16*)sourceBuffer;
+    signed char *dest = (signed char*)destinationBuffer;
+
+    PaInt32 temp, dither;
 
     while( count-- )
     {
-        /* IMPLEMENT ME */
+        temp = ((PaInt32)src[0]) << 16;
 
-        /* src += sourceStride;
-        dest += destinationStride; */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        *dest = (signed char) (((temp >> 1) + dither) >> 23);
+
+        src += sourceStride;
+        dest += destinationStride;
     }
 }
 
@@ -1413,16 +1436,20 @@ static void Int16_To_UInt8_Dither(
     void *sourceBuffer, signed int sourceStride,
     unsigned int count, struct PaUtilTriangularDitherGenerator *ditherGenerator )
 {
-    /* PaInt16 *src = (PaInt16*)sourceBuffer;
-    unsigned char *dest =  (unsigned char*)destinationBuffer; */
-    (void)ditherGenerator; /* unused parameter */
+    PaInt16 *src = (PaInt16*)sourceBuffer;
+    unsigned char *dest = (unsigned char*)destinationBuffer;
+
+    PaInt32 temp, dither;
 
     while( count-- )
     {
-        /* IMPLEMENT ME */
+        temp = ((PaInt32)src[0]) << 16;
 
-        /* src += sourceStride;
-        dest += destinationStride; */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        *dest = (unsigned char) ((((temp >> 1) + dither) >> 23) + 128);
+
+        src += sourceStride;
+        dest += destinationStride;
     }
 }
 

--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -976,9 +976,11 @@ static void Int32_To_Int8_Dither(
 
     while( count-- )
     {
-        /* REVIEW */
-        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
-        *dest = (signed char) ((((*src)>>1) + dither) >> 23);
+        /* increase dither scale to 24-bit value so that it would not be truncated completely when applied */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator ) << 8;
+
+        /* apply dither, truncate resulting 32-bit value to 8-bit */
+        *dest = (signed char) ((((*src) >> 1) + dither) >> 23);
 
         src += sourceStride;
         dest += destinationStride;
@@ -1019,7 +1021,10 @@ static void Int32_To_UInt8_Dither(
 
     while( count-- )
     {
-        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        /* increase dither scale to 24-bit value so that it would not be truncated completely when applied */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator ) << 8;
+
+        /* apply dither, truncate resulting 32-bit value to 8-bit and convert to unsigned */
         *dest = (unsigned char) ((((src[0] >> 1) + dither) >> 23) + 128);
 
         src += sourceStride;
@@ -1205,7 +1210,7 @@ static void Int24_To_Int8_Dither(
 
     while( count-- )
     {
-
+        /* convert 24-bit to 32-bit value */
 #if defined(PA_LITTLE_ENDIAN)
         temp = (((PaInt32)src[0]) << 8);
         temp = temp | (((PaInt32)src[1]) << 16);
@@ -1216,8 +1221,10 @@ static void Int24_To_Int8_Dither(
         temp = temp | (((PaInt32)src[2]) << 8);
 #endif
 
-        /* REVIEW */
-        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        /* increase dither scale to 24-bit value so that it would not be truncated completely when applied */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator ) << 8;
+
+        /* apply dither, truncate resulting 32-bit value to 8-bit */
         *dest = (signed char) (((temp >> 1) + dither) >> 23);
 
         src += sourceStride * 3;
@@ -1263,13 +1270,13 @@ static void Int24_To_UInt8_Dither(
     unsigned int count, struct PaUtilTriangularDitherGenerator *ditherGenerator )
 {
     unsigned char *src = (unsigned char*)sourceBuffer;
-    unsigned char  *dest = (unsigned char*)destinationBuffer;
+    unsigned char *dest = (unsigned char*)destinationBuffer;
 
     PaInt32 temp, dither;
 
     while( count-- )
     {
-
+        /* convert 24-bit to 32-bit value */
 #if defined(PA_LITTLE_ENDIAN)
         temp = (((PaInt32)src[0]) << 8);
         temp = temp | (((PaInt32)src[1]) << 16);
@@ -1280,7 +1287,10 @@ static void Int24_To_UInt8_Dither(
         temp = temp | (((PaInt32)src[2]) << 8);
 #endif
 
-        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        /* increase dither scale to 24-bit value so that it would not be truncated completely when applied */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator ) << 8;
+
+        /* apply dither, truncate resulting 32-bit value to 8-bit and convert to unsigned */
         *dest = (unsigned char) ((((temp >> 1) + dither) >> 23) + 128);
 
         src += sourceStride * 3;
@@ -1399,9 +1409,13 @@ static void Int16_To_Int8_Dither(
 
     while( count-- )
     {
+        /* convert 16-bit to 32-bit value */
         temp = ((PaInt32)src[0]) << 16;
 
-        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        /* increase dither scale to 24-bit value so that it would not be truncated completely when applied */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator ) << 8;
+
+        /* apply dither, truncate resulting 32-bit value to 8-bit */
         *dest = (signed char) (((temp >> 1) + dither) >> 23);
 
         src += sourceStride;
@@ -1443,9 +1457,13 @@ static void Int16_To_UInt8_Dither(
 
     while( count-- )
     {
+        /* convert 16-bit to 32-bit value */
         temp = ((PaInt32)src[0]) << 16;
 
-        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator );
+        /* increase dither scale to 24-bit value so that it would not be truncated completely when applied */
+        dither = PaUtil_Generate16BitTriangularDither( ditherGenerator ) << 8;
+
+        /* apply dither, truncate resulting 32-bit value to 8-bit and convert to unsigned */
         *dest = (unsigned char) ((((temp >> 1) + dither) >> 23) + 128);
 
         src += sourceStride;


### PR DESCRIPTION
Implements converters:

- Int32_To_UInt8_Dither
- Int24_To_UInt8_Dither
- Int16_To_UInt8_Dither
- Int16_To_Int8_Dither

Implementation is validated with `patest_converters`:

```c
== flags = paClipOff ==

=== Output contains non-zero data ===
Key: . - pass, X - fail
{{{
in|  out:      f32     i32     i24     i16      i8     ui8
f32             .       .       .       .       .       .
i32             .       .       X       .       .       .
i24             .       .       .       .       .       .
i16             .       .       .       .       .       .
 i8             .       .       .       .       .       .
ui8             .       .       .       .       .       .
}}}

=== Combined dynamic range (src->dest->float32) ===
Key: Noise amplitude in dBfs, X - fail (either above failed or dest->float32 failed)
{{{
in|  out:      f32     i32     i24     i16      i8     ui8
 f32          -inf  -180.6  -138.5   -79.4   -31.9   -31.3
 i32        -144.5  -144.5     X     -85.9   -42.1   -42.1
 i24        -138.5  -138.5  -138.5   -85.5   -42.1   -42.1
 i16         -84.8   -84.8   -84.8   -84.8   -42.1   -42.1
  i8         -36.6   -36.6   -36.6   -36.6   -36.6   -36.6
 ui8         -36.4   -36.4   -36.4   -36.4   -36.4   -36.4
}}}
```

Closes #168 