### PR TITLE
Avoid infinite loops in ALSA code

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -565,7 +565,7 @@ static void PaAlsa_CloseLibrary()
 }
 
 /* Check return value of ALSA function, and map it to PaError */
-#define ENSURE_(expr, code) \
+#define ENSURE_ON_ERROR_(expr, code, _on_error) \
     do { \
         int __pa_unsure_error_id;\
         if( UNLIKELY( (__pa_unsure_error_id = (expr)) < 0 ) ) \
@@ -579,9 +579,15 @@ static void PaAlsa_CloseLibrary()
             if( (code) == paUnanticipatedHostError ) \
                 PA_DEBUG(( "Host error description: %s\n", alsa_snd_strerror( __pa_unsure_error_id ) )); \
             result = (code); \
-            goto error; \
+            _on_error; \
         } \
     } while (0)
+
+/* Do NOT call this after an "error:" label. */
+#define ENSURE_(expr, code, goto error)
+
+/* Print warning but do not goto error. */
+#define ENSURE_SAFE_(expr, code, (void)0)
 
 #define ASSERT_CALL_(expr, success) \
     do {\
@@ -3255,9 +3261,9 @@ error:
     {
         unsigned int _min = 0, _max = 0;
         int _dir = 0;
-        ENSURE_( alsa_snd_pcm_hw_params_get_rate_min( hwParams, &_min, &_dir ), paUnanticipatedHostError );
+        ENSURE_SAFE_( alsa_snd_pcm_hw_params_get_rate_min( hwParams, &_min, &_dir ), paUnanticipatedHostError );
         _dir = 0;
-        ENSURE_( alsa_snd_pcm_hw_params_get_rate_max( hwParams, &_max, &_dir ), paUnanticipatedHostError );
+        ENSURE_SAFE_( alsa_snd_pcm_hw_params_get_rate_max( hwParams, &_max, &_dir ), paUnanticipatedHostError );
         PA_DEBUG(( "%s: SR min = %u, max = %u, req = %u\n", __FUNCTION__, _min, _max, reqRate ));
     }
     goto end;
@@ -3291,7 +3297,7 @@ static PaError AlsaRestart( PaAlsaStream *stream )
     PA_DEBUG(( "%s: Restarted audio\n", __FUNCTION__ ));
 
 error:
-    PA_ENSURE( PaUnixMutex_Unlock( &stream->stateMtx ) );
+    PA_ENSURE_SAFE( PaUnixMutex_Unlock( &stream->stateMtx ) );
 
     return result;
 }
@@ -3988,7 +3994,7 @@ error:
     if( xrun )
     {
         /* Recover from the xrun state */
-        PA_ENSURE( PaAlsaStream_HandleXrun( self ) );
+        PA_ENSURE_SAFE( PaAlsaStream_HandleXrun( self ) );
         *framesAvail = 0;
     }
     else
@@ -3996,7 +4002,7 @@ error:
         if( 0 != *framesAvail )
         {
             /* If we're reporting frames eligible for processing, one of the handles better be ready */
-            PA_UNLESS( self->capture.ready || self->playback.ready, paInternalError );
+            PA_UNLESS_SAFE( self->capture.ready || self->playback.ready, paInternalError );
         }
     }
     *xrunOccurred = xrun;
@@ -4229,7 +4235,7 @@ end:
 error:
     if( xrun )
     {
-        PA_ENSURE( PaAlsaStream_HandleXrun( self ) );
+        PA_ENSURE_SAFE( PaAlsaStream_HandleXrun( self ) );
         *numFrames = 0;
     }
     *xrunOccurred = xrun;

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -584,10 +584,10 @@ static void PaAlsa_CloseLibrary()
     } while (0)
 
 /* Do NOT call this after an "error:" label. */
-#define ENSURE_(expr, code, goto error)
+#define ENSURE_(expr, code) ENSURE_ON_ERROR_(expr, code, goto error)
 
 /* Print warning but do not goto error. */
-#define ENSURE_SAFE_(expr, code, (void)0)
+#define ENSURE_SAFE_(expr, code) ENSURE_ON_ERROR_(expr, code, (void)0)
 
 #define ASSERT_CALL_(expr, success) \
     do {\

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -587,7 +587,7 @@ static void PaAlsa_CloseLibrary()
 #define ENSURE_(expr, code) ENSURE_ON_ERROR_(expr, code, goto error)
 
 /* Print warning but do not goto error. */
-#define ENSURE_SAFE_(expr, code) ENSURE_ON_ERROR_(expr, code, (void)0)
+#define ENSURE_NO_GOTO_(expr, code) ENSURE_ON_ERROR_(expr, code, (void)0)
 
 #define ASSERT_CALL_(expr, success) \
     do {\
@@ -3261,9 +3261,9 @@ error:
     {
         unsigned int _min = 0, _max = 0;
         int _dir = 0;
-        ENSURE_SAFE_( alsa_snd_pcm_hw_params_get_rate_min( hwParams, &_min, &_dir ), paUnanticipatedHostError );
+        ENSURE_NO_GOTO_( alsa_snd_pcm_hw_params_get_rate_min( hwParams, &_min, &_dir ), paUnanticipatedHostError );
         _dir = 0;
-        ENSURE_SAFE_( alsa_snd_pcm_hw_params_get_rate_max( hwParams, &_max, &_dir ), paUnanticipatedHostError );
+        ENSURE_NO_GOTO_( alsa_snd_pcm_hw_params_get_rate_max( hwParams, &_max, &_dir ), paUnanticipatedHostError );
         PA_DEBUG(( "%s: SR min = %u, max = %u, req = %u\n", __FUNCTION__, _min, _max, reqRate ));
     }
     goto end;
@@ -3297,7 +3297,7 @@ static PaError AlsaRestart( PaAlsaStream *stream )
     PA_DEBUG(( "%s: Restarted audio\n", __FUNCTION__ ));
 
 error:
-    PA_ENSURE_SAFE( PaUnixMutex_Unlock( &stream->stateMtx ) );
+    PA_ENSURE_NO_GOTO( PaUnixMutex_Unlock( &stream->stateMtx ) );
 
     return result;
 }
@@ -3994,7 +3994,7 @@ error:
     if( xrun )
     {
         /* Recover from the xrun state */
-        PA_ENSURE_SAFE( PaAlsaStream_HandleXrun( self ) );
+        PA_ENSURE_NO_GOTO( PaAlsaStream_HandleXrun( self ) );
         *framesAvail = 0;
     }
     else
@@ -4002,7 +4002,7 @@ error:
         if( 0 != *framesAvail )
         {
             /* If we're reporting frames eligible for processing, one of the handles better be ready */
-            PA_UNLESS_SAFE( self->capture.ready || self->playback.ready, paInternalError );
+            PA_UNLESS_NO_GOTO( self->capture.ready || self->playback.ready, paInternalError );
         }
     }
     *xrunOccurred = xrun;
@@ -4235,7 +4235,7 @@ end:
 error:
     if( xrun )
     {
-        PA_ENSURE_SAFE( PaAlsaStream_HandleXrun( self ) );
+        PA_ENSURE_NO_GOTO( PaAlsaStream_HandleXrun( self ) );
         *numFrames = 0;
     }
     *xrunOccurred = xrun;

--- a/src/os/unix/pa_unix_util.h
+++ b/src/os/unix/pa_unix_util.h
@@ -66,28 +66,40 @@ extern "C"
 #define UNLIKELY(expr) (expr)
 #endif
 
-#define PA_UNLESS(expr, code) \
+#define PA_UNLESS_ON_ERROR(expr, code, _on_error) \
     do { \
         if( UNLIKELY( (expr) == 0 ) ) \
         { \
             PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = (code); \
-            goto error; \
+            _on_error; \
         } \
     } while (0);
+
+/* Do not call this after an "error:" label because it will loop forever! */
+#define PA_UNLESS(expr, code) PA_UNLESS_ON_ERROR(expr, code, goto error)
+
+/* This is safe to call after an "error:" label. */
+#define PA_UNLESS_SAFE(expr, code) PA_UNLESS_ON_ERROR(expr, code, (void)0)
 
 static PaError paUtilErr_;          /* Used with PA_ENSURE */
 
 /* Check PaError */
-#define PA_ENSURE(expr) \
+#define PA_ENSURE_ON_ERROR(expr, _on_error) \
     do { \
         if( UNLIKELY( (paUtilErr_ = (expr)) < paNoError ) ) \
         { \
             PaUtil_DebugPrint(( "Expression '" #expr "' failed in '" __FILE__ "', line: " PA_STRINGIZE( __LINE__ ) "\n" )); \
             result = paUtilErr_; \
-            goto error; \
+            _on_error; \
         } \
     } while (0);
+
+/* Do not call this after an "error:" label because it will loop forever! */
+#define PA_ENSURE(expr) PA_ENSURE_ON_ERROR(expr, goto error)
+
+/* This is safe to call after an "error:" label. */
+#define PA_ENSURE_SAFE(expr) PA_ENSURE_ON_ERROR(expr, (void)0)
 
 #define PA_ASSERT_CALL(expr, success) \
     paUtilErr_ = (expr); \

--- a/src/os/unix/pa_unix_util.h
+++ b/src/os/unix/pa_unix_util.h
@@ -80,7 +80,7 @@ extern "C"
 #define PA_UNLESS(expr, code) PA_UNLESS_ON_ERROR(expr, code, goto error)
 
 /* This is safe to call after an "error:" label. */
-#define PA_UNLESS_SAFE(expr, code) PA_UNLESS_ON_ERROR(expr, code, (void)0)
+#define PA_UNLESS_NO_GOTO(expr, code) PA_UNLESS_ON_ERROR(expr, code, (void)0)
 
 static PaError paUtilErr_;          /* Used with PA_ENSURE */
 
@@ -99,7 +99,7 @@ static PaError paUtilErr_;          /* Used with PA_ENSURE */
 #define PA_ENSURE(expr) PA_ENSURE_ON_ERROR(expr, goto error)
 
 /* This is safe to call after an "error:" label. */
-#define PA_ENSURE_SAFE(expr) PA_ENSURE_ON_ERROR(expr, (void)0)
+#define PA_ENSURE_NO_GOTO(expr) PA_ENSURE_ON_ERROR(expr, (void)0)
 
 #define PA_ASSERT_CALL(expr, success) \
     paUtilErr_ = (expr); \


### PR DESCRIPTION
Do not use the error macros that call "goto error" after an "error:" label.

Fixes #1037