### PR TITLE
patest_converters.c: fix printed table label: "dynamic range" -> "max abs diff"

### DIFF
--- a/test/patest_converters.c
+++ b/test/patest_converters.c
@@ -334,8 +334,8 @@ int main( int argc, const char **argv )
         printf( "}}}\n" ); // trac preformated text tag
 
         printf( "\n" );
-        printf( "=== Combined dynamic range (src->dest->float32) ===\n" );
-        printf( "Key: Noise amplitude in dBfs, X - fail (either above failed or dest->float32 failed)\n" );
+        printf( "=== Maximum absolute difference src -> dest -> float32 (non-exhaustive) ===\n" );
+        printf( "Key: Worst error amplitude in dBfs, X - fail (either above failed or dest->float32 failed)\n" );
         printf( "{{{\n" ); // trac preformated text tag
         printf( "in|  out:    " );
         for( destinationFormatIndex = 0; destinationFormatIndex < SAMPLE_FORMAT_COUNT; ++destinationFormatIndex ){


### PR DESCRIPTION
The test computes maximum absolute differences over a non-exhaustive test signal. It does not really establish the dynamic range of the conversion. Update the labels on the printed output accordingly.