### PR TITLE
CI: add autotools build targets for Ubuntu-mingw cross-compile and macOS

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -34,9 +34,10 @@ jobs:
             asio_sdk_cache_path: asiosdk.zip
             dependencies_extras: mingw-w64
             vcpkg_triplet: x64-mingw-static
-          - name: Windows MinGW
-            os: windows-latest
-            vcpkg_triplet: x64-mingw-static
+          # Use autotools_msys2.yml for Windows MinGW due to siginificant differences
+          # - name: Windows MinGW
+          #  os: windows-latest
+          #  vcpkg_triplet: x64-mingw-static
           - name: macOS Clang
             os: macOS-latest
             vcpkg_triplet: arm64-osx


### PR DESCRIPTION
Along with #1055 fixes #1047