### PR TITLE
Add function PaMacCore_GetOSWorkgroup()

### DIFF
--- a/include/pa_mac_core.h
+++ b/include/pa_mac_core.h
@@ -47,6 +47,8 @@
 
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
+#include <os/workgroup.h>
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -135,6 +137,17 @@ const char *PaMacCore_GetChannelName( int device, int channelIndex, bool input )
  */
 PaError PaMacCore_GetBufferSizeRange( PaDeviceIndex device,
                                        long *minBufferSizeFrames, long *maxBufferSizeFrames );
+
+
+/**
+ * Retrieve the audio workgroup of the specified device.
+ *
+ * @param device The global index of the PortAudio device about which the query is being made.
+ * @param workgroup A pointer to the location which will receive the workgroup value.
+ *
+ * @see kAudioDevicePropertyIOThreadOSWorkgroup in the CoreAudio SDK.
+ */
+ PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgroup );
 
 
 /**

--- a/include/pa_mac_core.h
+++ b/include/pa_mac_core.h
@@ -151,7 +151,7 @@ PaError PaMacCore_GetBufferSizeRange( PaDeviceIndex device,
  * @see kAudioDevicePropertyIOThreadOSWorkgroup in the CoreAudio SDK.
  */
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
- PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgroup );
+PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgroup );
 #endif
 
 /**

--- a/include/pa_mac_core.h
+++ b/include/pa_mac_core.h
@@ -47,8 +47,11 @@
 
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
-#include <os/workgroup.h>
 
+// Audio workgroups are only supported from MacOS 11 onwards.
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
+#include <os/workgroup.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -140,15 +143,16 @@ PaError PaMacCore_GetBufferSizeRange( PaDeviceIndex device,
 
 
 /**
- * Retrieve the audio workgroup of the specified device.
+ * Retrieve the audio workgroup of the specified device. (Mac OS 11 and higher only)
  *
  * @param device The global index of the PortAudio device about which the query is being made.
  * @param workgroup A pointer to the location which will receive the workgroup value.
  *
  * @see kAudioDevicePropertyIOThreadOSWorkgroup in the CoreAudio SDK.
  */
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
  PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgroup );
-
+#endif
 
 /**
  * Flags

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -250,12 +250,13 @@ PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgrou
             AudioDeviceID macCoreDeviceId = macCoreHostApi->devIds[hostApiDeviceIndex];
             UInt32 propSize = sizeof( os_workgroup_t );
 
-            // Determine if this is an inputs only device
-            Boolean isInputsOnly = 0;
+            // return the workgroup for the output scope unless the device only has inputs,
+            // in which case return the workgroup for the input scope
+            Boolean isInputOnly = 0;
             if( macCoreHostApi->inheritedHostApiRep.deviceInfos[hostApiDeviceIndex]->maxOutputChannels == 0 )
-                isInputsOnly = 1;
+                isInputOnly = 1;
 
-            result = WARNING(PaMacCore_AudioDeviceGetProperty( macCoreDeviceId, 0, isInputsOnly, kAudioDevicePropertyIOThreadOSWorkgroup, &propSize, workgroup ) );
+            result = WARNING(PaMacCore_AudioDeviceGetProperty( macCoreDeviceId, 0, isInputOnly, kAudioDevicePropertyIOThreadOSWorkgroup, &propSize, workgroup ) );
         }
     }
 

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -233,6 +233,34 @@ PaError PaMacCore_GetBufferSizeRange( PaDeviceIndex device,
 }
 
 
+PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgroup )
+{
+    PaError result;
+    PaUtilHostApiRepresentation *hostApi;
+
+    result = PaUtil_GetHostApiRepresentation( &hostApi, paCoreAudio );
+
+    if( result == paNoError )
+    {
+        PaDeviceIndex hostApiDeviceIndex;
+        result = PaUtil_DeviceIndexToHostApiDeviceIndex( &hostApiDeviceIndex, device, hostApi );
+        if( result == paNoError )
+        {
+            PaMacAUHAL *macCoreHostApi = (PaMacAUHAL*)hostApi;
+            AudioDeviceID macCoreDeviceId = macCoreHostApi->devIds[hostApiDeviceIndex];
+            UInt32 propSize = sizeof( os_workgroup_t );
+
+            // return the size range for the output scope unless we only have inputs
+            Boolean isInput = 0;
+
+            result = WARNING(PaMacCore_AudioDeviceGetProperty( macCoreDeviceId, 0, isInput, kAudioDevicePropertyIOThreadOSWorkgroup, &propSize, workgroup ) );
+        }
+    }
+
+    return result;
+}
+
+
 AudioDeviceID PaMacCore_GetStreamInputDevice( PaStream* s )
 {
     PaMacCoreStream *stream = (PaMacCoreStream*)s;

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -232,7 +232,7 @@ PaError PaMacCore_GetBufferSizeRange( PaDeviceIndex device,
     return result;
 }
 
-
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
 PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgroup )
 {
     PaError result;
@@ -261,7 +261,7 @@ PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgrou
 
     return result;
 }
-
+#endif
 
 AudioDeviceID PaMacCore_GetStreamInputDevice( PaStream* s )
 {

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -250,10 +250,12 @@ PaError PaMacCore_GetOSWorkgroup( PaDeviceIndex device, os_workgroup_t *workgrou
             AudioDeviceID macCoreDeviceId = macCoreHostApi->devIds[hostApiDeviceIndex];
             UInt32 propSize = sizeof( os_workgroup_t );
 
-            // return the size range for the output scope unless we only have inputs
-            Boolean isInput = 0;
+            // Determine if this is an inputs only device
+            Boolean isInputsOnly = 0;
+            if( macCoreHostApi->inheritedHostApiRep.deviceInfos[hostApiDeviceIndex]->maxOutputChannels == 0 )
+                isInputsOnly = 1;
 
-            result = WARNING(PaMacCore_AudioDeviceGetProperty( macCoreDeviceId, 0, isInput, kAudioDevicePropertyIOThreadOSWorkgroup, &propSize, workgroup ) );
+            result = WARNING(PaMacCore_AudioDeviceGetProperty( macCoreDeviceId, 0, isInputsOnly, kAudioDevicePropertyIOThreadOSWorkgroup, &propSize, workgroup ) );
         }
     }
 

--- a/src/hostapi/coreaudio/pa_mac_core_internal.h
+++ b/src/hostapi/coreaudio/pa_mac_core_internal.h
@@ -76,7 +76,6 @@
 #include "pa_ringbuffer.h"
 
 #include "pa_mac_core_blocking.h"
-#include "pa_mac_core_utilities.h"
 
 /* function prototypes */
 

--- a/src/hostapi/coreaudio/pa_mac_core_internal.h
+++ b/src/hostapi/coreaudio/pa_mac_core_internal.h
@@ -76,6 +76,7 @@
 #include "pa_ringbuffer.h"
 
 #include "pa_mac_core_blocking.h"
+#include "pa_mac_core_utilities.h"
 
 /* function prototypes */
 
@@ -96,6 +97,7 @@ PaError ReadStream( PaStream* stream, void *buffer, unsigned long frames );
 PaError WriteStream( PaStream* stream, const void *buffer, unsigned long frames );
 signed long GetStreamReadAvailable( PaStream* stream );
 signed long GetStreamWriteAvailable( PaStream* stream );
+
 /* PaMacAUHAL - host api datastructure specific to this implementation */
 typedef struct
 {


### PR DESCRIPTION
Implements a function to retrieve the mac OS workgroup for a certain audio device.

I needed this myself in order to implement efficient multithreaded audio processing on Mac OS from Big Sur onwards.

See this for exlanation:
https://developer.apple.com/documentation/audiotoolbox/understanding-audio-workgroups