### PR TITLE
configure.in: cause a reasonable diagnostic if AX_CHECK_COMPILE_FLAG is not available

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -8,7 +8,7 @@ dnl Require autoconf >= 2.13
 AC_PREREQ(2.13)
 
 dnl cause a reasonable diagnostic if AX_CHECK_COMPILE_FLAG is not available
-m4_pattern_forbid([AX_CHECK_COMPILE_FLAG])dnl
+m4_pattern_forbid([AX_CHECK_COMPILE_FLAG])
 
 dnl Init autoconf and make sure configure is being called
 dnl from the right directory

--- a/configure.in
+++ b/configure.in
@@ -7,6 +7,9 @@ dnl
 dnl Require autoconf >= 2.13
 AC_PREREQ(2.13)
 
+dnl cause a reasonable diagnostic if AX_CHECK_COMPILE_FLAG is not available
+m4_pattern_forbid([AX_CHECK_COMPILE_FLAG])dnl
+
 dnl Init autoconf and make sure configure is being called
 dnl from the right directory
 AC_INIT([include/portaudio.h])


### PR DESCRIPTION
On some platforms the `AX_CHECK_COMPILE_FLAG` macro (used in our `configure.in`) is not defined within the base `autotools` package, but rather in a separate `autotools-archive` package. If that package is not installed `AX_CHECK_COMPILE_FLAG` is not defined. This results in the use of `AX_CHECK_COMPILE_FLAG` being emitted verbatim into `./configure`, which in turn results in a cryptic error message:

```
./configure: line 19323: syntax error near unexpected token `-std=c11,'
./configure: line 19323: `        AX_CHECK_COMPILE_FLAG(-std=c11, CFLAGS="-std=c11 $CFLAGS", CFLAGS="-std=c99 $CFLAGS")'
Error: Process completed with exit code 2.
```

This patch improves the error diagnostic. The new diagnostic will be emitted at the time that `autoreconf` is run, and will not allow the `./configure` file to be generated if the `AX_CHECK_COMPILE_FLAG` macro is not defined. The new error is:

```
configure.ac:10: error: possibly undefined macro: AX_CHECK_COMPILE_FLAG
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf-2.72: error: /usr/bin/autoconf-2.72 failed with exit status: 1
```





