### PR TITLE
enable mingw in autotools.yml

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -35,7 +35,7 @@ jobs:
             dependencies_extras: mingw-w64
             vcpkg_triplet: x64-mingw-static
           # Use autotools_msys2.yml for Windows MinGW due to siginificant differences
-           - name: Windows MinGW
+          - name: Windows MinGW
             os: windows-latest
             vcpkg_triplet: x64-mingw-static
           - name: macOS Clang

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -35,9 +35,9 @@ jobs:
             dependencies_extras: mingw-w64
             vcpkg_triplet: x64-mingw-static
           # Use autotools_msys2.yml for Windows MinGW due to siginificant differences
-          # - name: Windows MinGW
-          #  os: windows-latest
-          #  vcpkg_triplet: x64-mingw-static
+           - name: Windows MinGW
+            os: windows-latest
+            vcpkg_triplet: x64-mingw-static
           - name: macOS Clang
             os: macOS-latest
             vcpkg_triplet: arm64-osx


### PR DESCRIPTION
I created this PR to text whether, with our latest autotools update, `./configure` would run out of the box with MinGW. Previously we were getting errors during build.