### PR TITLE
Fix CMake CI

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -60,7 +60,7 @@ jobs:
         appendedCacheKey: ${{ hashFiles( '**/vcpkg.json' ) }}
         additionalCachedPaths: build/vcpkg_installed
         # vcpkg commit: [libxml2] Fix ICU support option, hash: ca9ac0b, date: Dec 1, 2023, https://github.com/microsoft/vcpkg/commits
-        #vcpkgGitCommitId: ca9ac0ba65965937fb66783c4f726c2c755ad9d9
+        vcpkgGitCommitId: ca9ac0ba65965937fb66783c4f726c2c755ad9d9
         # Required when using vcpkg.json manifest in repository
         setupOnly: true
     # test configure and build

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -60,7 +60,7 @@ jobs:
         appendedCacheKey: ${{ hashFiles( '**/vcpkg.json' ) }}
         additionalCachedPaths: build/vcpkg_installed
         # vcpkg commit: [libxml2] Fix ICU support option, hash: ca9ac0b, date: Dec 1, 2023, https://github.com/microsoft/vcpkg/commits
-        vcpkgGitCommitId: ca9ac0ba65965937fb66783c4f726c2c755ad9d9
+        #vcpkgGitCommitId: ca9ac0ba65965937fb66783c4f726c2c755ad9d9
         # Required when using vcpkg.json manifest in repository
         setupOnly: true
     # test configure and build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         path: ${{ matrix.asio_sdk_cache_path }}
         key: ${{ hashFiles('.github/asiosdk-version.txt') }}
-               
+
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11
       if: ${{ matrix.vcpkg_triplet }} != null
@@ -87,11 +87,11 @@ jobs:
         vcpkgTriplet: ${{ matrix.vcpkg_triplet }}
         appendedCacheKey: ${{ hashFiles( '**/vcpkg.json' ) }}
         additionalCachedPaths: build/vcpkg_installed
-        # vcpkg commit: [libxml2] Fix ICU support option, hash: ca9ac0b, date: Dec 1, 2023, https://github.com/microsoft/vcpkg/commits
+        # latest vcpkg commit as of Aug 29, 2025, https://github.com/microsoft/vcpkg/commits
         vcpkgGitCommitId: 5300a2a461a53b76405db4fcbe6aeb0eea43935d
         # Required when using vcpkg.json manifest in repository
         setupOnly: true
-        
+
     - name: Configure PortAudio library
       run: cmake
            -G "${{ matrix.cmake_generator }}"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,7 +80,7 @@ jobs:
         key: ${{ hashFiles('.github/asiosdk-version.txt') }}
                
     - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v7
+      uses: lukka/run-vcpkg@v11
       if: ${{ matrix.vcpkg_triplet }} != null
       with:
         vcpkgDirectory: ${{ github.workspace }}/../vcpkg
@@ -88,7 +88,7 @@ jobs:
         appendedCacheKey: ${{ hashFiles( '**/vcpkg.json' ) }}
         additionalCachedPaths: build/vcpkg_installed
         # vcpkg commit: [libxml2] Fix ICU support option, hash: ca9ac0b, date: Dec 1, 2023, https://github.com/microsoft/vcpkg/commits
-        vcpkgGitCommitId: ca9ac0ba65965937fb66783c4f726c2c755ad9d9
+        vcpkgGitCommitId: 5300a2a461a53b76405db4fcbe6aeb0eea43935d
         # Required when using vcpkg.json manifest in repository
         setupOnly: true
         


### PR DESCRIPTION
CMake CI is failing with the following error:

Seems to be failing on msys download:
`https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst`

Latest is:
`https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4-3.4.10-5-x86_64.pkg.tar.zst`

See:
https://packages.msys2.org/packages/msys2-runtime-3.4?variant=x86_64

```
40s
Run cmake -G "Visual Studio [1](https://github.com/PortAudio/portaudio/actions/runs/17140627509/job/48627151449?pr=1061#step:6:1)7 2022" -DPA_USE_ASIO=ON -DASIO_SDK_ZIP_PATH="asiosdk.zip" -DCMAKE_TOOLCHAIN_FILE=D:\a\portaudio\portaudio/../vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=D:\a\portaudio\portaudio/../out -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVCPKG_TARGET_TRIPLET=x64-windows -DPA_USE_SKELETON=ON -DPA_BUILD_TESTS=ON -DPA_BUILD_EXAMPLES=ON -DPA_WARNINGS_ARE_ERRORS=ON -S . -B D:\a\portaudio\portaudio/build
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


CMake Deprecation Warning at D:/a/portaudio/vcpkg/scripts/buildsystems/vcpkg.cmake:40 (cmake_policy):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineSystem.cmake:146 (include)
  CMakeLists.txt:2 (project)


-- Running vcpkg install
Detecting compiler hash for triplet x64-windows...
The following packages will be built and installed:
    jack2:x64-windows -> 1.9.22
    pthreads:x64-windows -> 3.0.0#14
    tre:x64-windows -> 0.8.0#6
    vcpkg-cmake:x64-windows -> 2023-05-04
    vcpkg-cmake-config:x64-windows -> 2022-02-06#1
A suitable version of 7zip was not found (required v23.1.0) Downloading portable 7zip 23.1.0...
Downloading 7zip...
https://www.7-zip.org/a/7z2301-extra.7z->D:\a\portaudio\vcpkg\downloads\7z2301-extra.7z
Downloading https://www.7-zip.org/a/7z2301-extra.7z
Extracting 7zip...
Restored 0 package(s) from C:\Users\runneradmin\AppData\Local\vcpkg\archives in 198 us. Use --debug to see more details.
Installing 1/5 vcpkg-cmake:x64-windows...
Building vcpkg-cmake:x64-windows...
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg_cmake_build.cmake
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg_cmake_install.cmake
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/vcpkg-port-config.cmake
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake_x64-windows/share/vcpkg-cmake/copyright
-- Performing post-build validation
Stored binaries in 1 destinations in 20.7 ms.
Elapsed time to handle vcpkg-cmake:x64-windows: 59.1 ms
Installing 2/5 vcpkg-cmake-config:x64-windows...
Building vcpkg-cmake-config:x64-windows...
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake-config_x64-windows/share/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake-config_x64-windows/share/vcpkg-cmake-config/vcpkg-port-config.cmake
-- Installing: D:/a/portaudio/vcpkg/packages/vcpkg-cmake-config_x64-windows/share/vcpkg-cmake-config/copyright
-- Performing post-build validation
Stored binaries in 1 destinations in 17 ms.
Elapsed time to handle vcpkg-cmake-config:x64-windows: 51.2 ms
Installing 3/5 jack2:x64-windows...
Building jack2:x64-windows...
-- Downloading https://github.com/jackaudio/jack2/archive/v1.9.22.tar.gz -> jackaudio-jack2-v1.9.22.tar.gz...
-- Extracting source D:/a/portaudio/vcpkg/downloads/jackaudio-jack2-v1.9.22.tar.gz
-- Using source at D:/a/portaudio/vcpkg/buildtrees/jack2/src/v1.9.22-81016f24e4.clean
CMake Warning (dev) at scripts/cmake/vcpkg_find_acquire_program.cmake:70 (cmake_parse_arguments):
  The INTERPRETER keyword was followed by an empty string or no value at all.
  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  arg_INTERPRETER variable rather than setting it to an empty string.
Call Stack (most recent call first):
  scripts/cmake/vcpkg_find_acquire_program.cmake:139 (z_vcpkg_find_acquire_program_find_internal)
  D:/a/portaudio/portaudio/build/vcpkg_installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake:104 (vcpkg_find_acquire_program)
  ports/jack2/portfile.cmake:16 (vcpkg_cmake_configure)
  scripts/ports.cmake:170 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at scripts/cmake/vcpkg_find_acquire_program.cmake:30 (cmake_parse_arguments):
  The INTERPRETER keyword was followed by an empty string or no value at all.
  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  arg_INTERPRETER variable rather than setting it to an empty string.
Call Stack (most recent call first):
  scripts/cmake/vcpkg_find_acquire_program.cmake:145 (z_vcpkg_find_acquire_program_find_external)
  D:/a/portaudio/portaudio/build/vcpkg_installed/x64-windows/share/vcpkg-cmake/vcpkg_cmake_configure.cmake:104 (vcpkg_find_acquire_program)
  ports/jack2/portfile.cmake:16 (vcpkg_cmake_configure)
  scripts/ports.cmake:170 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found external ninja('1.[12](https://github.com/PortAudio/portaudio/actions/runs/17140627509/job/48627151449?pr=1061#step:6:13).1').
-- Configuring x64-windows
-- Building x64-windows-dbg
-- Building x64-windows-rel
-- Fixing pkgconfig file: D:/a/portaudio/vcpkg/packages/jack2_x64-windows/lib/pkgconfig/jack.pc
-- Downloading https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-pkgconf-1~2.1.0-1-any.pkg.tar.zst;https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-pkgconf-1~2.1.0-1-any.pkg.tar.zst;https://mirror.yandex.ru/mirrors/msys2/mingw/mingw64/mingw-w64-x86_64-pkgconf-1~2.1.0-1-any.pkg.tar.zst;https://mirrors.tuna.tsinghua.edu.cn/msys2/mingw/mingw64/mingw-w64-x86_64-pkgconf-1~2.1.0-1-any.pkg.tar.zst;https://mirrors.ustc.edu.cn/msys2/mingw/mingw64/mingw-w64-x86_64-pkgconf-1~2.1.0-1-any.pkg.tar.zst;https://mirror.selfnet.de/msys2/mingw/mingw64/mingw-w64-x86_64-pkgconf-1~2.1.0-1-any.pkg.tar.zst -> mingw-w64-x86_64-pkgconf-1~2.1.0-1-any.pkg.tar.zst...
-- Downloading https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst;https://repo.msys2.org/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst;https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst;https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst;https://mirrors.ustc.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst;https://mirror.selfnet.de/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst -> msys2-msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst...
[DEBUG] To include the environment variables in debug output, pass --debug-env
[DEBUG] Trying to load bundleconfig from D:\a\portaudio\vcpkg\vcpkg-bundle.json
[DEBUG] Failed to open: D:\a\portaudio\vcpkg\vcpkg-bundle.json
[DEBUG] Bundle config: readonly=false, usegitregistry=false, embeddedsha=nullopt, deployment=Git, vsversion=nullopt
[DEBUG] Metrics enabled.
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Feature flag 'dependencygraph' unset
Downloading https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst
Downloading https://repo.msys2.org/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst
Downloading https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst
Downloading https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst
Downloading https://mirrors.ustc.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst
Downloading https://mirror.selfnet.de/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst
error: Failed to download from mirror set
error: https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst: failed: status code 404
error: https://repo.msys2.org/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirror.yandex.ru/mirrors/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirrors.tuna.tsinghua.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirrors.ustc.edu.cn/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst: failed: status code 404
error: https://mirror.selfnet.de/msys2/msys/x86_64/msys2-runtime-3.4.9-3-x86_64.pkg.tar.zst: failed: status code 404
[DEBUG] D:\a\_work\1\s\src\vcpkg\base\downloads.cpp(1048): 
[DEBUG] Time in subprocesses: 0us
[DEBUG] Time in parsing JSON: 5us
[DEBUG] Time in JSON reader: 0us
[DEBUG] Time in filesystem: [14](https://github.com/PortAudio/portaudio/actions/runs/17140627509/job/48627151449?pr=1061#step:6:15)33us
[DEBUG] Time in loading ports: 0us
[DEBUG] Exiting after 9.3 s (9341487us)

CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:32 (message):

```

https://github.com/PortAudio/portaudio/actions/runs/17140627509/job/48627151449?pr=1061