### PR TITLE
ALSA: set buffer time when testing formats

### DIFF
--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -1828,7 +1828,7 @@ static PaError TestParameters( const PaUtilHostApiRepresentation *hostApi, const
     /*
      * Intel HDA driver doesn't set PCM rule to limit maximum size of buffer.
      * This can result in a request for too large a buffer size.
-     * That can cause memory allocation error in ALSA PCM core, at least Linux kernel 5.8.
+     * That can cause a memory allocation error in ALSA PCM core, at least it does in Linux kernel 5.8.
      * As a workaround, limit buffer size to a reasonable value.
      */
     {


### PR DESCRIPTION
This prevents an ENOMEM error on some devices when the buffer size is unspecified when testing formats.

Fixes #526