### PR TITLE
macos: fix unused symbol warnings in patest_converters.c

### DIFF
--- a/test/patest_converters.c
+++ b/test/patest_converters.c
@@ -70,47 +70,10 @@
 static PaSampleFormat sampleFormats_[ SAMPLE_FORMAT_COUNT ] =
     { paFloat32, paInt32, paInt24, paInt16, paInt8, paUInt8 }; /* all standard PA sample formats */
 
-static const char* sampleFormatNames_[SAMPLE_FORMAT_COUNT] =
-    { "paFloat32", "paInt32", "paInt24", "paInt16", "paInt8", "paUInt8" };
-
-
 static const char* abbreviatedSampleFormatNames_[SAMPLE_FORMAT_COUNT] =
     { "f32", "i32", "i24", "i16", " i8", "ui8" };
 
-
 PaError My_Pa_GetSampleSize( PaSampleFormat format );
-
-/*
-    available flags are paClipOff and paDitherOff
-    clipping is usually applied for float -> int conversions
-    dither is usually applied for all downconversions (ie anything but 8bit->8bit conversions
-*/
-
-static int CanClip( PaSampleFormat sourceFormat, PaSampleFormat destinationFormat )
-{
-    if( sourceFormat == paFloat32 && destinationFormat != sourceFormat )
-        return 1;
-    else
-        return 0;
-}
-
-static int CanDither( PaSampleFormat sourceFormat, PaSampleFormat destinationFormat )
-{
-    if( sourceFormat < destinationFormat && sourceFormat != paInt8 )
-        return 1;
-    else
-        return 0;
-}
-
-static void GenerateOneCycleSineReference( double *out, int frameCount, int strideFrames )
-{
-    int i;
-    for( i=0; i < frameCount; ++i ){
-        *out = sin( ((double)i/(double)frameCount) * 2. * M_PI );
-        out += strideFrames;
-    }
-}
-
 
 static void GenerateOneCycleSine( PaSampleFormat format, void *buffer, int frameCount, int strideFrames )
 {
@@ -266,7 +229,6 @@ int main( int argc, const char **argv )
             for( destinationFormatIndex = 0; destinationFormatIndex < SAMPLE_FORMAT_COUNT; ++destinationFormatIndex ){
                 sourceFormat = sampleFormats_[sourceFormatIndex];
                 destinationFormat = sampleFormats_[destinationFormatIndex];
-                //printf( "%s -> %s ", sampleFormatNames_[ sourceFormatIndex ], sampleFormatNames_[ destinationFormatIndex ] );
 
                 converter = PaUtil_SelectConverter( sourceFormat, destinationFormat, flags );
 


### PR DESCRIPTION
Fixes #1060