### PR TITLE
cmake: change logic for PA_BUILD_SHARED_LIBS to default ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(PortAudio VERSION 19.8)
 # General PortAudio stuff
 #
 
+# Policy: By default, build PortAudio as a shared library.
+# There are two ways to override the default behavior:
+# 1. User can select shared or static PortAudio library build by explicitly defining PA_BUILD_SHARED_LIBS to ON or OFF (e.g. on the command line or an importing project)
+# 2. If PA_BUILD_SHARED_LIBS is not set we respect the standard CMake BUILD_SHARED_LIBS variable if it is set.
 if (NOT DEFINED PA_BUILD_SHARED_LIBS)
     if (DEFINED BUILD_SHARED_LIBS)
         set(PA_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})


### PR DESCRIPTION
If PA_BUILD_SHARED_LIBS is already defined then keep the original value. If not defined, and if BUILD_SHARED_LIBS is defined then use that value.
    Otherwise set PA_BUILD_SHARED_LIBS=ON.

The previous default was OFF.
In PortAudio v19.7 the default was ON.

Fixes #918