### PR TITLE
Remove non-functional SGI/Irix host-API references

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,34 +357,6 @@ case "${host_os}" in
         DLL_LIBS="${DLL_LIBS} -lwinmm"
         ;;
 
-  irix* )
-        dnl SGI IRIX audio library (AL) configuration (Pieter, oct 2-13, 2003).
-        dnl The 'dmedia' library is needed to read the Unadjusted System Time (UST).
-        dnl
-        AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR([IRIX posix thread library not found!]))
-        AC_CHECK_LIB(audio,   alOpenPort,     , AC_MSG_ERROR([IRIX audio library not found!]))
-        AC_CHECK_LIB(dmedia,  dmGetUST,       , AC_MSG_ERROR([IRIX digital media library not found!]))
-
-        dnl See the '#ifdef PA_USE_SGI' in file pa_unix/pa_unix_hostapis.c
-        dnl which selects the appropriate PaXXX_Initialize() function.
-        dnl
-        AC_DEFINE(PA_USE_SGI,1)
-
-        CFLAGS="$CFLAGS -I\$(top_srcdir)/src/os/unix"
-
-        dnl The _REENTRANT option for pthread safety. Perhaps not necessary but it 'll do no harm.
-        dnl
-        THREAD_CFLAGS="-D_REENTRANT"
-
-        OTHER_OBJS="pa_sgi/pa_sgi.o src/os/unix/pa_unix_hostapis.o src/os/unix/pa_unix_util.o"
-
-        dnl SGI books say -lpthread should be the last of the libs mentioned.
-        dnl
-        LIBS="-lm -ldmedia -laudio -lpthread"
-        PADLL="libportaudio.so"
-        SHARED_FLAGS=""
-        ;;
-
   *)
         dnl Unix configuration
 

--- a/src/common/pa_hostapi.h
+++ b/src/common/pa_hostapi.h
@@ -139,13 +139,6 @@ are defaulted to 1.
 #define PA_USE_PULSEAUDIO 1
 #endif
 
-#ifndef PA_USE_SGI
-#define PA_USE_SGI 0
-#elif (PA_USE_SGI != 0) && (PA_USE_SGI != 1)
-#undef PA_USE_SGI
-#define PA_USE_SGI 1
-#endif
-
 #ifndef PA_USE_COREAUDIO
 #define PA_USE_COREAUDIO 0
 #elif (PA_USE_COREAUDIO != 0) && (PA_USE_COREAUDIO != 1)

--- a/src/os/unix/pa_unix_hostapis.c
+++ b/src/os/unix/pa_unix_hostapis.c
@@ -48,8 +48,6 @@ PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
 PaError PaSndio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaOSS_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaAudioIO_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
-/* Added for IRIX, Pieter, oct 2, 2003: */
-PaError PaSGI_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 /* Linux AudioScience HPI */
 PaError PaAsiHpi_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaMacCore_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
@@ -96,10 +94,6 @@ PaUtilHostApiInitializer *paHostApiInitializers[] =
 
 #if PA_USE_JACK
         PaJack_Initialize,
-#endif
-                    /* Added for IRIX, Pieter, oct 2, 2003: */
-#if PA_USE_SGI
-        PaSGI_Initialize,
 #endif
 
 #if PA_USE_ASIHPI


### PR DESCRIPTION
SGI/Irix was never ported to the v19 API, but there was still space for it in the host API configuration. This PR removes the remaining references to SGI/Irix from the codebase.