### PR TITLE
Fix SHARED build for paqa_dither.c

### DIFF
--- a/qa/CMakeLists.txt
+++ b/qa/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_test(paqa_errs)
 add_test(paqa_devs)
-add_test(paqa_dither)
+if(LINK_PRIVATE_SYMBOLS)
+  add_test(paqa_dither)
+endif()
 add_test(paqa_latency)
 
 subdirs(loopback)


### PR DESCRIPTION
That program calls internal functions that are not visible in the SHARED library. So it can only be built with the STATIC library.

Fixes #1094