### PR TITLE
PulseAudio: Fix device name handling for sinks and sources

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -802,7 +802,7 @@ PaError PaPulseAudio_StartStreamCb( PaStream * s )
         if( result == paNoError && stream->inputDevice != defaultInputDevice )
         {
             pulseaudioName = pulseaudioHostApi->
-                        pulseaudioDeviceNames[stream->inputDevice];
+                                deviceInfoArray[stream->inputDevice].name;
         }
 
         if ( result == paNoError )
@@ -882,7 +882,7 @@ PaError PaPulseAudio_StartStreamCb( PaStream * s )
             if( result == paNoError && stream->outputDevice != defaultOutputDevice )
             {
                 pulseaudioName = pulseaudioHostApi->
-                                    pulseaudioDeviceNames[stream->outputDevice];
+                                    deviceInfoArray[stream->outputDevice].name;
             }
 
             if(result == paNoError)


### PR DESCRIPTION
PR #1090, which changed how device names are handled, broke the process of selecting the correct device when connecting to playback sinks or recording sources.

This commit addresses this issue by ensuring proper device selection during connection.