### PR TITLE
[autotools] Update cpp bindings's Makefile.in

### DIFF
--- a/bindings/cpp/Makefile.in
+++ b/bindings/cpp/Makefile.in
@@ -184,8 +184,10 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/portaudiocpp.pc.in \
-	AUTHORS COPYING ChangeLog INSTALL NEWS README compile \
-	config.guess config.sub install-sh ltmain.sh missing
+	$(top_srcdir)/../../compile $(top_srcdir)/../../config.guess \
+	$(top_srcdir)/../../config.sub $(top_srcdir)/../../install-sh \
+	$(top_srcdir)/../../ltmain.sh $(top_srcdir)/../../missing \
+	AUTHORS COPYING ChangeLog INSTALL NEWS README
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/bindings/cpp/bin/Makefile.in
+++ b/bindings/cpp/bin/Makefile.in
@@ -128,7 +128,7 @@ AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
 am__v_at_1 = 
-depcomp = $(SHELL) $(top_srcdir)/depcomp
+depcomp = $(SHELL) $(top_srcdir)/../../depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = $(BINDIR)/$(DEPDIR)/devs.Po \
 	$(BINDIR)/$(DEPDIR)/sine.Po
@@ -175,7 +175,7 @@ am__define_uniq_tagged_files = \
   unique=`for i in $$list; do \
     if test -f "$$i"; then echo $$i; else echo $(srcdir)/$$i; fi; \
   done | $(am__uniquify_input)`
-am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/depcomp
+am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/../../depcomp
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/bindings/cpp/lib/Makefile.in
+++ b/bindings/cpp/lib/Makefile.in
@@ -162,7 +162,7 @@ AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
 am__v_at_1 = 
-depcomp = $(SHELL) $(top_srcdir)/depcomp
+depcomp = $(SHELL) $(top_srcdir)/../../depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = $(SRCDIR)/$(DEPDIR)/BlockingStream.Plo \
 	$(SRCDIR)/$(DEPDIR)/CFunCallbackStream.Plo \
@@ -223,7 +223,7 @@ am__define_uniq_tagged_files = \
   unique=`for i in $$list; do \
     if test -f "$$i"; then echo $$i; else echo $(srcdir)/$$i; fi; \
   done | $(am__uniquify_input)`
-am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/depcomp
+am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/../../depcomp
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@


### PR DESCRIPTION
Running autoreconf for cpp bindings modified Makefile.in files. The subtle changes in the paths are required to find required auxiliary files: config.guess config.sub ltmain.sh compile missing install-sh

Fixes #1091 