### PR TITLE
pulseaudio: Add missing usleep to PaPulseAudio_ReleaseOperation

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -113,15 +113,13 @@ void PaPulseAudio_ReleaseOperation(PaPulseAudio_HostApiRepresentation *hostapi,
      * of a second then 3 seconds (which is very long time to wait
      * for operation to end) is then 3000000 us
      */
-    uint32_t wait = (3 * 1000000);
+    int32_t wait_us = (3 * 1000000);
+    const uint32_t sleep_us = 100;
     pa_operation *localOperation = (*operation);
     pa_operation_state_t localOperationState = PA_OPERATION_RUNNING;
 
-    // As mainly operation is done when running locally
-    // done after 1-3 then 1000 is enough to wait if
-    // something goes wrong
 
-    while( wait > 0 )
+    while( wait_us > 0 )
     {
 
         PaPulseAudio_Lock( hostapi->mainloop );
@@ -139,8 +137,8 @@ void PaPulseAudio_ReleaseOperation(PaPulseAudio_HostApiRepresentation *hostapi,
         }
         PaPulseAudio_UnLock( hostapi->mainloop );
 
-        wait -= 100;
-        usleep(100);
+        wait_us -= sleep_us;
+        usleep(sleep_us);
     }
 
     // No wait if operation have been DONE or CANCELLED


### PR DESCRIPTION
Add missing usleep to PaPulseAudio_ReleaseOperation and make sure that maximum waiting for operation end is 3 seconds.