### PR TITLE
pulseaudio: Remove missedBytes variable as it's not used anywhere

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -351,29 +351,6 @@ static int _PaPulseAudio_ProcessAudio(PaPulseAudio_Stream *stream,
          */
         PA_PULSEAUDIO_IS_ERROR( stream, paStreamIsStopped )
 
-        /* There is only Record stream so
-         * see if we have enough stuff to feed record stream
-         * If not then bail out.
-         */
-        if( isInputCb &&
-            PaUtil_GetRingBufferReadAvailable(&stream->inputRing) < pulseaudioInputBytes )
-        {
-            if(isOutputCb && (pulseaudioOutputWritten < length) && !stream->missedBytes)
-            {
-                stream->missedBytes = length - pulseaudioOutputWritten;
-            }
-            else
-            {
-                stream->missedBytes = 0;
-            }
-            break;
-        }
-        else if( pulseaudioOutputWritten >= length)
-        {
-            stream->missedBytes = 0;
-            break;
-        }
-
         if(  stream->outputStream )
         {
             PaPulseAudio_updateTimeInfo( stream->outputStream,
@@ -735,7 +712,6 @@ PaError PaPulseAudio_StartStreamCb( PaStream * s )
     stream->isStopped = 1;
     stream->pulseaudioIsActive = 1;
     stream->pulseaudioIsStopped = 0;
-    stream->missedBytes = 0;
 
     /* Ready the processor */
     PaUtil_ResetBufferProcessor( &stream->bufferProcessor );
@@ -987,8 +963,6 @@ static PaError RequestStop( PaPulseAudio_Stream * stream,
     stream->isStopped = 1;
     stream->pulseaudioIsActive = 0;
     stream->pulseaudioIsStopped = 1;
-
-    stream->missedBytes = 0;
 
     /* Test if there is something that we can play */
     if( stream->outputStream

--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_internal.h
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_internal.h
@@ -143,8 +143,6 @@ typedef struct PaPulseAudio_Stream
 
     PaUtilRingBuffer inputRing;
 
-    size_t missedBytes;
-
     /* Used in communication between threads
      *
      * State machine works like this:


### PR DESCRIPTION
In Pulseaudio there is formal callback when buffer under runs. Rely on callback and remove not needed missedBytes variable.