### PR TITLE
[Windows] Fix Windows ARM64 compilation

### DIFF
--- a/src/common/pa_memorybarrier.h
+++ b/src/common/pa_memorybarrier.h
@@ -101,7 +101,12 @@
 #elif (_MSC_VER >= 1400) && !defined(_WIN32_WCE)
 #   include <intrin.h>
 /* note that MSVC intrinsics _ReadWriteBarrier(), _ReadBarrier(), _WriteBarrier() are just compiler barriers *not* memory barriers */
-#   if defined(_M_IX86) || defined(_M_X64)
+#   if defined(_M_ARM64)
+        /* https://learn.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=msvc-170 */
+#       define PaUtil_FullMemoryBarrier()  __dmb(_ARM64_BARRIER_ISH)
+#       define PaUtil_ReadMemoryBarrier()  __dmb(_ARM64_BARRIER_ISHLD)
+#       define PaUtil_WriteMemoryBarrier() __dmb(_ARM64_BARRIER_ISHST)
+#   else
 #       pragma intrinsic(_ReadWriteBarrier)
 #       pragma intrinsic(_ReadBarrier)
 #       pragma intrinsic(_WriteBarrier)
@@ -109,13 +114,6 @@
 #       define PaUtil_FullMemoryBarrier()  _ReadWriteBarrier()
 #       define PaUtil_ReadMemoryBarrier()  _ReadBarrier()
 #       define PaUtil_WriteMemoryBarrier() _WriteBarrier()
-#   elif defined(_M_ARM64)
-        /* https://learn.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=msvc-170 */
-#       define PaUtil_FullMemoryBarrier()  __dmb(_ARM64_BARRIER_ISH)
-#       define PaUtil_ReadMemoryBarrier()  __dmb(_ARM64_BARRIER_ISHLD)
-#       define PaUtil_WriteMemoryBarrier() __dmb(_ARM64_BARRIER_ISHST)
-#   else
-#       error Unsupported MSVC architecture
 #   endif
 #elif defined(_WIN32_WCE)
 #   define PaUtil_FullMemoryBarrier()


### PR DESCRIPTION
Add ARM64 memory barrier definitions for MSVC.

Fixes #1101 