### PR TITLE
remove 'pa_trace.h still useful?' comment from pa_front.c

### DIFF
--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -74,7 +74,7 @@
 #include "pa_types.h"
 #include "pa_hostapi.h"
 #include "pa_stream.h"
-#include "pa_trace.h" /* still useful?*/
+#include "pa_trace.h"
 #include "pa_debugprint.h"
 
 #ifndef PA_GIT_REVISION


### PR DESCRIPTION
yes, still used and still useful.