### PR TITLE
Add Windows ARM64 support in CI

### DIFF
--- a/.github/workflows/MSBuild.yml
+++ b/.github/workflows/MSBuild.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         BUILD_CONFIGURATION: [Release]
-        BUILD_PLATFORM: [Win32, x64]
+        BUILD_PLATFORM: [Win32, x64, ARM64]
 
     steps:
     - name: Add MSBuild to PATH

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [Ubuntu-GCC, Ubuntu-MinGW, Windows-MSVC, Windows-MinGW, macOS-Clang, macOS-Clang-framework]
+        name: [Ubuntu-GCC, Ubuntu-MinGW, Windows-MSVC, Windows-MinGW, Windows-MSVC-ARM64, Windows-MinGW-ARM64, macOS-Clang, macOS-Clang-framework]
         shared_libs: [ON, OFF]
         include:
           - name: Ubuntu-GCC
@@ -41,6 +41,30 @@ jobs:
           - name: Windows-MinGW
             os: windows-latest
             vcpkg_triplet: x64-mingw-static
+            cmake_generator: "MinGW Makefiles"
+            # ASIO_SDK_ZIP_PATH needs to be quoted or CMake will save the download to
+            # asiosdk instead of asiosdk.zip.
+            asio_sdk_cache_path: "asiosdk.zip"
+            # Somehow CMake fails to find the toolchain file if a relative path is used on Windows.
+            cmake_options:
+              -DPA_USE_ASIO=ON
+              -DASIO_SDK_ZIP_PATH="asiosdk.zip"
+          - name: Windows-MSVC-ARM64
+            os: windows-11-arm
+            vcpkg_triplet: arm64-windows
+            cmake_arch: ARM64
+            cmake_generator: "Visual Studio 17 2022"
+            # ASIO_SDK_ZIP_PATH needs to be quoted or CMake will save the download to
+            # asiosdk instead of asiosdk.zip.
+            asio_sdk_cache_path: "asiosdk.zip"
+            # Somehow CMake fails to find the toolchain file if a relative path is used on Windows.
+            cmake_options:
+              -DPA_USE_ASIO=ON
+              -DASIO_SDK_ZIP_PATH="asiosdk.zip"
+          - name: Windows-MinGW-ARM64
+            os: windows-11-arm
+            vcpkg_triplet: arm64-mingw-static
+            # arch is implicit by using the arm64-* vcpkg triplet; cmake_arch is not needed for MinGW generators
             cmake_generator: "MinGW Makefiles"
             # ASIO_SDK_ZIP_PATH needs to be quoted or CMake will save the download to
             # asiosdk instead of asiosdk.zip.
@@ -95,9 +119,11 @@ jobs:
         setupOnly: true
 
     - name: Configure PortAudio library
+      # If cmake_arch is not defined, the toolchain default architecture is used
       run: cmake
            -G "${{ matrix.cmake_generator }}"
            ${{ matrix.cmake_options }}
+           ${{ matrix.cmake_arch && format('-A {0}', matrix.cmake_arch) || '' }}
            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/../vcpkg/scripts/buildsystems/vcpkg.cmake
            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/../out
            -DCMAKE_BUILD_TYPE=${{ env.cmake_build_type }}

--- a/msvc/portaudio.sln
+++ b/msvc/portaudio.sln
@@ -7,24 +7,33 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
+		Debug|ARM64 = Debug|ARM64
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
+		Release|ARM64 = Release|ARM64
 		ReleaseMinDependency|Win32 = ReleaseMinDependency|Win32
 		ReleaseMinDependency|x64 = ReleaseMinDependency|x64
+		ReleaseMinDependency|ARM64 = ReleaseMinDependency|ARM64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Debug|Win32.ActiveCfg = Debug|Win32
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Debug|Win32.Build.0 = Debug|Win32
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Debug|x64.ActiveCfg = Debug|x64
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Debug|x64.Build.0 = Debug|x64
+		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Debug|ARM64.Build.0 = Debug|ARM64
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Release|Win32.ActiveCfg = Release|Win32
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Release|Win32.Build.0 = Release|Win32
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Release|x64.ActiveCfg = Release|x64
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Release|x64.Build.0 = Release|x64
+		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Release|ARM64.ActiveCfg = Release|ARM64
+		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.Release|ARM64.Build.0 = Release|ARM64
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.ReleaseMinDependency|Win32.ActiveCfg = ReleaseMinDependency|Win32
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.ReleaseMinDependency|Win32.Build.0 = ReleaseMinDependency|Win32
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.ReleaseMinDependency|x64.ActiveCfg = ReleaseMinDependency|x64
 		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.ReleaseMinDependency|x64.Build.0 = ReleaseMinDependency|x64
+		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.ReleaseMinDependency|ARM64.ActiveCfg = ReleaseMinDependency|ARM64
+		{0A18A071-125E-442F-AFF7-A3F68ABECF99}.ReleaseMinDependency|ARM64.Build.0 = ReleaseMinDependency|ARM64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/msvc/portaudio.vcproj
+++ b/msvc/portaudio.vcproj
@@ -13,6 +13,9 @@
 		<Platform
 			Name="x64"
 		/>
+		<Platform
+			Name="ARM64"
+		/>
 	</Platforms>
 	<ToolFiles>
 	</ToolFiles>
@@ -214,6 +217,78 @@
 			/>
 		</Configuration>
 		<Configuration
+			Name="Release|ARM64"
+			OutputDirectory="$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
+			ConfigurationType="2"
+			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC60.vsprops"
+			UseOfMFC="0"
+			ATLMinimizesCRunTimeLibraryUsage="false"
+			>
+			<Tool Name="VCPreBuildEventTool" />
+			<Tool Name="VCCustomBuildTool" />
+			<Tool Name="VCXMLDataGeneratorTool" />
+			<Tool Name="VCWebServiceProxyGeneratorTool" />
+			<Tool
+				Name="VCMIDLTool"
+				PreprocessorDefinitions="NDEBUG"
+				MkTypLibCompatible="true"
+				SuppressStartupBanner="true"
+				TargetEnvironment="5"
+				TypeLibraryName=".\Release_x86/portaudio.tlb"
+				HeaderFileName=""
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="2"
+				InlineFunctionExpansion="1"
+				EnableIntrinsicFunctions="true"
+				FavorSizeOrSpeed="1"
+				AdditionalIncludeDirectories="..\src\common;..\include;.\;..\src\os\win"
+				PreprocessorDefinitions="_WIN64;_ARM64;NDEBUG;_USRDLL;PA_ENABLE_DEBUG_OUTPUT;_CRT_SECURE_NO_DEPRECATE;PAWIN_USE_WDMKS_DEVICE_INFO;PA_USE_ASIO=0;PA_USE_DS=0;PA_USE_WMME=1;PA_USE_WASAPI=1;PA_USE_WDMKS=1"
+				StringPooling="true"
+				RuntimeLibrary="2"
+				EnableFunctionLevelLinking="true"
+				PrecompiledHeaderFile="$(PlatformName)\$(ConfigurationName)\portaudio.pch"
+				AssemblerListingLocation="$(PlatformName)\$(ConfigurationName)\"
+				ObjectFile="$(PlatformName)\$(ConfigurationName)\"
+				ProgramDataBaseFileName="$(PlatformName)\$(ConfigurationName)\"
+				WarningLevel="3"
+				SuppressStartupBanner="true"
+			/>
+			<Tool Name="VCManagedResourceCompilerTool" />
+			<Tool
+				Name="VCResourceCompilerTool"
+				PreprocessorDefinitions="NDEBUG"
+				Culture="1033"
+			/>
+			<Tool Name="VCPreLinkEventTool" />
+			<Tool
+				Name="VCLinkerTool"
+				AdditionalDependencies="ksuser.lib"
+				OutputFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.dll"
+				LinkIncremental="1"
+				SuppressStartupBanner="true"
+				AdditionalLibraryDirectories=""
+				ModuleDefinitionFile=".\portaudio.def"
+				ProgramDatabaseFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.pdb"
+				ImportLibrary="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.lib"
+				TargetMachine="7"
+			/>
+			<Tool Name="VCALinkTool" />
+			<Tool Name="VCManifestTool" />
+			<Tool Name="VCXDCMakeTool" />
+			<Tool
+				Name="VCBscMakeTool"
+				SuppressStartupBanner="true"
+				OutputFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.bsc"
+			/>
+			<Tool Name="VCFxCopTool" />
+			<Tool Name="VCAppVerifierTool" />
+			<Tool Name="VCWebDeploymentTool" />
+			<Tool Name="VCPostBuildEventTool" />
+		</Configuration>
+		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="$(PlatformName)\$(ConfigurationName)"
 			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
@@ -391,6 +466,102 @@
 				Name="VCBscMakeTool"
 				SuppressStartupBanner="true"
 				OutputFile="$(PlatformName)\$(ConfigurationName)/portaudio_x64.bsc"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCWebDeploymentTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
+		<Configuration
+			Name="Debug|ARM64"
+			OutputDirectory="$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
+			ConfigurationType="2"
+			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC60.vsprops"
+			UseOfMFC="0"
+			ATLMinimizesCRunTimeLibraryUsage="false"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				PreprocessorDefinitions="_DEBUG"
+				MkTypLibCompatible="true"
+				SuppressStartupBanner="true"
+				TargetEnvironment="5"
+				TypeLibraryName=".\Debug_arm64/portaudio.tlb"
+				HeaderFileName=""
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="0"
+				AdditionalIncludeDirectories="..\src\common,..\include,.\,..\src\os\win"
+				PreprocessorDefinitions="_WIN64;_ARM64;_DEBUG;_USRDLL;PA_ENABLE_DEBUG_OUTPUT;_CRT_SECURE_NO_DEPRECATE;PAWIN_USE_WDMKS_DEVICE_INFO;PA_USE_ASIO=0;PA_USE_DS=0;PA_USE_WMME=1;PA_USE_WASAPI=1;PA_USE_WDMKS=1"
+				MinimalRebuild="true"
+				BasicRuntimeChecks="3"
+				RuntimeLibrary="3"
+				PrecompiledHeaderFile="$(PlatformName)\$(ConfigurationName)\portaudio.pch"
+				AssemblerListingLocation="$(PlatformName)\$(ConfigurationName)\"
+				ObjectFile="$(PlatformName)\$(ConfigurationName)\"
+				ProgramDataBaseFileName="$(PlatformName)\$(ConfigurationName)\"
+				WarningLevel="3"
+				SuppressStartupBanner="true"
+				DebugInformationFormat="3"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+				PreprocessorDefinitions="_DEBUG"
+				Culture="1033"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				AdditionalDependencies=""
+				OutputFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.dll"
+				LinkIncremental="2"
+				SuppressStartupBanner="true"
+				ModuleDefinitionFile=".\portaudio.def"
+				GenerateDebugInformation="true"
+				ProgramDatabaseFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.pdb"
+				ImportLibrary="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.lib"
+				TargetMachine="7"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+				SuppressStartupBanner="true"
+				OutputFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.bsc"
 			/>
 			<Tool
 				Name="VCFxCopTool"
@@ -601,6 +772,104 @@
 				Name="VCPostBuildEventTool"
 			/>
 		</Configuration>
+		<Configuration
+			Name="ReleaseMinDependency|ARM64"
+			OutputDirectory="$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
+			ConfigurationType="2"
+			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC60.vsprops"
+			UseOfMFC="0"
+			ATLMinimizesCRunTimeLibraryUsage="false"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				PreprocessorDefinitions="NDEBUG"
+				MkTypLibCompatible="true"
+				SuppressStartupBanner="true"
+				TargetEnvironment="5"
+				TypeLibraryName=".\Release_arm64/portaudio.tlb"
+				HeaderFileName=""
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="2"
+				InlineFunctionExpansion="1"
+				EnableIntrinsicFunctions="true"
+				FavorSizeOrSpeed="1"
+				AdditionalIncludeDirectories="..\src\common;..\include;.\;..\src\os\win"
+				PreprocessorDefinitions="_WIN64;_ARM64;NDEBUG;_USRDLL;PA_ENABLE_DEBUG_OUTPUT;_CRT_SECURE_NO_DEPRECATE;PAWIN_USE_WDMKS_DEVICE_INFO;PA_USE_ASIO=0;PA_USE_DS=0;PA_USE_WMME=1;PA_USE_WASAPI=1;PA_USE_WDMKS=1"
+				StringPooling="true"
+				RuntimeLibrary="0"
+				EnableFunctionLevelLinking="true"
+				PrecompiledHeaderFile="$(PlatformName)\$(ConfigurationName)\portaudio.pch"
+				AssemblerListingLocation="$(PlatformName)\$(ConfigurationName)\"
+				ObjectFile="$(PlatformName)\$(ConfigurationName)\"
+				ProgramDataBaseFileName="$(PlatformName)\$(ConfigurationName)\"
+				WarningLevel="3"
+				SuppressStartupBanner="true"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+				PreprocessorDefinitions="NDEBUG"
+				Culture="1033"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				AdditionalDependencies="ksuser.lib"
+				OutputFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.dll"
+				LinkIncremental="1"
+				SuppressStartupBanner="true"
+				AdditionalLibraryDirectories=""
+				ModuleDefinitionFile=".\portaudio.def"
+				ProgramDatabaseFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.pdb"
+				ImportLibrary="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.lib"
+				TargetMachine="7"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+				SuppressStartupBanner="true"
+				OutputFile="$(PlatformName)\$(ConfigurationName)\portaudio_arm64.bsc"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCWebDeploymentTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
 	</Configurations>
 	<References>
 	</References>
@@ -634,6 +903,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -652,6 +930,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -662,6 +949,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -692,6 +988,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -710,6 +1015,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -720,6 +1034,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -750,6 +1073,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -768,6 +1100,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -778,6 +1119,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -808,6 +1158,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -826,6 +1185,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -836,6 +1204,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -866,6 +1243,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -884,6 +1270,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -894,6 +1289,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -924,6 +1328,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -942,6 +1355,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -952,6 +1374,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -982,6 +1413,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -1000,6 +1440,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -1010,6 +1459,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -1040,6 +1498,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -1058,6 +1525,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -1068,6 +1544,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -1098,6 +1583,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -1116,6 +1610,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -1126,6 +1629,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -1156,6 +1668,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -1174,6 +1695,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -1184,6 +1714,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -1214,6 +1753,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Release|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="Debug|Win32"
 						>
 						<Tool
@@ -1232,6 +1780,15 @@
 						/>
 					</FileConfiguration>
 					<FileConfiguration
+						Name="Debug|ARM64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
 						Name="ReleaseMinDependency|Win32"
 						>
 						<Tool
@@ -1242,6 +1799,15 @@
 					</FileConfiguration>
 					<FileConfiguration
 						Name="ReleaseMinDependency|x64"
+						>
+						<Tool
+							Name="VCCLCompilerTool"
+							AdditionalIncludeDirectories=""
+							PreprocessorDefinitions=""
+						/>
+					</FileConfiguration>
+					<FileConfiguration
+						Name="ReleaseMinDependency|ARM64"
 						>
 						<Tool
 							Name="VCCLCompilerTool"
@@ -1279,6 +1845,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Release|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="Debug|Win32"
 							>
 							<Tool
@@ -1297,6 +1872,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Debug|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="ReleaseMinDependency|Win32"
 							>
 							<Tool
@@ -1307,6 +1891,15 @@
 						</FileConfiguration>
 						<FileConfiguration
 							Name="ReleaseMinDependency|x64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
+							Name="ReleaseMinDependency|ARM64"
 							>
 							<Tool
 								Name="VCCLCompilerTool"
@@ -1340,6 +1933,15 @@
 								/>
 							</FileConfiguration>
 							<FileConfiguration
+								Name="Release|ARM64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
 								Name="Debug|Win32"
 								>
 								<Tool
@@ -1358,6 +1960,15 @@
 								/>
 							</FileConfiguration>
 							<FileConfiguration
+								Name="Debug|ARM64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
 								Name="ReleaseMinDependency|Win32"
 								>
 								<Tool
@@ -1368,6 +1979,15 @@
 							</FileConfiguration>
 							<FileConfiguration
 								Name="ReleaseMinDependency|x64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
+								Name="ReleaseMinDependency|ARM64"
 								>
 								<Tool
 									Name="VCCLCompilerTool"
@@ -1398,6 +2018,15 @@
 								/>
 							</FileConfiguration>
 							<FileConfiguration
+								Name="Release|ARM64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
 								Name="Debug|Win32"
 								>
 								<Tool
@@ -1416,6 +2045,15 @@
 								/>
 							</FileConfiguration>
 							<FileConfiguration
+								Name="Debug|ARM64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
 								Name="ReleaseMinDependency|Win32"
 								>
 								<Tool
@@ -1426,6 +2064,15 @@
 							</FileConfiguration>
 							<FileConfiguration
 								Name="ReleaseMinDependency|x64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
+								Name="ReleaseMinDependency|ARM64"
 								>
 								<Tool
 									Name="VCCLCompilerTool"
@@ -1456,6 +2103,15 @@
 								/>
 							</FileConfiguration>
 							<FileConfiguration
+								Name="Release|ARM64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
 								Name="Debug|Win32"
 								>
 								<Tool
@@ -1474,6 +2130,15 @@
 								/>
 							</FileConfiguration>
 							<FileConfiguration
+								Name="Debug|ARM64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
 								Name="ReleaseMinDependency|Win32"
 								>
 								<Tool
@@ -1484,6 +2149,15 @@
 							</FileConfiguration>
 							<FileConfiguration
 								Name="ReleaseMinDependency|x64"
+								>
+								<Tool
+									Name="VCCLCompilerTool"
+									AdditionalIncludeDirectories="..\src\hostapi\asio\ASIOSDK\host;..\src\hostapi\asio\ASIOSDK\host\pc;..\src\hostapi\asio\ASIOSDK\common"
+									PreprocessorDefinitions=""
+								/>
+							</FileConfiguration>
+							<FileConfiguration
+								Name="ReleaseMinDependency|ARM64"
 								>
 								<Tool
 									Name="VCCLCompilerTool"
@@ -1519,6 +2193,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Release|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="Debug|Win32"
 							>
 							<Tool
@@ -1537,6 +2220,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Debug|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="ReleaseMinDependency|Win32"
 							>
 							<Tool
@@ -1547,6 +2239,15 @@
 						</FileConfiguration>
 						<FileConfiguration
 							Name="ReleaseMinDependency|x64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
+							Name="ReleaseMinDependency|ARM64"
 							>
 							<Tool
 								Name="VCCLCompilerTool"
@@ -1577,6 +2278,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Release|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="Debug|Win32"
 							>
 							<Tool
@@ -1595,6 +2305,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Debug|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="ReleaseMinDependency|Win32"
 							>
 							<Tool
@@ -1605,6 +2324,15 @@
 						</FileConfiguration>
 						<FileConfiguration
 							Name="ReleaseMinDependency|x64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
+							Name="ReleaseMinDependency|ARM64"
 							>
 							<Tool
 								Name="VCCLCompilerTool"
@@ -1639,6 +2367,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Release|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="Debug|Win32"
 							>
 							<Tool
@@ -1657,6 +2394,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Debug|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="ReleaseMinDependency|Win32"
 							>
 							<Tool
@@ -1667,6 +2413,15 @@
 						</FileConfiguration>
 						<FileConfiguration
 							Name="ReleaseMinDependency|x64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
+							Name="ReleaseMinDependency|ARM64"
 							>
 							<Tool
 								Name="VCCLCompilerTool"
@@ -1725,6 +2480,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Release|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="Debug|Win32"
 							>
 							<Tool
@@ -1743,6 +2507,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Debug|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="ReleaseMinDependency|Win32"
 							>
 							<Tool
@@ -1753,6 +2526,15 @@
 						</FileConfiguration>
 						<FileConfiguration
 							Name="ReleaseMinDependency|x64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
+							Name="ReleaseMinDependency|ARM64"
 							>
 							<Tool
 								Name="VCCLCompilerTool"
@@ -1783,6 +2565,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Release|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="Debug|Win32"
 							>
 							<Tool
@@ -1801,6 +2592,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Debug|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="ReleaseMinDependency|Win32"
 							>
 							<Tool
@@ -1811,6 +2611,15 @@
 						</FileConfiguration>
 						<FileConfiguration
 							Name="ReleaseMinDependency|x64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
+							Name="ReleaseMinDependency|ARM64"
 							>
 							<Tool
 								Name="VCCLCompilerTool"
@@ -1853,6 +2662,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Release|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="Debug|Win32"
 							>
 							<Tool
@@ -1871,6 +2689,15 @@
 							/>
 						</FileConfiguration>
 						<FileConfiguration
+							Name="Debug|ARM64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
 							Name="ReleaseMinDependency|Win32"
 							>
 							<Tool
@@ -1881,6 +2708,15 @@
 						</FileConfiguration>
 						<FileConfiguration
 							Name="ReleaseMinDependency|x64"
+							>
+							<Tool
+								Name="VCCLCompilerTool"
+								AdditionalIncludeDirectories=""
+								PreprocessorDefinitions=""
+							/>
+						</FileConfiguration>
+						<FileConfiguration
+							Name="ReleaseMinDependency|ARM64"
 							>
 							<Tool
 								Name="VCCLCompilerTool"


### PR DESCRIPTION
This PR adds Windows ARM64 support to the MSBuild and CMake CI workflows.

Changes:
- CMake
    - Added `Windows-MSVC-ARM64` and `Windows-MinGW-ARM64` jobs.
    - Configured appropriate vcpkg triplets and generators.
    - Added conditional `-A` handling for MSVC ARM64 builds.
- MSBuild
  - Added ARM64 platform configuration to `portaudio.vcproj` and `portaudio.sln`
  - Added ARM64 to the CI build matrix.
