### PR TITLE
Fix Float32_To_UInt8 undefined behavior on negative samples

### DIFF
--- a/src/common/pa_converters.c
+++ b/src/common/pa_converters.c
@@ -759,7 +759,10 @@ static void Float32_To_UInt8(
 
     while( count-- )
     {
-        unsigned char samp = (unsigned char)(128 + ((unsigned char) (*src * (127.0f))));
+        /* Cast to int before biasing: converting a negative float directly to unsigned char is
+           undefined behavior (C11 6.3.1.4) and saturates to 0 on some targets (e.g. AArch64),
+           collapsing the negative half of the signal to 128. */
+        unsigned char samp = (unsigned char)(128 + (int)(*src * (127.0f)));
         *dest = samp;
 
         src += sourceStride;


### PR DESCRIPTION
Fixes #1155.

`Float32_To_UInt8` casts a possibly-negative `float` to `unsigned char` before adding the 128 bias, which is undefined behavior (C11 §6.3.1.4):

```c
unsigned char samp = (unsigned char)(128 + ((unsigned char) (*src * (127.0f))));
```

It happens to give the correct result on x86/MSVC (`cvttss2si` + low-byte truncation), but on **AArch64/clang** `fcvtzu` saturates negatives to `0`, so every negative sample becomes `128` — the entire negative half of the signal collapses to mid-scale. The `_Clip` / `_Dither` / `_DitherClip` UInt8 variants are unaffected because they route through `PaInt32`.

The fix casts through `int` first (matching those variants):

```c
unsigned char samp = (unsigned char)(128 + (int)(*src * (127.0f)));
```

Bit-identical to the previous x86 output for in-range samples, and correct on every platform. Full analysis in #1155.
