### PR TITLE
Uniquely identify sound devices on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -331,7 +331,7 @@ case "${host_os}" in
         if [[ "x$with_wmme" = "xyes" ]]; then
             add_objects src/hostapi/wmme/pa_win_wmme.o src/os/win/pa_win_hostapis.o src/os/win/pa_win_util.o src/os/win/pa_win_version.o src/os/win/pa_win_waveformat.o
             LIBS="${LIBS} -lwinmm -lm -lole32 -luuid"
-            DLL_LIBS="${DLL_LIBS} -lwinmm"
+            DLL_LIBS="${DLL_LIBS} -lwinmm -lole32"
             CFLAGS="$CFLAGS -UPA_USE_WMME -DPA_USE_WMME=1"
             INCLUDES="$INCLUDES pa_win_wmme.h pa_win_waveformat.h"
         fi

--- a/include/portaudio.h
+++ b/include/portaudio.h
@@ -523,6 +523,7 @@ typedef struct PaDeviceInfo
     PaTime defaultHighOutputLatency;
 
     double defaultSampleRate;
+    const char* uniqueID;
 } PaDeviceInfo;
 
 

--- a/src/hostapi/dsound/pa_win_ds.c
+++ b/src/hostapi/dsound/pa_win_ds.c
@@ -983,6 +983,15 @@ static PaError AddOutputDeviceInfoFromDirectSound(
 
         if( lpGUID == NULL )
             hostApi->info.defaultOutputDevice = hostApi->info.deviceCount;
+        else
+        {
+            WCHAR GUIDstr[100] = { 0 };
+            LPSTR uniqueID = (LPSTR)PaUtil_GroupAllocateZeroInitializedMemory(winDsHostApi->allocations, 100);
+            if (StringFromGUID2(lpGUID, GUIDstr, 100) > 0 && deviceInfo->uniqueID) {
+                WideCharToMultiByte(CP_UTF8, 0, GUIDstr, (INT32)wcslen(GUIDstr), uniqueID, 100 - 1, 0, 0);
+                deviceInfo->uniqueID = uniqueID;
+            }
+        }
 
         hostApi->info.deviceCount++;
     }

--- a/src/hostapi/wasapi/pa_win_wasapi.c
+++ b/src/hostapi/wasapi/pa_win_wasapi.c
@@ -1744,11 +1744,17 @@ static PaError FillDeviceInfo(PaWasapiHostApiRepresentation *paWasapi, void *pEn
     // Get device Id
     {
         WCHAR *deviceId;
+        LPSTR uniqueId;
 
         hr = IMMDevice_GetId(wasapiDeviceInfo->device, &deviceId);
         IF_FAILED_INTERNAL_ERROR_JUMP(hr, result, error);
 
         wcsncpy(wasapiDeviceInfo->deviceId, deviceId, PA_WASAPI_DEVICE_ID_LEN - 1);
+
+        uniqueId = (LPSTR)PaUtil_GroupAllocateZeroInitializedMemory(paWasapi->allocations, (long)PA_WASAPI_DEVICE_ID_LEN * sizeof(char));
+        WideCharToMultiByte(CP_UTF8, 0, wasapiDeviceInfo->deviceId, (INT32)wcslen(wasapiDeviceInfo->deviceId), uniqueId, PA_WASAPI_DEVICE_ID_LEN - 1, 0, 0);
+        deviceInfo->uniqueID = uniqueId;
+
         CoTaskMemFree(deviceId);
     }
 

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -760,12 +760,15 @@ static PaError InitializeInputDeviceInfo( PaWinMmeHostApiRepresentation *winMmeH
     DetectDefaultSampleRate( winMmeDeviceInfo, winMmeInputDeviceId,
             QueryInputWaveFormatEx, deviceInfo->maxInputChannels );
 
-    if (memcmp(&wic.NameGuid, &GUID_NULL, sizeof(wic.NameGuid)) != 0) {
-        WCHAR GUIDstr[100] = { 0 };
-        LPSTR uniqueID = (LPSTR)PaUtil_GroupAllocateZeroInitializedMemory(winMmeHostApi->allocations, (long)100 * sizeof(char));
-        if (StringFromGUID2(&wic.NameGuid, GUIDstr, 100) > 0 && uniqueID) {
-            CopyWCharStringToUtf8CString(uniqueID, 100, GUIDstr);
-            deviceInfo->uniqueID = uniqueID;
+    {
+        static const GUID nullNameGuid = { 0 };
+        if (memcmp(&wic.NameGuid, &nullNameGuid, sizeof(wic.NameGuid)) != 0) {
+            WCHAR GUIDstr[100] = { 0 };
+            LPSTR uniqueID = (LPSTR)PaUtil_GroupAllocateZeroInitializedMemory(winMmeHostApi->allocations, (long)100 * sizeof(char));
+            if (StringFromGUID2(&wic.NameGuid, GUIDstr, 100) > 0 && uniqueID) {
+                CopyWCharStringToUtf8CString(uniqueID, 100, GUIDstr);
+                deviceInfo->uniqueID = uniqueID;
+            }
         }
     }
 

--- a/src/hostapi/wmme/pa_win_wmme.c
+++ b/src/hostapi/wmme/pa_win_wmme.c
@@ -677,13 +677,13 @@ static PaError InitializeInputDeviceInfo( PaWinMmeHostApiRepresentation *winMmeH
     PaError result = paNoError;
     char *deviceName; /* non-const ptr */
     MMRESULT mmresult;
-    WAVEINCAPSW wic;
+    WAVEINCAPS2W wic;
     PaDeviceInfo *deviceInfo = &winMmeDeviceInfo->inheritedDeviceInfo;
     size_t len;
 
     *success = 0;
 
-    mmresult = waveInGetDevCapsW( winMmeInputDeviceId, &wic, sizeof( WAVEINCAPSW ) );
+    mmresult = waveInGetDevCapsW( winMmeInputDeviceId, (LPWAVEINCAPSW) & wic, sizeof(wic));
     if( mmresult == MMSYSERR_NOMEM )
     {
         result = paInsufficientMemory;
@@ -759,6 +759,15 @@ static PaError InitializeInputDeviceInfo( PaWinMmeHostApiRepresentation *winMmeH
 
     DetectDefaultSampleRate( winMmeDeviceInfo, winMmeInputDeviceId,
             QueryInputWaveFormatEx, deviceInfo->maxInputChannels );
+
+    if (memcmp(&wic.NameGuid, &GUID_NULL, sizeof(wic.NameGuid)) != 0) {
+        WCHAR GUIDstr[100] = { 0 };
+        LPSTR uniqueID = (LPSTR)PaUtil_GroupAllocateZeroInitializedMemory(winMmeHostApi->allocations, (long)100 * sizeof(char));
+        if (StringFromGUID2(&wic.NameGuid, GUIDstr, 100) > 0 && uniqueID) {
+            CopyWCharStringToUtf8CString(uniqueID, 100, GUIDstr);
+            deviceInfo->uniqueID = uniqueID;
+        }
+    }
 
     *success = 1;
 


### PR DESCRIPTION
If a user unplugs a USB headset and plugs it into another USB port then the sound device may get a new PaDeviceIndex, i.e. we cannot use PaDeviceIndex to identify a sound device.

With this change a sound device (PaDeviceInfo) can be uniquely identified after a Pa_Terminate()/Pa_Initialize().

So far only Windows is supported (using the sound device's GUID).