### PR TITLE
Simplify CalculateFrameShift()

### DIFF
--- a/src/common/pa_process.c
+++ b/src/common/pa_process.c
@@ -56,34 +56,18 @@
 #define PA_MIN_( a, b ) ( ((a)<(b)) ? (a) : (b) )
 
 
-/* greatest common divisor - PGCD in French */
+/* greatest common divisor */
 static unsigned long GCD( unsigned long a, unsigned long b )
 {
     return (b==0) ? a : GCD( b, a%b);
 }
 
-/* least common multiple - PPCM in French */
-static unsigned long LCM( unsigned long a, unsigned long b )
-{
-    return (a*b) / GCD(a,b);
-}
-
-#define PA_MAX_( a, b ) (((a) > (b)) ? (a) : (b))
-
 static unsigned long CalculateFrameShift( unsigned long M, unsigned long N )
 {
-    unsigned long result = 0;
-    unsigned long i;
-    unsigned long lcm;
-
     assert( M > 0 );
     assert( N > 0 );
-
-    lcm = LCM( M, N );
-    for( i = M; i < lcm; i += M )
-        result = PA_MAX_( result, i % N );
-
-    return result;
+    /* https://lac2026.sciencesconf.org/722511 */
+    return N - GCD( M, N );
 }
 
 

--- a/src/common/pa_process.c
+++ b/src/common/pa_process.c
@@ -66,7 +66,11 @@ static unsigned long CalculateFrameShift( unsigned long M, unsigned long N )
 {
     assert( M > 0 );
     assert( N > 0 );
-    /* https://lac2026.sciencesconf.org/722511 */
+    /*
+        The minimum required delay is calculated according to:
+        M. Rath & M. Geier, "Minimum required delay for realtime block size adaptation in digital audio signal processing",
+        Linux Audio Conference 2026; https://lac2026.sciencesconf.org/722511
+    */
     return N - GCD( M, N );
 }
 


### PR DESCRIPTION
The explanation/proof for why that formula is correct is in the referenced paper: https://lac2026.sciencesconf.org/722511

The paper also provides a comparison to the previous implementation, which is described here: https://hal.science/hal-02158912v1

The code was not wrong before, it's now just simpler (and needs fewer computations, but that's probably not really relevant in this case).