### PR TITLE
alsa: suppress stderr noise from device probing

### DIFF
--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -77,11 +77,6 @@
 #include "pa_trace.h"
 #include "pa_debugprint.h"
 
-#if PA_USE_JACK
-#include <jack/jack.h>
-static void PaJack_SilenceErrorCallback(const char *msg) { (void)msg; }
-#endif /* PA_USE_JACK */
-
 #ifndef PA_GIT_REVISION
 #include "pa_gitrevision.h"
 #endif
@@ -387,10 +382,6 @@ PaError Pa_Initialize( void )
         PaUtil_InitializeClock();
         PaUtil_ResetTraceMessages();
 
-#if PA_USE_JACK
-        jack_set_error_function(PaJack_SilenceErrorCallback);
-#endif
-
         result = InitializeHostApis();
         if( result == paNoError )
             ++initializationCount_;
@@ -418,10 +409,6 @@ PaError Pa_Terminate( void )
             CloseOpenStreams();
 
             TerminateHostApis();
-
-#if PA_USE_JACK
-            jack_set_error_function(NULL);
-#endif
 
             PaUtil_DumpTraceMessages();
         }

--- a/src/common/pa_front.c
+++ b/src/common/pa_front.c
@@ -77,6 +77,11 @@
 #include "pa_trace.h"
 #include "pa_debugprint.h"
 
+#if PA_USE_JACK
+#include <jack/jack.h>
+static void PaJack_SilenceErrorCallback(const char *msg) { (void)msg; }
+#endif /* PA_USE_JACK */
+
 #ifndef PA_GIT_REVISION
 #include "pa_gitrevision.h"
 #endif
@@ -382,6 +387,10 @@ PaError Pa_Initialize( void )
         PaUtil_InitializeClock();
         PaUtil_ResetTraceMessages();
 
+#if PA_USE_JACK
+        jack_set_error_function(PaJack_SilenceErrorCallback);
+#endif
+
         result = InitializeHostApis();
         if( result == paNoError )
             ++initializationCount_;
@@ -409,6 +418,10 @@ PaError Pa_Terminate( void )
             CloseOpenStreams();
 
             TerminateHostApis();
+
+#if PA_USE_JACK
+            jack_set_error_function(NULL);
+#endif
 
             PaUtil_DumpTraceMessages();
         }

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -303,6 +303,7 @@ __attribute__((constructor)) static void PaAlsa_InstallLogHandler( void )
     snd_lib_log_set_handler_ft setLogHandler;
     snd_lib_error_set_handler_ft setErrorHandler;
 
+    /* Return immediately if a PortAudio handler is already installed. */
     if( g_AlsaSetLogHandler != NULL || g_AlsaSetErrorHandler != NULL )
         return;
 
@@ -334,6 +335,10 @@ __attribute__((constructor)) static void PaAlsa_InstallLogHandler( void )
     }
     else if( setErrorHandler != NULL )
     {
+        /* The old snd_lib_error_set_handler API does not provide any
+           means to detect an existing error handler. Always install the
+           PortAudio error handler, replacing any already-registered
+           handler. */
         setErrorHandler( AlsaErrorHandler );
         g_AlsaSetErrorHandler = setErrorHandler;
     }

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -252,8 +252,8 @@ static void *g_AlsaLib = NULL;
 /* Suppress Alsa's default stderr logging unless PA_ENABLE_DEBUG_OUTPUT is defined. */
 #ifdef PA_ENABLE_DEBUG_OUTPUT
 
-static void PaAlsa_InstallLogHandler( void ) {}
-static void PaAlsa_UninstallLogHandler( void ) {}
+static void PaAlsa_InstallSilentLogHandler( void ) {}
+static void PaAlsa_UninstallSilentLogHandler( void ) {}
 
 #else
 
@@ -285,20 +285,20 @@ extern snd_lib_log_handler_t snd_lib_log_set_handler( snd_lib_log_handler_t ) __
 static snd_lib_log_set_handler_ft g_AlsaSetLogHandler = NULL;
 static snd_lib_error_set_handler_ft g_AlsaSetErrorHandler = NULL;
 
-static void AlsaLogHandler( int prio, int interface, const char *file, int line,
+static void AlsaSilentLogHandler( int prio, int interface, const char *file, int line,
         const char *function, int errcode, const char *fmt, va_list arg )
 {
     (void)prio; (void)interface; (void)file; (void)line;
     (void)function; (void)errcode; (void)fmt; (void)arg;
 }
 
-static void AlsaErrorHandler( const char *file, int line, const char *function, int err,
+static void AlsaSilentErrorHandler( const char *file, int line, const char *function, int err,
         const char *fmt, ... )
 {
     (void)file; (void)line; (void)function; (void)err; (void)fmt;
 }
 
-__attribute__((constructor)) static void PaAlsa_InstallLogHandler( void )
+__attribute__((constructor)) static void PaAlsa_InstallSilentLogHandler( void )
 {
     snd_lib_log_set_handler_ft setLogHandler;
     snd_lib_error_set_handler_ft setErrorHandler;
@@ -329,7 +329,7 @@ __attribute__((constructor)) static void PaAlsa_InstallLogHandler( void )
 
         if( previous == defaultHandler )
         {
-            setLogHandler( AlsaLogHandler );
+            setLogHandler( AlsaSilentLogHandler );
             g_AlsaSetLogHandler = setLogHandler;
         }
     }
@@ -339,7 +339,7 @@ __attribute__((constructor)) static void PaAlsa_InstallLogHandler( void )
            means to detect an existing error handler. Always install the
            PortAudio error handler, replacing any already-registered
            handler. */
-        setErrorHandler( AlsaErrorHandler );
+        setErrorHandler( AlsaSilentErrorHandler );
         g_AlsaSetErrorHandler = setErrorHandler;
     }
 }
@@ -347,7 +347,7 @@ __attribute__((constructor)) static void PaAlsa_InstallLogHandler( void )
 /* Restore Alsa's default handler even if PortAudio is unloaded without Pa_Terminate()
    having been called, so that Alsa is not left holding a pointer into unmapped code.
 */
-__attribute__((destructor)) static void PaAlsa_UninstallLogHandler( void )
+__attribute__((destructor)) static void PaAlsa_UninstallSilentLogHandler( void )
 {
     if( g_AlsaSetLogHandler != NULL )
     {

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -740,12 +740,8 @@ static const PaAlsaDeviceInfo *GetDeviceInfo( const PaUtilHostApiRepresentation 
     return (const PaAlsaDeviceInfo *)hostApi->deviceInfos[device];
 }
 
-/** Uncommented because AlsaErrorHandler is unused for anything good yet. If AlsaErrorHandler is
-    to be used, do not forget to register this callback in PaAlsa_Initialize, and unregister in Terminate.
-*/
-/*static void AlsaErrorHandler(const char *file, int line, const char *function, int err, const char *fmt, ...)
-{
-}*/
+static void AlsaErrorHandler(const char *file, int line, const char *function,
+                             int err, const char *fmt, ...) {}
 
 PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex )
 {
@@ -771,10 +767,8 @@ PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
     (*hostApi)->OpenStream = OpenStream;
     (*hostApi)->IsFormatSupported = IsFormatSupported;
 
-    /** If AlsaErrorHandler is to be used, do not forget to unregister callback pointer in
-        Terminate function.
-    */
-    /*ENSURE_( snd_lib_error_set_handler(AlsaErrorHandler), paUnanticipatedHostError );*/
+    ENSURE_(snd_lib_error_set_handler(AlsaErrorHandler),
+            paUnanticipatedHostError);
 
     PA_ENSURE( BuildDeviceList( alsaHostApi ) );
 
@@ -821,9 +815,7 @@ static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
 
     assert( hostApi );
 
-    /** See AlsaErrorHandler and PaAlsa_Initialize for details.
-    */
-    /*snd_lib_error_set_handler(NULL);*/
+    snd_lib_error_set_handler(NULL);
 
     if( alsaHostApi->allocations )
     {

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -879,7 +879,7 @@ PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
     (*hostApi)->OpenStream = OpenStream;
     (*hostApi)->IsFormatSupported = IsFormatSupported;
 
-    PaAlsa_InstallLogHandler();
+    PaAlsa_InstallSilentLogHandler();
 
     PA_ENSURE( BuildDeviceList( alsaHostApi ) );
 
@@ -926,7 +926,7 @@ static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
 
     assert( hostApi );
 
-    PaAlsa_UninstallLogHandler();
+    PaAlsa_UninstallSilentLogHandler();
 
     if( alsaHostApi->allocations )
     {

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -62,6 +62,7 @@
 #include <time.h>
 #include <sys/mman.h>
 #include <signal.h> /* For sig_atomic_t */
+#include <stdarg.h> /* For va_list */
 #ifdef PA_ALSA_DYNAMIC
     #include <dlfcn.h> /* For dlXXX functions */
 #endif
@@ -247,6 +248,115 @@ static const char *g_AlsaLibName = PA_ALSA_PATHNAME;
 
 /* Handle to dynamically loaded library. */
 static void *g_AlsaLib = NULL;
+
+/* Suppress Alsa's default stderr logging unless PA_ENABLE_DEBUG_OUTPUT is defined. */
+#ifdef PA_ENABLE_DEBUG_OUTPUT
+
+static void PaAlsa_InstallLogHandler( void ) {}
+static void PaAlsa_UninstallLogHandler( void ) {}
+
+#else
+
+/* snd_lib_log_set_handler() was added in Alsa 1.2.15 and supersedes the deprecated
+   snd_lib_error_set_handler(). snd_lib_log_set_local() is deliberately not used: it
+   only affects the calling thread, so it can neither be installed for the whole
+   process from a constructor, nor reliably removed again from a destructor.
+   Declare the handler type here so that this file still compiles against
+   pre-1.2.15 headers.
+*/
+#if !defined(SND_LIB_VERSION) || SND_LIB_VERSION < ALSA_VERSION_INT( 1, 2, 15 )
+typedef void (*snd_lib_log_handler_t)( int prio, int interface, const char *file, int line,
+        const char *function, int errcode, const char *fmt, va_list arg );
+#endif
+
+typedef snd_lib_log_handler_t (*snd_lib_log_set_handler_ft)( snd_lib_log_handler_t );
+typedef int (*snd_lib_error_set_handler_ft)( snd_lib_error_handler_t );
+
+#ifndef PA_ALSA_DYNAMIC
+/* Weak reference: resolves to NULL against libasound < 1.2.15, so a PortAudio built
+   against newer headers still loads there.
+*/
+extern snd_lib_log_handler_t snd_lib_log_set_handler( snd_lib_log_handler_t ) __attribute__((weak));
+#endif
+
+/* The setter PortAudio installed its handler with, retained so that it is removed with
+   the same function it was installed with. Both NULL when nothing is installed.
+*/
+static snd_lib_log_set_handler_ft g_AlsaSetLogHandler = NULL;
+static snd_lib_error_set_handler_ft g_AlsaSetErrorHandler = NULL;
+
+static void AlsaLogHandler( int prio, int interface, const char *file, int line,
+        const char *function, int errcode, const char *fmt, va_list arg )
+{
+    (void)prio; (void)interface; (void)file; (void)line;
+    (void)function; (void)errcode; (void)fmt; (void)arg;
+}
+
+static void AlsaErrorHandler( const char *file, int line, const char *function, int err,
+        const char *fmt, ... )
+{
+    (void)file; (void)line; (void)function; (void)err; (void)fmt;
+}
+
+__attribute__((constructor)) static void PaAlsa_InstallLogHandler( void )
+{
+    snd_lib_log_set_handler_ft setLogHandler;
+    snd_lib_error_set_handler_ft setErrorHandler;
+
+    if( g_AlsaSetLogHandler != NULL || g_AlsaSetErrorHandler != NULL )
+        return;
+
+#ifdef PA_ALSA_DYNAMIC
+    /* The library is not loaded yet when the constructor runs; PaAlsa_Initialize()
+       retries after PaAlsa_LoadLibrary(). */
+    if( g_AlsaLib == NULL )
+        return;
+
+    setLogHandler = (snd_lib_log_set_handler_ft) dlsym( g_AlsaLib, "snd_lib_log_set_handler" );
+    setErrorHandler = (snd_lib_error_set_handler_ft) dlsym( g_AlsaLib, "snd_lib_error_set_handler" );
+#else
+    setLogHandler = &snd_lib_log_set_handler;
+    setErrorHandler = &snd_lib_error_set_handler;
+#endif
+
+    if( setLogHandler != NULL )
+    {
+        /* Passing NULL installs Alsa's default handler and returns the previous one;
+           comparing them is the only way to leave an application's handler in place. */
+        snd_lib_log_handler_t previous = setLogHandler( NULL );
+        snd_lib_log_handler_t defaultHandler = setLogHandler( previous );
+
+        if( previous == defaultHandler )
+        {
+            setLogHandler( AlsaLogHandler );
+            g_AlsaSetLogHandler = setLogHandler;
+        }
+    }
+    else if( setErrorHandler != NULL )
+    {
+        setErrorHandler( AlsaErrorHandler );
+        g_AlsaSetErrorHandler = setErrorHandler;
+    }
+}
+
+/* Restore Alsa's default handler even if PortAudio is unloaded without Pa_Terminate()
+   having been called, so that Alsa is not left holding a pointer into unmapped code.
+*/
+__attribute__((destructor)) static void PaAlsa_UninstallLogHandler( void )
+{
+    if( g_AlsaSetLogHandler != NULL )
+    {
+        g_AlsaSetLogHandler( NULL );
+        g_AlsaSetLogHandler = NULL;
+    }
+    else if( g_AlsaSetErrorHandler != NULL )
+    {
+        g_AlsaSetErrorHandler( NULL );
+        g_AlsaSetErrorHandler = NULL;
+    }
+}
+
+#endif /* PA_ENABLE_DEBUG_OUTPUT */
 
 #ifdef PA_ALSA_DYNAMIC
 
@@ -740,14 +850,6 @@ static const PaAlsaDeviceInfo *GetDeviceInfo( const PaUtilHostApiRepresentation 
     return (const PaAlsaDeviceInfo *)hostApi->deviceInfos[device];
 }
 
-static void AlsaLogHandler(int prio, int interface, const char *file, int line,
-                           const char *function, int errcode, const char *fmt,
-                           va_list arg) {
-  (void)prio;
-  (void)interface;
-  (void)arg;
-}
-
 PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex )
 {
     PaError result = paNoError;
@@ -772,7 +874,7 @@ PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
     (*hostApi)->OpenStream = OpenStream;
     (*hostApi)->IsFormatSupported = IsFormatSupported;
 
-    snd_lib_log_set_local(AlsaLogHandler);
+    PaAlsa_InstallLogHandler();
 
     PA_ENSURE( BuildDeviceList( alsaHostApi ) );
 
@@ -819,7 +921,7 @@ static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
 
     assert( hostApi );
 
-    snd_lib_log_set_local(NULL);
+    PaAlsa_UninstallLogHandler();
 
     if( alsaHostApi->allocations )
     {

--- a/src/hostapi/alsa/pa_linux_alsa.c
+++ b/src/hostapi/alsa/pa_linux_alsa.c
@@ -740,8 +740,13 @@ static const PaAlsaDeviceInfo *GetDeviceInfo( const PaUtilHostApiRepresentation 
     return (const PaAlsaDeviceInfo *)hostApi->deviceInfos[device];
 }
 
-static void AlsaErrorHandler(const char *file, int line, const char *function,
-                             int err, const char *fmt, ...) {}
+static void AlsaLogHandler(int prio, int interface, const char *file, int line,
+                           const char *function, int errcode, const char *fmt,
+                           va_list arg) {
+  (void)prio;
+  (void)interface;
+  (void)arg;
+}
 
 PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex )
 {
@@ -767,8 +772,7 @@ PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex
     (*hostApi)->OpenStream = OpenStream;
     (*hostApi)->IsFormatSupported = IsFormatSupported;
 
-    ENSURE_(snd_lib_error_set_handler(AlsaErrorHandler),
-            paUnanticipatedHostError);
+    snd_lib_log_set_local(AlsaLogHandler);
 
     PA_ENSURE( BuildDeviceList( alsaHostApi ) );
 
@@ -815,7 +819,7 @@ static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
 
     assert( hostApi );
 
-    snd_lib_error_set_handler(NULL);
+    snd_lib_log_set_local(NULL);
 
     if( alsaHostApi->allocations )
     {

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -77,8 +77,10 @@
 /* Suppress JACK's stderr logging before jack_client_open(); PaJack_Initialize()
    installs its own silent JackErrorCallback() only after that. Restore the default on
    unload so that JACK is not left holding a pointer into unmapped code.
+
+    Currently not supported with MSVC on Windows because __attribute((constructor))__ is not available (patches welcome).
 */
-#ifndef PA_ENABLE_DEBUG_OUTPUT
+#if !defined(PA_ENABLE_DEBUG_OUTPUT) && !defined(_MSC_VER)
 
 static void JackSilentErrorCallback( const char *msg )
 {
@@ -95,7 +97,7 @@ __attribute__((destructor)) static void PaJack_DestructErrorCallback( void )
     jack_set_error_function( NULL );
 }
 
-#endif /* PA_ENABLE_DEBUG_OUTPUT */
+#endif /* !defined(PA_ENABLE_DEBUG_OUTPUT) && !defined(_MSC_VER) */
 
 static pthread_t mainThread_;
 static char *jackErr_ = NULL;

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -62,16 +62,6 @@
 #include <jack/types.h>
 #include <jack/jack.h>
 
-static void PaJack_SilenceErrorCallback(const char *msg) { (void)msg; }
-
-__attribute__((constructor)) static void PaJack_SilenceEarly(void) {
-  jack_set_error_function(PaJack_SilenceErrorCallback);
-}
-
-__attribute__((destructor)) static void PaJack_RestoreErrorCallback(void) {
-  jack_set_error_function(NULL);
-}
-
 #include "pa_util.h"
 #include "pa_pthread_util.h"
 #include "pa_hostapi.h"
@@ -83,6 +73,29 @@ __attribute__((destructor)) static void PaJack_RestoreErrorCallback(void) {
 #include "pa_debugprint.h"
 
 #include "pa_jack.h"
+
+/* Suppress JACK's stderr logging before jack_client_open(); PaJack_Initialize()
+   installs its own silent JackErrorCallback() only after that. Restore the default on
+   unload so that JACK is not left holding a pointer into unmapped code.
+*/
+#ifndef PA_ENABLE_DEBUG_OUTPUT
+
+static void JackSilentErrorCallback( const char *msg )
+{
+    (void)msg;
+}
+
+__attribute__((constructor)) static void PaJack_ConstructErrorCallback( void )
+{
+    jack_set_error_function( JackSilentErrorCallback );
+}
+
+__attribute__((destructor)) static void PaJack_DestructErrorCallback( void )
+{
+    jack_set_error_function( NULL );
+}
+
+#endif /* PA_ENABLE_DEBUG_OUTPUT */
 
 static pthread_t mainThread_;
 static char *jackErr_ = NULL;
@@ -900,8 +913,6 @@ static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
     }
 
     PaUtil_FreeMemory( jackHostApi );
-
-    jack_set_error_function(NULL);
 
     free( jackErr_ );
     jackErr_ = NULL;

--- a/src/hostapi/jack/pa_jack.c
+++ b/src/hostapi/jack/pa_jack.c
@@ -62,6 +62,16 @@
 #include <jack/types.h>
 #include <jack/jack.h>
 
+static void PaJack_SilenceErrorCallback(const char *msg) { (void)msg; }
+
+__attribute__((constructor)) static void PaJack_SilenceEarly(void) {
+  jack_set_error_function(PaJack_SilenceErrorCallback);
+}
+
+__attribute__((destructor)) static void PaJack_RestoreErrorCallback(void) {
+  jack_set_error_function(NULL);
+}
+
 #include "pa_util.h"
 #include "pa_pthread_util.h"
 #include "pa_hostapi.h"
@@ -890,6 +900,8 @@ static void Terminate( struct PaUtilHostApiRepresentation *hostApi )
     }
 
     PaUtil_FreeMemory( jackHostApi );
+
+    jack_set_error_function(NULL);
 
     free( jackErr_ );
     jackErr_ = NULL;


### PR DESCRIPTION
uncomments AlsaErrorHandler with proper init/term lifecycle, fixes dangling pointer on dlclose (regressed in 96b86da)

Ppreviously the unregister was missing, causing SIGSEGV on dynamic unload

noise example

```
ALSA lib pcm_dsnoop.c:572:(snd_pcm_dsnoop_open) [error.pcm] unable to open slave
ALSA lib pcm_dmix.c:1000:(snd_pcm_dmix_open) [error.pcm] unable to open slave
ALSA lib pcm.c:2722:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.rear
ALSA lib pcm.c:2722:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.center_lfe
ALSA lib pcm.c:2722:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.side
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib pcm_a52.c:1036:(_snd_pcm_a52_open) [error.] a52 is only for playback
ALSA lib confmisc.c:160:(snd_config_get_card) [error.core] Invalid field card
ALSA lib pcm_usb_stream.c:481:(_snd_pcm_usb_stream_open) [error.] Invalid card 'card'
ALSA lib confmisc.c:160:(snd_config_get_card) [error.core] Invalid field card
ALSA lib pcm_usb_stream.c:481:(_snd_pcm_usb_stream_open) [error.] Invalid card 'card'
ALSA lib pcm_dmix.c:1000:(snd_pcm_dmix_open) [error.pcm] unable to open slave
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
```


closes #163