### PR TITLE
Add Coreaudio ID to Portaudio device index mapping

### DIFF
--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -414,7 +414,6 @@ static PaError gatherDeviceInfo(PaMacAUHAL *auhalHostApi)
     if( 0 != PaMacCore_AudioHardwareGetProperty(kAudioHardwarePropertyDefaultInputDevice,
             &size,
             &auhalHostApi->defaultIn) ) {
-        int i;
         auhalHostApi->defaultIn  = kAudioDeviceUnknown;
         VDBUG(("Failed to get default input device from OS."));
         VDBUG((" I will substitute the first available input Device."));
@@ -431,7 +430,6 @@ static PaError gatherDeviceInfo(PaMacAUHAL *auhalHostApi)
     if( 0 != PaMacCore_AudioHardwareGetProperty(kAudioHardwarePropertyDefaultOutputDevice,
             &size,
             &auhalHostApi->defaultOut) ) {
-        int i;
         auhalHostApi->defaultIn  = kAudioDeviceUnknown;
         VDBUG(("Failed to get default output device from OS."));
         VDBUG((" I will substitute the first available output Device."));
@@ -2871,4 +2869,36 @@ static double GetStreamCpuLoad( PaStream* s )
     VVDBUG(("GetStreamCpuLoad()\n"));
 
     return PaUtil_GetCpuLoad( &stream->cpuLoadMeasurer );
+}
+
+
+/*
+ * Return the PortAudio device index corresponding to a native
+ * CoreAudio AudioDeviceID. Useful when interoperating with
+ * other CoreAudio APIs that use AudioDeviceID directly.
+ */
+PaDeviceIndex PaMacCore_GetDeviceIndexForAudioDeviceID(AudioDeviceID id)
+{
+    PaUtilHostApiRepresentation *hostApi;
+    PaMacAUHAL *auhalHostApi;
+    PaError err;
+    int i;
+
+    err = PaUtil_GetHostApiRepresentation(&hostApi, paCoreAudio);
+    if (err != paNoError)
+        return paNoDevice;
+
+    auhalHostApi = (PaMacAUHAL *)hostApi;
+
+    for (i = 0; i < auhalHostApi->devCount; i++)
+    {
+        VVDBUG(("PA %lu -> CoreAudio %u\n",
+             (unsigned long)(hostApi->privatePaFrontInfo.baseDeviceIndex + i),
+             (unsigned int)auhalHostApi->devIds[i]));
+	        
+	    if (auhalHostApi->devIds[i] == id)
+            return hostApi->privatePaFrontInfo.baseDeviceIndex + i;
+    }
+
+    return paNoDevice;
 }

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -414,6 +414,7 @@ static PaError gatherDeviceInfo(PaMacAUHAL *auhalHostApi)
     if( 0 != PaMacCore_AudioHardwareGetProperty(kAudioHardwarePropertyDefaultInputDevice,
             &size,
             &auhalHostApi->defaultIn) ) {
+        int i;
         auhalHostApi->defaultIn  = kAudioDeviceUnknown;
         VDBUG(("Failed to get default input device from OS."));
         VDBUG((" I will substitute the first available input Device."));
@@ -430,6 +431,7 @@ static PaError gatherDeviceInfo(PaMacAUHAL *auhalHostApi)
     if( 0 != PaMacCore_AudioHardwareGetProperty(kAudioHardwarePropertyDefaultOutputDevice,
             &size,
             &auhalHostApi->defaultOut) ) {
+        int i;
         auhalHostApi->defaultIn  = kAudioDeviceUnknown;
         VDBUG(("Failed to get default output device from OS."));
         VDBUG((" I will substitute the first available output Device."));


### PR DESCRIPTION
It is sometimes useful to be able to correlate a coreaudio device to a Portaudio device, especially when multiple coreaudio devices have the same name and need to be differentiated by their ID numbers.

After compiling in this extra function, the IDs can be correlated with the following function in python:

````
from cffi import FFI

_pa_extra_ffi = FFI()
_pa_extra_ffi.cdef("""
    int PaMacCore_GetDeviceIndexForAudioDeviceID(unsigned int id);
""")

_pa_extra_lib = _pa_extra_ffi.dlopen(
    "/Users/doug/Library/Python/3.12/lib/python/site-packages/_sounddevice_data/portaudio-binaries/libportaudio.dylib"
)


def get_portaudio_index_from_coreaudio_id(target_core_id):
    """
    Convert a macOS CoreAudio AudioDeviceID into a PortAudio/sounddevice index.
    """
    index = _pa_extra_lib.PaMacCore_GetDeviceIndexForAudioDeviceID(target_core_id)

    if index < 0:
        return None

    return index
````

I have also removed two unused variables `i` in unrelated parts of the file.