### PR TITLE
fix monotonic latency errors on MacOS

### DIFF
--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -68,9 +68,15 @@
 #include <math.h>
 #include <libkern/OSAtomic.h>
 
+#include <fenv.h>
+#pragma STDC FENV_ACCESS ON
+
 #include "pa_mac_core.h"
 #include "pa_mac_core_utilities.h"
 #include "pa_mac_core_blocking.h"
+
+#include <fenv.h>
+#pragma STDC FENV_ACCESS ON
 
 #ifdef __cplusplus
 extern "C"
@@ -82,6 +88,17 @@ extern "C"
 
 /* prototypes for functions declared in this file */
 PaError PaMacCore_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+
+static double rounded_divide(double numerator, double denominator, int round)
+{
+    int old_mode = fegetround();
+    if (fesetround(FE_UPWARD) == 0) {
+            double result = numerator / denominator;
+            fesetround(old_mode);
+            return result;
+    }
+    return numerator / denominator;
+}
 
 /*
  * Function declared in pa_mac_core.h. Sets up a PaMacCoreStreamInfoStruct
@@ -1720,12 +1737,6 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
     UInt32 fixedInputLatency = 0;
     UInt32 fixedOutputLatency = 0;
-    /* Most of the tests pass with just the ceil() call. But there was one failure that
-     * needed this epsilon fix. The reportedLatency was low by 1e-19.
-     * This value value was chosen because it is much smaller than the human scale and
-     * much larger than the scale of the rounding errors.
-     */
-    const double kLatencyEpsilon = 1e-10; /* Rounding error in frames. */
     // Accumulate contributions to latency in these variables.
     UInt32 inputLatencyFrames = 0;
     UInt32 outputLatencyFrames = 0;
@@ -2050,13 +2061,8 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( inputParameters )
     {
         inputLatencyFrames += PaUtil_GetBufferProcessorInputLatencyFrames(&stream->bufferProcessor);
-        double latency = inputLatencyFrames / sampleRate;
-        if( latency < inputParameters->suggestedLatency &&
-            (inputParameters->suggestedLatency - latency) * sampleRate < kLatencyEpsilon )
-        {
-            latency = inputParameters->suggestedLatency;
-        }
-        stream->streamRepresentation.streamInfo.inputLatency = latency;
+        /* round upward so that reported latency is not less than actual latency */
+        stream->streamRepresentation.streamInfo.inputLatency = rounded_divide(inputLatencyFrames, sampleRate, FE_UPWARD);
     }
     else
     {
@@ -2066,13 +2072,8 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( outputParameters )
     {
         outputLatencyFrames += PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor);
-        double latency = outputLatencyFrames / sampleRate;
-        if( latency < outputParameters->suggestedLatency &&
-            (outputParameters->suggestedLatency - latency) * sampleRate < kLatencyEpsilon )
-        {
-            latency = outputParameters->suggestedLatency;
-        }
-        stream->streamRepresentation.streamInfo.outputLatency = latency;
+        /* round upward so that reported latency is not less than actual latency */
+       stream->streamRepresentation.streamInfo.outputLatency = rounded_divide(outputLatencyFrames, sampleRate, FE_UPWARD);
     }
     else
     {

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -1720,6 +1720,11 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
     UInt32 fixedInputLatency = 0;
     UInt32 fixedOutputLatency = 0;
+    /* Most of the tests pass with just the ceil() call. But there was one failure that
+     * needed this epsilon fix. The reportedLatency was low by 1e-19.
+     * This value value was chosen because it is much smaller than the human scale and
+     * much larger than the scale of the rounding errors.
+     */
     const double kLatencyEpsilon = 1e-10; /* Rounding error in frames. */
     // Accumulate contributions to latency in these variables.
     UInt32 inputLatencyFrames = 0;

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -62,21 +62,22 @@
  * PaMacCore_SetError() will do this.
  */
 
-#include "pa_mac_core_internal.h"
-
 #include <fenv.h>
 /* This PRAGMA can reduce performance. So consider moving this into its
  * own file along with rounded_divide().
  */
 #pragma STDC FENV_ACCESS ON
 
-#include <string.h> /* strlen(), memcmp() etc. */
 #include <math.h>
 #include <libkern/OSAtomic.h>
+#include <string.h> /* strlen(), memcmp() etc. */
 
+#include "pa_mac_core_internal.h"
 #include "pa_mac_core.h"
 #include "pa_mac_core_utilities.h"
 #include "pa_mac_core_blocking.h"
+
+#include "pa_debugprint.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -92,11 +93,12 @@ PaError PaMacCore_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIn
 static double rounded_divide(double numerator, double denominator, int round)
 {
     int old_mode = fegetround();
-    if (fesetround(FE_UPWARD) == 0) {
+    if (fesetround(round) == 0) {
             double result = numerator / denominator;
             fesetround(old_mode);
             return result;
     }
+    PaUtil_DebugPrint("pa_mac_core.c: fesetround(%d) failed!\n", round);
     return numerator / denominator;
 }
 

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -64,19 +64,19 @@
 
 #include "pa_mac_core_internal.h"
 
+#include <fenv.h>
+/* This PRAGMA can reduce performance. So consider moving this into its
+ * own file along with rounded_divide().
+ */
+#pragma STDC FENV_ACCESS ON
+
 #include <string.h> /* strlen(), memcmp() etc. */
 #include <math.h>
 #include <libkern/OSAtomic.h>
 
-#include <fenv.h>
-#pragma STDC FENV_ACCESS ON
-
 #include "pa_mac_core.h"
 #include "pa_mac_core_utilities.h"
 #include "pa_mac_core_blocking.h"
-
-#include <fenv.h>
-#pragma STDC FENV_ACCESS ON
 
 #ifdef __cplusplus
 extern "C"
@@ -2073,7 +2073,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     {
         outputLatencyFrames += PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor);
         /* round upward so that reported latency is not less than actual latency */
-       stream->streamRepresentation.streamInfo.outputLatency = rounded_divide(outputLatencyFrames, sampleRate, FE_UPWARD);
+        stream->streamRepresentation.streamInfo.outputLatency = rounded_divide(outputLatencyFrames, sampleRate, FE_UPWARD);
     }
     else
     {

--- a/src/hostapi/coreaudio/pa_mac_core.c
+++ b/src/hostapi/coreaudio/pa_mac_core.c
@@ -65,6 +65,7 @@
 #include "pa_mac_core_internal.h"
 
 #include <string.h> /* strlen(), memcmp() etc. */
+#include <math.h>
 #include <libkern/OSAtomic.h>
 
 #include "pa_mac_core.h"
@@ -1649,7 +1650,7 @@ static UInt32 CalculateOptimalBufferSize( PaMacAUHAL *auhalHostApi,
     // Use maximum of suggested input and output latencies.
     if( inputParameters )
     {
-        UInt32 suggestedLatencyFrames = inputParameters->suggestedLatency * sampleRate;
+        UInt32 suggestedLatencyFrames = (UInt32) ceil( inputParameters->suggestedLatency * sampleRate );
         // Calculate a buffer size assuming we are double buffered.
         SInt32 variableLatencyFrames = suggestedLatencyFrames - fixedInputLatency;
         // Prevent negative latency.
@@ -1658,7 +1659,7 @@ static UInt32 CalculateOptimalBufferSize( PaMacAUHAL *auhalHostApi,
     }
     if( outputParameters )
     {
-        UInt32 suggestedLatencyFrames = outputParameters->suggestedLatency * sampleRate;
+        UInt32 suggestedLatencyFrames = (UInt32) ceil( outputParameters->suggestedLatency * sampleRate );
         SInt32 variableLatencyFrames = suggestedLatencyFrames - fixedOutputLatency;
         variableLatencyFrames = MAX( variableLatencyFrames, 0 );
         resultBufferSizeFrames = MAX( resultBufferSizeFrames, (UInt32) variableLatencyFrames );
@@ -1719,6 +1720,7 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
     UInt32 fixedInputLatency = 0;
     UInt32 fixedOutputLatency = 0;
+    const double kLatencyEpsilon = 1e-10; /* Rounding error in frames. */
     // Accumulate contributions to latency in these variables.
     UInt32 inputLatencyFrames = 0;
     UInt32 outputLatencyFrames = 0;
@@ -2043,7 +2045,13 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( inputParameters )
     {
         inputLatencyFrames += PaUtil_GetBufferProcessorInputLatencyFrames(&stream->bufferProcessor);
-        stream->streamRepresentation.streamInfo.inputLatency = inputLatencyFrames / sampleRate;
+        double latency = inputLatencyFrames / sampleRate;
+        if( latency < inputParameters->suggestedLatency &&
+            (inputParameters->suggestedLatency - latency) * sampleRate < kLatencyEpsilon )
+        {
+            latency = inputParameters->suggestedLatency;
+        }
+        stream->streamRepresentation.streamInfo.inputLatency = latency;
     }
     else
     {
@@ -2053,7 +2061,13 @@ static PaError OpenStream( struct PaUtilHostApiRepresentation *hostApi,
     if( outputParameters )
     {
         outputLatencyFrames += PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor);
-        stream->streamRepresentation.streamInfo.outputLatency = outputLatencyFrames / sampleRate;
+        double latency = outputLatencyFrames / sampleRate;
+        if( latency < outputParameters->suggestedLatency &&
+            (outputParameters->suggestedLatency - latency) * sampleRate < kLatencyEpsilon )
+        {
+            latency = outputParameters->suggestedLatency;
+        }
+        stream->streamRepresentation.streamInfo.outputLatency = latency;
     }
     else
     {


### PR DESCRIPTION
Rounding errors were causing the new paqa_latency_monotonic.c test to fail.

Fixes #1171